### PR TITLE
Refactor tests: Introduce API session in functional tests

### DIFF
--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -1,13 +1,21 @@
 # -*- coding: utf-8 -*-
+
+# pylint: disable=E1002
+# E1002: Use of super on an old style class
+
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import applyProfile
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import FunctionalTesting
+from urlparse import urljoin
+from urlparse import urlparse
 
 from plone.testing import z2
 
 from zope.configuration import xmlconfig
+
+import requests
 
 
 class PlonerestapiLayer(PloneSandboxLayer):
@@ -34,3 +42,21 @@ PLONE_RESTAPI_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_RESTAPI_FIXTURE, z2.ZSERVER_FIXTURE),
     name="PlonerestapiLayer:Functional"
 )
+
+
+class RelativeSession(requests.Session):
+    """A session that takes a base URL and makes requests relative to that
+    base if their URL is relative (doesn't begin with a HTTP[S] scheme).
+    """
+
+    def __init__(self, base_url):
+        super(RelativeSession, self).__init__()
+        if not base_url.endswith('/'):
+            base_url += '/'
+        self.__base_url = base_url
+
+    def request(self, method, url, **kwargs):
+        if urlparse(url).scheme not in ('http', 'https'):
+            url = url.lstrip('/')
+            url = urljoin(self.__base_url, url)
+        return super(RelativeSession, self).request(method, url, **kwargs)

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 from plone.restapi.testing import PLONE_RESTAPI_FUNCTIONAL_TESTING
+from plone.restapi.testing import RelativeSession
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import SITE_OWNER_NAME
@@ -17,7 +18,6 @@ from zope.intid.interfaces import IIntIds
 import unittest2 as unittest
 
 import os
-import requests
 
 REQUEST_HEADER_KEYS = [
     'accept'
@@ -66,6 +66,11 @@ class TestTraversal(unittest.TestCase):
         self.request = self.layer['request']
         self.portal = self.layer['portal']
         self.portal_url = self.portal.absolute_url()
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({'Accept': 'application/json'})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         self.portal.invokeFactory('Document', id='front-page')
         self.document = self.portal['front-page']
@@ -90,11 +95,7 @@ class TestTraversal(unittest.TestCase):
         )
 
     def test_documentation_document(self):
-        response = requests.get(
-            self.document.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.document.absolute_url())
         save_response_for_documentation('document.json', response)
 
     def test_documentation_news_item(self):
@@ -115,11 +116,7 @@ class TestTraversal(unittest.TestCase):
         self.portal.newsitem.image_caption = u'This is an image caption.'
         import transaction
         transaction.commit()
-        response = requests.get(
-            self.portal.newsitem.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.newsitem.absolute_url())
         save_response_for_documentation('newsitem.json', response)
 
     def test_documentation_event(self):
@@ -130,11 +127,7 @@ class TestTraversal(unittest.TestCase):
         self.portal.event.end = datetime(2013, 1, 1, 12, 0)
         import transaction
         transaction.commit()
-        response = requests.get(
-            self.portal.event.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.event.absolute_url())
         save_response_for_documentation('event.json', response)
 
     def test_documentation_link(self):
@@ -144,11 +137,7 @@ class TestTraversal(unittest.TestCase):
         self.portal.remoteUrl = 'http://plone.org'
         import transaction
         transaction.commit()
-        response = requests.get(
-            self.portal.link.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.link.absolute_url())
         save_response_for_documentation('link.json', response)
 
     def test_documentation_file(self):
@@ -168,11 +157,7 @@ class TestTraversal(unittest.TestCase):
         self.portal.file.file = RelationValue(file_id)
         import transaction
         transaction.commit()
-        response = requests.get(
-            self.portal.file.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.file.absolute_url())
         save_response_for_documentation('file.json', response)
 
     def test_documentation_image(self):
@@ -187,11 +172,7 @@ class TestTraversal(unittest.TestCase):
         )
         import transaction
         transaction.commit()
-        response = requests.get(
-            self.portal.image.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.image.absolute_url())
         save_response_for_documentation('image.json', response)
 
     def test_documentation_folder(self):
@@ -210,11 +191,7 @@ class TestTraversal(unittest.TestCase):
         )
         import transaction
         transaction.commit()
-        response = requests.get(
-            self.portal.folder.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.folder.absolute_url())
         save_response_for_documentation('folder.json', response)
 
     def test_documentation_collection(self):
@@ -239,25 +216,13 @@ class TestTraversal(unittest.TestCase):
         )
         import transaction
         transaction.commit()
-        response = requests.get(
-            self.portal.collection.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.collection.absolute_url())
         save_response_for_documentation('collection.json', response)
 
     def test_documentation_siteroot(self):
-        response = requests.get(
-            self.portal.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.absolute_url())
         save_response_for_documentation('siteroot.json', response)
 
     def test_documentation_404_not_found(self):
-        response = requests.get(
-            self.portal.absolute_url() + '/non-existing-resource',
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get('non-existing-resource')
         save_response_for_documentation('404_not_found.json', response)

--- a/src/plone/restapi/tests/test_services.py
+++ b/src/plone/restapi/tests/test_services.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.restapi.testing import PLONE_RESTAPI_FUNCTIONAL_TESTING
+from plone.restapi.testing import RelativeSession
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import SITE_OWNER_NAME
@@ -14,7 +15,6 @@ from zope.intid.interfaces import IIntIds
 
 import unittest
 import os
-import requests
 import transaction
 
 
@@ -27,6 +27,10 @@ class TestTraversal(unittest.TestCase):
         self.portal = self.layer['portal']
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({'Accept': 'application/json'})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
     def test_get_document(self):
         self.portal.invokeFactory(
@@ -42,11 +46,7 @@ class TestTraversal(unittest.TestCase):
         )
         transaction.commit()
 
-        response = requests.get(
-            self.portal.doc1.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.doc1.absolute_url())
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -99,11 +99,7 @@ class TestTraversal(unittest.TestCase):
         self.portal.news1.image_caption = u'This is an image caption.'
         transaction.commit()
 
-        response = requests.get(
-            self.portal.news1.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.news1.absolute_url())
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -144,11 +140,7 @@ class TestTraversal(unittest.TestCase):
         )
         transaction.commit()
 
-        response = requests.get(
-            self.portal.folder1.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.folder1.absolute_url())
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -174,11 +166,7 @@ class TestTraversal(unittest.TestCase):
         )
 
     def test_get_site_root(self):
-        response = requests.get(
-            self.portal_url,
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal_url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.headers.get('Content-Type'),
@@ -200,12 +188,7 @@ class TestTraversal(unittest.TestCase):
         self.portal.setDefaultPage('front-page')
         transaction.commit()
 
-        response = requests.get(
-            self.portal_url,
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
-
+        response = self.api_session.get(self.portal_url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.headers.get('Content-Type'),
@@ -240,11 +223,7 @@ class TestTraversal(unittest.TestCase):
         self.portal.file1.file = RelationValue(file_id)
         transaction.commit()
 
-        response = requests.get(
-            self.portal.file1.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.file1.absolute_url())
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -271,11 +250,7 @@ class TestTraversal(unittest.TestCase):
         )
         transaction.commit()
 
-        response = requests.get(
-            self.portal.img1.absolute_url(),
-            headers={'Accept': 'application/json'},
-            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        )
+        response = self.api_session.get(self.portal.img1.absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.headers.get('Content-Type'),


### PR DESCRIPTION
Introduces a helper class `RelativeSession` that can be used to 

- Set up commonly used HTTP headers like `Accept: application/json` and `Authentication` *once* in the test setup
- Make requests using relative URLs. Avoids the need to always concatenate strings with `portal.absolute_url()`

This then allows to write tests like this

```python
response = self.api_session.get('non-existing-resource')
```

instead of

```python
        response = requests.get(
            self.portal_url + '/non-existing-resource',
            headers={'Accept': 'application/json'},
            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
        )
```

which eliminates a ton of repetition and line noise, and makes the tests more expressive.

@tisto @jone @buchi