### PR TITLE
No changed files when running tests

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -30,6 +30,8 @@ eggs =
 [test]
 recipe = zc.recipe.testrunner
 eggs = ${instance:eggs}
+initialization =
+    os.environ['TZ'] = 'UTC'
 defaults = ['-s', 'plone.restapi', '--auto-color', '--auto-progress']
 
 [coverage]

--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -12,6 +12,12 @@ content-type: application/json
   "creators": [
     "test_user_1_"
   ], 
+  "customViewFields": [
+    "Title", 
+    "Creator", 
+    "Type", 
+    "ModificationDate"
+  ], 
   "description": "This is a collection with two documents", 
   "effective": "1969-12-31T00:00:00+02:00", 
   "exclude_from_nav": "False", 

--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -19,9 +19,9 @@ content-type: application/json
     "ModificationDate"
   ], 
   "description": "This is a collection with two documents", 
-  "effective": "1969-12-31T00:00:00+02:00", 
+  "effective": "1969-12-31T00:00:00+00:00", 
   "exclude_from_nav": "False", 
-  "expires": "2499-12-31T00:00:00+02:00", 
+  "expires": "2499-12-31T00:00:00+00:00", 
   "icon": "++resource++plone.dexterity.item.gif", 
   "isPrincipiaFolderish": "0", 
   "item_count": "30", 

--- a/docs/source/_json/document.json
+++ b/docs/source/_json/document.json
@@ -13,9 +13,9 @@ content-type: application/json
     "test_user_1_"
   ], 
   "description": "Congratulations! You have successfully installed Plone.", 
-  "effective": "1969-12-31T00:00:00+02:00", 
+  "effective": "1969-12-31T00:00:00+00:00", 
   "exclude_from_nav": "False", 
-  "expires": "2499-12-31T00:00:00+02:00", 
+  "expires": "2499-12-31T00:00:00+00:00", 
   "icon": "++resource++plone.dexterity.item.gif", 
   "isPrincipiaFolderish": "0", 
   "language": "", 

--- a/docs/source/_json/event.json
+++ b/docs/source/_json/event.json
@@ -14,10 +14,10 @@ content-type: application/json
     "test_user_1_"
   ], 
   "description": "This is an event", 
-  "effective": "1969-12-31T00:00:00+02:00", 
+  "effective": "1969-12-31T00:00:00+00:00", 
   "end": "2013-01-01T12:00:00", 
   "exclude_from_nav": "False", 
-  "expires": "2499-12-31T00:00:00+02:00", 
+  "expires": "2499-12-31T00:00:00+00:00", 
   "icon": "++resource++plone.dexterity.item.gif", 
   "isPrincipiaFolderish": "0", 
   "language": "", 

--- a/docs/source/_json/event.json
+++ b/docs/source/_json/event.json
@@ -8,18 +8,21 @@ content-type: application/json
   "@context": "http://www.w3.org/ns/hydra/context.jsonld", 
   "@id": "http://localhost:55001/plone/event", 
   "@type": "Event", 
+  "attendees": [], 
   "contributors": [], 
   "creators": [
     "test_user_1_"
   ], 
   "description": "This is an event", 
   "effective": "1969-12-31T00:00:00+02:00", 
+  "end": "2013-01-01T12:00:00", 
   "exclude_from_nav": "False", 
   "expires": "2499-12-31T00:00:00+02:00", 
   "icon": "++resource++plone.dexterity.item.gif", 
   "isPrincipiaFolderish": "0", 
   "language": "", 
   "meta_type": "Dexterity Item", 
+  "open_end": "False", 
   "parent": {
     "@id": "http://localhost:55001/plone", 
     "description": "", 
@@ -27,5 +30,7 @@ content-type: application/json
   }, 
   "relatedItems": [], 
   "rights": "", 
-  "title": "Event"
+  "start": "2013-01-01T10:00:00", 
+  "title": "Event", 
+  "whole_day": "False"
 }

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -13,9 +13,9 @@ content-type: application/json
     "test_user_1_"
   ], 
   "description": "This is a folder with two documents", 
-  "effective": "1969-12-31T00:00:00+02:00", 
+  "effective": "1969-12-31T00:00:00+00:00", 
   "exclude_from_nav": "False", 
-  "expires": "2499-12-31T00:00:00+02:00", 
+  "expires": "2499-12-31T00:00:00+00:00", 
   "icon": "++resource++plone.dexterity.item.gif", 
   "isAnObjectManager": "1", 
   "isPrincipiaFolderish": "1", 

--- a/docs/source/_json/link.json
+++ b/docs/source/_json/link.json
@@ -13,9 +13,9 @@ content-type: application/json
     "test_user_1_"
   ], 
   "description": "This is a link", 
-  "effective": "1969-12-31T00:00:00+02:00", 
+  "effective": "1969-12-31T00:00:00+00:00", 
   "exclude_from_nav": "False", 
-  "expires": "2499-12-31T00:00:00+02:00", 
+  "expires": "2499-12-31T00:00:00+00:00", 
   "icon": "++resource++plone.dexterity.item.gif", 
   "isPrincipiaFolderish": "0", 
   "language": "", 

--- a/docs/source/_json/newsitem.json
+++ b/docs/source/_json/newsitem.json
@@ -13,9 +13,9 @@ content-type: application/json
     "test_user_1_"
   ], 
   "description": "This is a news item", 
-  "effective": "1969-12-31T00:00:00+02:00", 
+  "effective": "1969-12-31T00:00:00+00:00", 
   "exclude_from_nav": "False", 
-  "expires": "2499-12-31T00:00:00+02:00", 
+  "expires": "2499-12-31T00:00:00+00:00", 
   "icon": "++resource++plone.dexterity.item.gif", 
   "image": "http://localhost:55001/plone/newsitem/@@images/image", 
   "image_caption": "This is an image caption.", 

--- a/src/plone/restapi/serializer.py
+++ b/src/plone/restapi/serializer.py
@@ -20,6 +20,7 @@ from zope.schema import Datetime
 from zope.interface import implementer
 from zope.component import adapter
 from zope.component import getUtility
+from datetime import datetime
 
 
 try:
@@ -92,7 +93,9 @@ def SerializeToJson(context):
             # RichText
             if isinstance(schema_object, RichText):
                 result[title] = value.output
-            # DateTime
+            # datetime / DateTime
+            elif isinstance(value, datetime):
+                result[title] = value.isoformat()
             elif isinstance(schema_object, Datetime):
                 # Return DateTime in ISO-8601 format. See
                 # https://pypi.python.org/pypi/DateTime/3.0 and

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -51,7 +51,7 @@ def save_response_for_documentation(filename, response):
     f.write('HTTP {} {}\n'.format(response.status_code, response.reason))
     for key, value in response.headers.items():
         if key.lower() in RESPONSE_HEADER_KEYS:
-            f.write('{}: {}\n'.format(key, value))
+            f.write('{}: {}\n'.format(key.lower(), value))
     f.write('\n')
     f.write(response.content)
     f.close()


### PR DESCRIPTION
When running tests, I end up with changed .json-files from the `test_documentation` test.
Maybe I was just doing it wrong, but I thought I'd fix what I can and try making the test run without having unnecessary changes.

My changes:
- Fix error when serializing python datetime object.
- Update `event.json` and `collection.json` with new fields.
- Always lowercase response-headers, since they were uppercase on my machine but commit in lowercase.
- Set timezone to `UTC` in `bin/test` (buildout) in order to have the same serialized dates wherever the machine runs.

Not sure if you want those changes, but I'd like to not have changed files when running the tests :wink: 