### PR TITLE
Fix travis tests: update setuptools version.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -88,7 +88,7 @@ plone.dexterity = git git://github.com/plone/plone.dexterity.git pushurl=git@git
 plone.rest = git git://github.com/plone/plone.rest.git pushurl=git@github.com:plone/plone.rest.git branch=master
 
 [versions]
-setuptools = 18.3.2
+setuptools = 18.5
 zc.buildout = 2.4.3
 zope.interface = 4.0.5
 coverage = 3.7.1


### PR DESCRIPTION
In order to solve the version conflict below we update the setuptools version.

```python
..
  File "/home/travis/build/plone/plone.restapi/local/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 605, in _maybe_add_setuptools
    if ws.find(requirement) is None:
  File "/home/travis/build/plone/plone.restapi/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 718, in find
    raise VersionConflict(dist, req)
VersionConflict: (setuptools 18.5 (/home/travis/build/plone/plone.restapi/lib/python2.7/site-packages), Requirement.parse(setuptools==18.3.2))
The command "bin/buildout -N -t 3 -c travis.cfg" failed and exited with 1 during .
```

https://travis-ci.org/plone/plone.restapi/builds/89610721