### PR TITLE
Search

### DIFF
--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -1,0 +1,21 @@
+GET /plone/search?sort_on=path
+Accept: application/json
+
+HTTP 200 OK
+content-type: application/json
+
+{
+  "items_count": 2, 
+  "member": [
+    {
+      "@id": "http://localhost:55001/plone/front-page", 
+      "description": "Congratulations! You have successfully installed Plone.", 
+      "title": "Welcome to Plone"
+    }, 
+    {
+      "@id": "http://localhost:55001/plone/robot-test-folder", 
+      "description": "", 
+      "title": "Test Folder"
+    }
+  ]
+}

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -5,17 +5,12 @@ HTTP 200 OK
 content-type: application/json
 
 {
-  "items_count": 2, 
+  "items_count": 1, 
   "member": [
     {
       "@id": "http://localhost:55001/plone/front-page", 
       "description": "Congratulations! You have successfully installed Plone.", 
       "title": "Welcome to Plone"
-    }, 
-    {
-      "@id": "http://localhost:55001/plone/robot-test-folder", 
-      "description": "", 
-      "title": "Test Folder"
     }
   ]
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ Contents
 
    introduction
    crud
+   searching
    content-negotiation
    error-handling
    http-status-codes

--- a/docs/source/searching.rst
+++ b/docs/source/searching.rst
@@ -1,0 +1,116 @@
+==============================================================================
+Search
+==============================================================================
+
+Content in a Plone site can be searched for by invoking the ``/search``
+endpoint on any context::
+
+  GET /plone/search HTTP/1.1
+  Accept: application/json
+
+A search is **contextual** by default, i.e. it is bound to a specific collection
+and searches within that collection and any sub-collections. Since a Plone
+site is also a collection, we therefore have a global search and contextual
+searches all exposed with the same pattern.
+
+In terms of the resulting catalog query this means that, by default, a search
+will be constrained by path to the context it's invoked on, unless you
+explicitly supply your own ``path`` query.
+
+Search results are represented similar to collections:
+
+
+.. literalinclude:: _json/search.json
+   :language: js
+
+The default representation for search results is a summary that contains only
+the most basic information. In order to return specific metadata columns, see
+the documentation of the ``metadata_fields`` parameter below.
+
+
+Query format
+============
+
+Queries and query-wide options (like ``sort_on``) are submitted as query
+string parameters to the ``/search`` request::
+
+  GET /plone/search?SearchableText=lorem
+
+This is nearly identical to the way that queries are passed to the Plone
+``@@search`` browser view, with only a few minor differences.
+
+For general information on how to query the Plone catalog, please refer to the
+`Plone Documentation on Querying`_.
+
+Query options
+-------------
+
+In case you want to supply query options to a query against a particular index,
+you'll need to flatten the corresponding query dictionary and use a dotted
+notation to indicate nesting.
+
+For example, to specify the ``depth`` query option for a path query, the
+original query as a Python dictionary would look like this::
+
+    query = {'path': {'query': '/folder',
+                      'depth': 2}}
+
+This dictionary will need to be flattened in dotted notation in order to pass
+it in a query string::
+
+  GET /plone/search?path.query=%2Ffolder&path.depth=2
+
+Again, this is very similar to how `Record Arguments`_ are parsed by
+ZPublisher, except that you can omit the ``:record`` suffix.
+
+
+Data types in queries
+---------------------
+
+Because HTTP query strings contain no information about data types, any query
+string parameter value ends up as a string in the Zope's request. This means,
+that for values types that aren't string, these data types need to be
+reconstructed on the server side in plone.restapi.
+
+For most index types and their query values and query options,
+plone.restapi can handle this for you. If you pass it
+``path.query=foo&path.depth=1``, it has the necessary knowledge about the
+``ExtendedPathIndex``'s options to turn the string ``1`` for the ``depth``
+argument back into an integer before passing the query on to the catalog.
+
+However, certain index types (a ``FieldIndex`` for example) may take
+arbitrary data types as query values. In that case, ``plone.restapi`` simply
+can't know what data type to cast your query value to, and you'll need to
+specify it using ZPublisher type hints::
+
+  GET /plone/search?numeric_field=42:int HTTP/1.1
+  Accept: application/json
+
+
+Please refer to the `Documentation on Argument Conversion in ZPublisher`_ for
+details.
+
+
+Retrieving additional metadata
+==============================
+
+By default the results are represented as summaries that only contain the most
+basic information about the items, like their URL and title. If you need to
+retrieve additional metadata columns, you can do so by specifying the
+additional column names in the ``metadata_fields`` parameter::
+
+  GET /plone/search?SearchableText=lorem&metadata_fields=modified HTTP/1.1
+  Accept: application/json
+
+The metadata from those columns then will be included in the results. In order
+to specify multiple columns, simply repeat the query string parameter once for
+every column name (the ``requests`` module will do this automatically for
+you if you pass it a list of values for a query string parameter).
+
+In order to retrieve all metadata columns that the catalog knows about, use
+``metadata_fields=_all``.
+
+
+.. _`Record Arguments`: http://docs.zope.org/zope2/zdgbook/ObjectPublishing.html?highlight=record#record-arguments
+.. _`Plone Documentation on Querying`: http://docs.plone.org/develop/plone/searching_and_indexing/query.html
+.. _`Documentation on Argument Conversion in ZPublisher`: http://docs.zope.org/zope2/zdgbook/ObjectPublishing.html#argument-conversion

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -3,3 +3,6 @@ extends =
     base.cfg
     http://dist.plone.org/release/4.3.9/versions.cfg
     versions.cfg
+
+[versions]
+plone.app.contenttypes = 1.1b5

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/4.3.7/versions.cfg
+    http://dist.plone.org/release/4.3.9/versions.cfg
     versions.cfg

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -3,3 +3,7 @@ extends =
     base.cfg
     http://dist.plone.org/release/5.0.4/versions.cfg
     versions.cfg
+
+[versions]
+plone.testing = 4.2.1
+

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.0.2/versions.cfg
+    http://dist.plone.org/release/5.0.4/versions.cfg
     versions.cfg

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -5,4 +5,4 @@ extends =
     versions.cfg
 
 [versions]
-plone.app.contenttypes = 1.2.10
+plone.app.contenttypes = 1.2.8

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -1,9 +1,8 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.0.4/versions.cfg
+    http://dist.plone.org/release/5.0.2/versions.cfg
     versions.cfg
 
 [versions]
-plone.testing = 4.2.1
-
+plone.app.contenttypes = 1.2.10

--- a/src/plone/restapi/configure.zcml
+++ b/src/plone/restapi/configure.zcml
@@ -30,5 +30,6 @@
   <include package=".services" />
   <include package=".serializer" />
   <include package=".deserializer" />
+  <include package=".search" />
 
 </configure>

--- a/src/plone/restapi/search/configure.zcml
+++ b/src/plone/restapi/search/configure.zcml
@@ -13,7 +13,10 @@
     <adapter factory=".query.ExtendedPathIndexQueryParser" />
     <adapter factory=".query.DateIndexQueryParser" />
     <adapter factory=".query.DateRangeIndexQueryParser" />
-    <adapter factory=".query.DateRecurringIndexQueryParser" />
     <adapter factory=".query.UUIDIndexQueryParser" />
+
+    <configure zcml:condition="installed Products.DateRecurringIndex">
+        <adapter factory=".date_recurring_index.DateRecurringIndexQueryParser" />
+    </configure>
 
 </configure>

--- a/src/plone/restapi/search/configure.zcml
+++ b/src/plone/restapi/search/configure.zcml
@@ -1,0 +1,19 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="plone.restapi">
+
+    <adapter factory=".query.ZCatalogCompatibleQueryAdapter" />
+
+    <adapter factory=".query.ZCTextIndexQueryParser" />
+    <adapter factory=".query.KeywordIndexQueryParser" />
+    <adapter factory=".query.FieldIndexQueryParser" />
+    <adapter factory=".query.BooleanIndexQueryParser" />
+    <adapter factory=".query.ExtendedPathIndexQueryParser" />
+    <adapter factory=".query.DateIndexQueryParser" />
+    <adapter factory=".query.DateRangeIndexQueryParser" />
+    <adapter factory=".query.DateRecurringIndexQueryParser" />
+    <adapter factory=".query.UUIDIndexQueryParser" />
+
+</configure>

--- a/src/plone/restapi/search/date_recurring_index.py
+++ b/src/plone/restapi/search/date_recurring_index.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from DateTime import DateTime
+from plone.restapi.interfaces import IIndexQueryParser
+from plone.restapi.search.query import BaseIndexQueryParser
+from Products.DateRecurringIndex.index import DateRecurringIndex
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IIndexQueryParser)
+@adapter(DateRecurringIndex, Interface, Interface)
+class DateRecurringIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = DateTime
+    query_options = {
+        'range': str,
+    }

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.interfaces import ISerializeToJson
+from Products.CMFCore.utils import getToolByName
+from zope.component import getMultiAdapter
+
+
+class SearchHandler(object):
+    """Executes a catalog search based on a query dict, and returns
+    JSON compatible results.
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+        self.catalog = getToolByName(self.context, 'portal_catalog')
+
+    def search(self, query=None):
+        if query is None:
+            query = {}
+
+        lazy_resultset = self.catalog.searchResults(query)
+        results = getMultiAdapter((lazy_resultset, self.request),
+                                  ISerializeToJson)()
+        return results

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import IZCatalogCompatibleQuery
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
 
@@ -14,6 +15,11 @@ class SearchHandler(object):
         self.request = request
         self.catalog = getToolByName(self.context, 'portal_catalog')
 
+    def _parse_query(self, query):
+        catalog_compatible_query = getMultiAdapter(
+            (self.context, self.request), IZCatalogCompatibleQuery)(query)
+        return catalog_compatible_query
+
     def _constrain_query_by_path(self, query):
         # If no 'path' parameter was supplied, restrict search to current
         # context and its children by adding a path constraint
@@ -25,6 +31,7 @@ class SearchHandler(object):
         if query is None:
             query = {}
 
+        query = self._parse_query(query)
         self._constrain_query_by_path(query)
 
         lazy_resultset = self.catalog.searchResults(query)

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -14,9 +14,18 @@ class SearchHandler(object):
         self.request = request
         self.catalog = getToolByName(self.context, 'portal_catalog')
 
+    def _constrain_query_by_path(self, query):
+        # If no 'path' parameter was supplied, restrict search to current
+        # context and its children by adding a path constraint
+        if 'path' not in query:
+            path = '/'.join(self.context.getPhysicalPath())
+            query['path'] = path
+
     def search(self, query=None):
         if query is None:
             query = {}
+
+        self._constrain_query_by_path(query)
 
         lazy_resultset = self.catalog.searchResults(query)
         results = getMultiAdapter((lazy_resultset, self.request),

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -31,10 +31,15 @@ class SearchHandler(object):
         if query is None:
             query = {}
 
+        metadata_fields = query.pop('metadata_fields', [])
+        if not isinstance(metadata_fields, list):
+            metadata_fields = [metadata_fields]
+
         query = self._parse_query(query)
         self._constrain_query_by_path(query)
 
         lazy_resultset = self.catalog.searchResults(query)
-        results = getMultiAdapter((lazy_resultset, self.request),
-                                  ISerializeToJson)()
+        results = getMultiAdapter(
+            (lazy_resultset, self.request),
+            ISerializeToJson)(metadata_fields=metadata_fields)
         return results

--- a/src/plone/restapi/search/query.py
+++ b/src/plone/restapi/search/query.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+"""
+The adapters in this module are responsible for turning back a catalog query
+that has been serialized (to a HTTP query string or JSON) into a query that is
+suitable for passing to catalog.searchResults().
+
+The main issue here is typing of query values and query options. See docs for
+the IZCatalogCompatibleQuery and IIndexQueryParser interfaces for details.
+
+The adapters provided in this module cover the index types present in default
+Plone 4.3 / 5.0 installations.
+
+Index types used in a default Plone 4.3:
+
+- BooleanIndex
+- DateIndex
+- DateRangeIndex
+- ExtendedPathIndex
+- FieldIndex
+- GopipIndex (not queriable)
+- KeywordIndex
+- UUIDIndex
+- ZCTextIndex
+
+Plone 5.0:
+
+- DateRecurringIndex (plus all of the above)
+"""
+
+from DateTime import DateTime
+from DateTime.interfaces import SyntaxError as DTSyntaxError
+from plone.restapi.interfaces import IIndexQueryParser
+from plone.restapi.interfaces import IZCatalogCompatibleQuery
+from Products.CMFCore.utils import getToolByName
+from Products.DateRecurringIndex.index import DateRecurringIndex
+from Products.ExtendedPathIndex.ExtendedPathIndex import ExtendedPathIndex
+from Products.PluginIndexes.BooleanIndex.BooleanIndex import BooleanIndex
+from Products.PluginIndexes.DateIndex.DateIndex import DateIndex
+from Products.PluginIndexes.DateRangeIndex.DateRangeIndex import DateRangeIndex
+from Products.PluginIndexes.FieldIndex.FieldIndex import FieldIndex
+from Products.PluginIndexes.KeywordIndex.KeywordIndex import KeywordIndex
+from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
+from Products.ZCTextIndex.ZCTextIndex import ZCTextIndex
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+# Marker value to signal that query values may be of an arbitrary type
+ANY_TYPE = object()
+
+
+class QueryParsingException(Exception):
+    """An error happened while parsing a search query.
+    """
+
+
+@implementer(IZCatalogCompatibleQuery)
+@adapter(Interface, Interface)
+class ZCatalogCompatibleQueryAdapter(object):
+    """Converts a Python dictionary representing a catalog query, but with
+    possibly wrong value types, to a ZCatalog compatible query dict suitable
+    for passing to catalog.searchResults().
+
+    See the IZCatalogCompatibleQuery interface documentation for details.
+    """
+
+    global_query_params = {
+        'sort_on': str,
+        'sort_order': str,
+        'sort_limit': int,
+    }
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+        self.catalog = getToolByName(self.context, 'portal_catalog')
+
+    def get_index(self, name):
+        return self.catalog._catalog.indexes.get(name)
+
+    def parse_query_param(self, idx_name, idx_query):
+        _type = self.global_query_params[idx_name]
+        return _type(idx_query)
+
+    def __call__(self, query):
+        for idx_name, idx_query in query.items():
+            if idx_name in self.global_query_params:
+                # It's a query-wide parameter like 'sort_on'
+                query[idx_name] = self.parse_query_param(idx_name, idx_query)
+                continue
+
+            # Then check for each index present in the query if there is an
+            # IIndexQueryParser that knows how to deserialize any values
+            # that could not be serialized in a query string or JSON
+            index = self.get_index(idx_name)
+            if index is None:
+                log.warn("No such index: %r" % idx_name)
+                continue
+
+            query_opts_parser = getMultiAdapter(
+                (index, self.context, self.request), IIndexQueryParser)
+
+            if query_opts_parser is not None:
+                idx_query = query_opts_parser.parse(idx_query)
+
+            query[idx_name] = idx_query
+        return query
+
+
+class BaseIndexQueryParser(object):
+    """Base class for IIndexQueryParser adapters.
+
+    See the IIndexQueryParser interface documentation for details.
+    """
+
+    query_value_type = str
+    query_options = {}
+
+    def __init__(self, index=None, context=None, request=None):
+        self.index = index
+        self.context = context
+        self.request = request
+
+    def parse(self, idx_query):
+        if isinstance(idx_query, dict):
+            return self.parse_complex_query(idx_query)
+        return self.parse_simple_query(idx_query)
+
+    def parse_query_value(self, query_value):
+        if self.query_value_type is ANY_TYPE:
+            return query_value
+        try:
+            query_value = self.query_value_type(query_value)
+
+        except (ValueError, DTSyntaxError):
+            raise QueryParsingException(
+                "Query value %r for index %s must be of type %r" % (
+                    query_value, self.index, self.query_value_type))
+        return self.query_value_type(query_value)
+
+    def parse_simple_query(self, idx_query):
+        if isinstance(idx_query, (list, tuple)):
+            return [self.parse_query_value(q) for q in idx_query]
+        return self.parse_query_value(idx_query)
+
+    def parse_complex_query(self, idx_query):
+        idx_query = idx_query.copy()
+        parsed_query = {}
+
+        try:
+            qv = idx_query.pop('query')
+            parsed_query['query'] = self.parse_simple_query(qv)
+        except KeyError:
+            raise QueryParsingException(
+                "Query for index %r is missing a 'query' key!" % self.index)
+
+        for opt_key, opt_value in idx_query.items():
+            if opt_key in self.query_options:
+                opt_type = self.query_options[opt_key]
+                try:
+                    parsed_query[opt_key] = opt_type(opt_value)
+                except ValueError:
+                    raise QueryParsingException(
+                        "Value %r for query option %r (index %r) could not be"
+                        " casted to %r" % (
+                            opt_value, opt_key, self.index, opt_type))
+            else:
+                log.warn("Unrecognized query option %r for index %r" % (
+                    opt_key, self.index))
+                # Pass along unknown option without modification
+                parsed_query[opt_key] = opt_value
+
+        return parsed_query
+
+
+@implementer(IIndexQueryParser)
+@adapter(ZCTextIndex, Interface, Interface)
+class ZCTextIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = str
+    query_options = {}
+
+
+@implementer(IIndexQueryParser)
+@adapter(KeywordIndex, Interface, Interface)
+class KeywordIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = ANY_TYPE
+    query_options = {
+        'operator': str,
+        'range': str,
+    }
+
+
+@implementer(IIndexQueryParser)
+@adapter(BooleanIndex, Interface, Interface)
+class BooleanIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = bool
+    query_options = {}
+
+    def parse_query_value(self, query_value):
+        if not str(query_value).lower() in ('true', 'false', '1', '0'):
+            raise QueryParsingException(
+                'Could not parse query value %r as boolean' % query_value)
+        return str(query_value).lower() in ('true', '1')
+
+
+@implementer(IIndexQueryParser)
+@adapter(FieldIndex, Interface, Interface)
+class FieldIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = ANY_TYPE
+    query_options = {
+        'range': str,
+    }
+
+
+@implementer(IIndexQueryParser)
+@adapter(ExtendedPathIndex, Interface, Interface)
+class ExtendedPathIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = str
+    query_options = {
+        'level': int,
+        'operator': str,
+        'depth': int,
+        'navtree': bool,
+        'navtree_start': int,
+    }
+
+
+@implementer(IIndexQueryParser)
+@adapter(DateIndex, Interface, Interface)
+class DateIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = DateTime
+    query_options = {
+        'range': str,
+    }
+
+
+@implementer(IIndexQueryParser)
+@adapter(DateRangeIndex, Interface, Interface)
+class DateRangeIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = DateTime
+    query_options = {}
+
+
+@implementer(IIndexQueryParser)
+@adapter(DateRecurringIndex, Interface, Interface)
+class DateRecurringIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = DateTime
+    query_options = {
+        'range': str,
+    }
+
+
+@implementer(IIndexQueryParser)
+@adapter(UUIDIndex, Interface, Interface)
+class UUIDIndexQueryParser(BaseIndexQueryParser):
+
+    query_value_type = str
+    query_options = {
+        'range': str,
+    }

--- a/src/plone/restapi/search/query.py
+++ b/src/plone/restapi/search/query.py
@@ -25,6 +25,9 @@ Index types used in a default Plone 4.3:
 Plone 5.0:
 
 - DateRecurringIndex (plus all of the above)
+
+The adapter for DateRecurringIndex is in a separate module and registered
+conditionally in order to avoid breaking compatibility with vanilla Plone 4.3.
 """
 
 from DateTime import DateTime
@@ -32,7 +35,6 @@ from DateTime.interfaces import SyntaxError as DTSyntaxError
 from plone.restapi.interfaces import IIndexQueryParser
 from plone.restapi.interfaces import IZCatalogCompatibleQuery
 from Products.CMFCore.utils import getToolByName
-from Products.DateRecurringIndex.index import DateRecurringIndex
 from Products.ExtendedPathIndex.ExtendedPathIndex import ExtendedPathIndex
 from Products.PluginIndexes.BooleanIndex.BooleanIndex import BooleanIndex
 from Products.PluginIndexes.DateIndex.DateIndex import DateIndex
@@ -252,16 +254,6 @@ class DateRangeIndexQueryParser(BaseIndexQueryParser):
 
     query_value_type = DateTime
     query_options = {}
-
-
-@implementer(IIndexQueryParser)
-@adapter(DateRecurringIndex, Interface, Interface)
-class DateRecurringIndexQueryParser(BaseIndexQueryParser):
-
-    query_value_type = DateTime
-    query_options = {
-        'range': str,
-    }
 
 
 @implementer(IIndexQueryParser)

--- a/src/plone/restapi/search/utils.py
+++ b/src/plone/restapi/search/utils.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+
+def unflatten_dotted_dict(dct):
+    """Reconstructs nesting for a dict that has been flattened to one level.
+
+    Further nesting is indicated by dots in the key names: Keys will be merged
+    together into sub-dicts based on their longest common prefix.
+
+    Example:
+
+    >>> dct = {
+    ...     'a.b.X': 1,
+    ...     'a.b.Y': 2,
+    ...     'a.foo': 3,
+    ...     'bar': 4,
+    ... }
+    >>>
+    >>> unflatten_dotted_dict(dct)
+
+    {'a': {'b': {'X': 1,
+                 'Y': 2},
+           'foo': 3},
+     'bar': 4}
+    """
+    def create_or_get(dct, key):
+        return dct.setdefault(key, {})
+
+    result = {}
+
+    for key, value in dct.items():
+        key_segments = key.split('.')
+        # Create nested dicts from parent keys, if any
+        inner = reduce(create_or_get, [result] + key_segments[:-1])
+        # Assign value to terminal key
+        inner[key_segments[-1]] = value
+
+    return result

--- a/src/plone/restapi/serializer/catalog.py
+++ b/src/plone/restapi/serializer/catalog.py
@@ -1,11 +1,59 @@
 # -*- coding: utf-8 -*-
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer.converters import json_compatible
+from Products.CMFCore.utils import getToolByName
+from Products.ZCatalog.interfaces import ICatalogBrain
 from Products.ZCatalog.Lazy import Lazy
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component.hooks import getSite
 from zope.interface import implementer
 from zope.interface import Interface
+
+
+BRAIN_METHODS = ['getPath', 'getURL']
+
+
+@implementer(ISerializeToJson)
+@adapter(ICatalogBrain, Interface)
+class BrainSerializer(object):
+    """Serializes a catalog brain to a Python data structure that can in turn
+    be serialized to JSON.
+    """
+
+    def __init__(self, brain, request):
+        self.brain = brain
+        self.request = request
+
+    def _get_metadata_to_include(self, metadata_fields):
+        if metadata_fields and '_all' in metadata_fields:
+            site = getSite()
+            catalog = getToolByName(site, 'portal_catalog')
+            metadata_attrs = catalog.schema() + BRAIN_METHODS
+            return metadata_attrs
+
+        return metadata_fields
+
+    def __call__(self, metadata_fields=('_all',)):
+        metadata_to_include = self._get_metadata_to_include(metadata_fields)
+
+        result = {}
+        for attr in metadata_to_include:
+            value = getattr(self.brain, attr, None)
+
+            # Handle values that are provided via methods on brains, like
+            # getPath or getURL (see ICatalogBrain for details)
+            if attr in BRAIN_METHODS:
+                value = value()
+
+            value = json_compatible(value)
+
+            # TODO: Deal with metadata attributes that already contain
+            # timestamps as isoformat strings, like 'Created'
+            result[attr] = value
+
+        return result
 
 
 @implementer(ISerializeToJson)
@@ -19,13 +67,20 @@ class LazyCatalogResultSerializer(object):
         self.lazy_resultset = lazy_resultset
         self.request = request
 
-    def __call__(self):
+    def __call__(self, metadata_fields=()):
         results = {}
         results['items_count'] = self.lazy_resultset.actual_result_count
         results['member'] = []
 
         for brain in self.lazy_resultset:
-            brain_summary = getMultiAdapter(
+            result = getMultiAdapter(
                 (brain, self.request), ISerializeToJsonSummary)()
-            results['member'].append(brain_summary)
+
+            if metadata_fields:
+                metadata = getMultiAdapter(
+                    (brain, self.request),
+                    ISerializeToJson)(metadata_fields=metadata_fields)
+                result.update(metadata)
+
+            results['member'].append(result)
         return results

--- a/src/plone/restapi/serializer/catalog.py
+++ b/src/plone/restapi/serializer/catalog.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from Products.ZCatalog.Lazy import Lazy
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(Lazy, Interface)
+class LazyCatalogResultSerializer(object):
+    """Serializes a ZCatalog resultset (one of the subclasses of `Lazy`) to
+    a Python data structure that can in turn be serialized to JSON.
+    """
+
+    def __init__(self, lazy_resultset, request):
+        self.lazy_resultset = lazy_resultset
+        self.request = request
+
+    def __call__(self):
+        results = {}
+        results['items_count'] = self.lazy_resultset.actual_result_count
+        results['member'] = []
+
+        for brain in self.lazy_resultset:
+            brain_summary = getMultiAdapter(
+                (brain, self.request), ISerializeToJsonSummary)()
+            results['member'].append(brain_summary)
+        return results

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -52,6 +52,7 @@
         <adapter factory=".relationfield.relationvalue_converter" />
     </configure>
 
+    <adapter factory=".catalog.BrainSerializer" />
     <adapter factory=".catalog.LazyCatalogResultSerializer" />
 
 </configure>

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -34,7 +34,9 @@
     <adapter factory=".converters.default_converter" />
     <adapter factory=".converters.dict_converter" />
     <adapter factory=".converters.frozenset_converter" />
+    <adapter factory=".converters.i18n_message_converter" />
     <adapter factory=".converters.list_converter" />
+    <adapter factory=".converters.missing_value_converter" />
     <adapter factory=".converters.persistent_list_converter" />
     <adapter factory=".converters.persistent_mapping_converter" />
     <adapter factory=".converters.python_datetime_converter" />
@@ -49,5 +51,7 @@
     <configure zcml:condition="installed z3c.relationfield">
         <adapter factory=".relationfield.relationvalue_converter" />
     </configure>
+
+    <adapter factory=".catalog.LazyCatalogResultSerializer" />
 
 </configure>

--- a/src/plone/restapi/serializer/converters.py
+++ b/src/plone/restapi/serializer/converters.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-from DateTime import DateTime
-from Products.CMFPlone.utils import getSiteEncoding
-from Products.CMFPlone.utils import safe_unicode
 from datetime import date
+from DateTime import DateTime
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
@@ -10,10 +8,17 @@ from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
 from plone.app.textfield.interfaces import IRichTextValue
 from plone.restapi.interfaces import IJsonCompatible
+from Products.CMFPlone.utils import getSiteEncoding
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import adapter
 from zope.component.hooks import getSite
-from zope.interface import Interface
+from zope.globalrequest import getRequest
+from zope.i18n import translate
+from zope.i18nmessageid.message import Message
 from zope.interface import implementer
+from zope.interface import Interface
+
+import Missing
 
 
 def json_compatible(value):
@@ -135,3 +140,16 @@ def richtext_converter(value):
         u'content-type': json_compatible(value.mimeType),
         u'encoding': json_compatible(value.encoding),
     }
+
+
+@adapter(Message)
+@implementer(IJsonCompatible)
+def i18n_message_converter(value):
+    value = translate(value, context=getRequest())
+    return value
+
+
+@adapter(Missing.Value.__class__)
+@implementer(IJsonCompatible)
+def missing_value_converter(value):
+    return None

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -2,5 +2,6 @@
     xmlns="http://namespaces.zope.org/zope">
 
   <include package=".content"/>
+  <include package=".search"/>
 
 </configure>

--- a/src/plone/restapi/services/search/configure.zcml
+++ b/src/plone/restapi/services/search/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone">
+
+  <plone:service
+    method="GET"
+    for="zope.interface.Interface"
+    factory=".get.SearchGet"
+    name="search"
+    permission="zope2.View"
+    />
+
+</configure>

--- a/src/plone/restapi/services/search/get.py
+++ b/src/plone/restapi/services/search/get.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from plone.rest import Service
+from plone.restapi.search.handler import SearchHandler
+
+
+class SearchGet(Service):
+
+    def render(self):
+        query = self.request.form.copy()
+        return SearchHandler(self.context, self.request).search(query)

--- a/src/plone/restapi/services/search/get.py
+++ b/src/plone/restapi/services/search/get.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from plone.rest import Service
 from plone.restapi.search.handler import SearchHandler
+from plone.restapi.search.utils import unflatten_dotted_dict
 
 
 class SearchGet(Service):
 
     def render(self):
         query = self.request.form.copy()
+        query = unflatten_dotted_dict(query)
         return SearchHandler(self.context, self.request).search(query)

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -4,11 +4,13 @@
 # E1002: Use of super on an old style class
 
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
+from plone.restapi.tests.dxtypes import INDEXES as DX_TYPES_INDEXES
+from plone.restapi.tests.helpers import add_catalog_indexes
 from urlparse import urljoin
 from urlparse import urlparse
 
@@ -41,6 +43,7 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.restapi:default')
         applyProfile(portal, 'plone.restapi:testing')
+        add_catalog_indexes(portal, DX_TYPES_INDEXES)
 
 PLONE_RESTAPI_DX_FIXTURE = PloneRestApiDXLayer()
 PLONE_RESTAPI_DX_INTEGRATION_TESTING = IntegrationTesting(

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -19,6 +19,13 @@ from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
 
+INDEXES = (
+    ("test_int_field", "FieldIndex"),
+    ("test_list_field", "KeywordIndex"),
+    ("test_bool_field", "BooleanIndex"),
+)
+
+
 class IDXTestDocumentSchema(model.Schema):
 
     # zope.schema fields

--- a/src/plone/restapi/tests/helpers.py
+++ b/src/plone/restapi/tests/helpers.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from urlparse import urlparse
+
+
+def result_paths(results):
+    """Helper function to make it easier to write list-based assertions on
+    result sets from the search endpoint.
+    """
+    def get_path(item):
+        if 'getPath' in item:
+            return item['getPath']
+        return urlparse(item['@id']).path
+
+    return [get_path(item) for item in results['member']]

--- a/src/plone/restapi/tests/helpers.py
+++ b/src/plone/restapi/tests/helpers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from Products.CMFCore.utils import getToolByName
 from urlparse import urlparse
 
 
@@ -12,3 +13,24 @@ def result_paths(results):
         return urlparse(item['@id']).path
 
     return [get_path(item) for item in results['member']]
+
+
+def add_catalog_indexes(portal, indexes):
+    """Add all `indexes` to the plone catalog.
+
+    The argument `indexes` can be a tuple of length two when only name and
+    meta_type are required. It also supports a tuple of length three when
+    additional arguments are required to add an index (e.g. when adding a
+    `ZCTextIndex` index).
+
+    """
+    catalog = getToolByName(portal, 'portal_catalog')
+    current_indexes = catalog.indexes()
+
+    indexables = []
+    for name, index_type in indexes:
+        if name not in current_indexes:
+            catalog.addIndex(name, index_type)
+            indexables.append(name)
+    if len(indexables) > 0:
+        catalog.manage_reindexIndex(ids=indexables)

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -266,3 +266,8 @@ class TestTraversal(unittest.TestCase):
     def test_documentation_404_not_found(self):
         response = self.api_session.get('non-existing-resource')
         save_response_for_documentation('404_not_found.json', response)
+
+    def test_documentation_search(self):
+        query = {'sort_on': 'path'}
+        response = self.api_session.get('/search', params=query)
+        save_response_for_documentation('search.json', response)

--- a/src/plone/restapi/tests/test_query_parsers.py
+++ b/src/plone/restapi/tests/test_query_parsers.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+from DateTime import DateTime
+from plone.restapi.search.query import BaseIndexQueryParser
+from plone.restapi.search.query import BooleanIndexQueryParser
+from plone.restapi.search.query import DateIndexQueryParser
+from plone.restapi.search.query import DateRangeIndexQueryParser
+from plone.restapi.search.query import ExtendedPathIndexQueryParser
+from plone.restapi.search.query import FieldIndexQueryParser
+from plone.restapi.search.query import KeywordIndexQueryParser
+from plone.restapi.search.query import QueryParsingException
+from plone.restapi.search.query import UUIDIndexQueryParser
+from plone.restapi.search.query import ZCTextIndexQueryParser
+import unittest
+
+
+class TestBaseIndexQueryParser(unittest.TestCase):
+
+    def test_casts_simple_query_to_string(self):
+        qp = BaseIndexQueryParser()
+        self.assertEqual('42', qp.parse(42))
+
+    def test_casts_complex_query_values_to_string(self):
+        qp = BaseIndexQueryParser()
+        self.assertEqual({'query': '42'}, qp.parse({'query': 42}))
+
+    def test_casts_query_values_in_sequences(self):
+        qp = BaseIndexQueryParser()
+        self.assertEqual(['23', '42'], qp.parse([23, 42]))
+        self.assertEqual(['23', '42'], qp.parse((23, 42)))
+
+    def test_raises_on_missing_query_key_for_complex_queries(self):
+        qp = BaseIndexQueryParser()
+        with self.assertRaises(QueryParsingException):
+            qp.parse({})
+
+
+class TestZCTextIndexQueryParser(unittest.TestCase):
+
+    def test_casts_simple_query_to_string(self):
+        qp = ZCTextIndexQueryParser()
+        self.assertEqual('42', qp.parse(42))
+
+    def test_casts_complex_query_values_to_string(self):
+        qp = ZCTextIndexQueryParser()
+        self.assertEqual({'query': '42'}, qp.parse({'query': 42}))
+
+
+class TestKeywordIndexQueryParser(unittest.TestCase):
+
+    def test_returns_simple_query_unchanged(self):
+        qp = KeywordIndexQueryParser()
+        self.assertEqual('keyword', qp.parse('keyword'))
+        self.assertEqual(42, qp.parse(42))
+
+    def test_returns_complex_query_values_unchanged(self):
+        qp = KeywordIndexQueryParser()
+        self.assertEqual({'query': 'keyword'}, qp.parse({'query': 'keyword'}))
+        self.assertEqual({'query': 42}, qp.parse({'query': 42}))
+
+    def test_casts_operator_option_to_string(self):
+        qp = KeywordIndexQueryParser()
+        self.assertEqual(
+            {'operator': '42', 'query': 'keyword'},
+            qp.parse({'operator': 42, 'query': 'keyword'}))
+
+    def test_casts_range_option_to_string(self):
+        qp = KeywordIndexQueryParser()
+        self.assertEqual(
+            {'range': '42', 'query': 'keyword'},
+            qp.parse({'range': 42, 'query': 'keyword'}))
+
+
+class TestBooleanIndexQueryParser(unittest.TestCase):
+
+    def test_casts_simple_query_to_boolean(self):
+        qp = BooleanIndexQueryParser()
+        self.assertEqual(True, qp.parse('True'))
+        self.assertEqual(True, qp.parse('true'))
+        self.assertEqual(True, qp.parse('1'))
+        self.assertEqual(False, qp.parse('False'))
+        self.assertEqual(False, qp.parse('false'))
+        self.assertEqual(False, qp.parse('0'))
+
+    def test_casts_complex_query_values_to_boolean(self):
+        qp = BooleanIndexQueryParser()
+        self.assertEqual({'query': True}, qp.parse({'query': 'True'}))
+        self.assertEqual({'query': True}, qp.parse({'query': 'true'}))
+        self.assertEqual({'query': True}, qp.parse({'query': '1'}))
+        self.assertEqual({'query': False}, qp.parse({'query': 'False'}))
+        self.assertEqual({'query': False}, qp.parse({'query': 'false'}))
+        self.assertEqual({'query': False}, qp.parse({'query': '0'}))
+
+    def test_raises_for_invalid_query_type(self):
+        qp = BooleanIndexQueryParser()
+        with self.assertRaises(QueryParsingException):
+            qp.parse(42)
+
+
+class TestFieldIndexQueryParser(unittest.TestCase):
+
+    def test_returns_simple_query_unchanged(self):
+        qp = FieldIndexQueryParser()
+        self.assertEqual('foo', qp.parse('foo'))
+        self.assertEqual(42, qp.parse(42))
+
+    def test_returns_complex_query_values_unchanged(self):
+        qp = FieldIndexQueryParser()
+        self.assertEqual({'query': 'foo'}, qp.parse({'query': 'foo'}))
+        self.assertEqual({'query': 42}, qp.parse({'query': 42}))
+
+    def test_casts_range_option_to_string(self):
+        qp = FieldIndexQueryParser()
+        self.assertEqual(
+            {'range': '42', 'query': '/path'},
+            qp.parse({'range': 42, 'query': '/path'}))
+
+
+class TestExtendedPathIndexQueryParser(unittest.TestCase):
+
+    def test_casts_simple_query_to_string(self):
+        qp = ExtendedPathIndexQueryParser()
+        self.assertEqual('42', qp.parse(42))
+
+    def test_casts_complex_query_values_to_string(self):
+        qp = ExtendedPathIndexQueryParser()
+        self.assertEqual({'query': '42'}, qp.parse({'query': 42}))
+
+    def test_casts_level_option_to_int(self):
+        qp = ExtendedPathIndexQueryParser()
+        self.assertEqual(
+            {'level': 3, 'query': '/path'},
+            qp.parse({'level': '3', 'query': '/path'}))
+
+    def test_casts_operator_option_to_string(self):
+        qp = ExtendedPathIndexQueryParser()
+        self.assertEqual(
+            {'operator': '42', 'query': '/path'},
+            qp.parse({'operator': 42, 'query': '/path'}))
+
+    def test_casts_depth_option_to_int(self):
+        qp = ExtendedPathIndexQueryParser()
+        self.assertEqual(
+            {'depth': 3, 'query': '/path'},
+            qp.parse({'depth': '3', 'query': '/path'}))
+
+    def test_casts_navtree_option_to_int(self):
+        qp = ExtendedPathIndexQueryParser()
+        self.assertEqual(
+            {'navtree': False, 'query': '/path'},
+            qp.parse({'navtree': 0, 'query': '/path'}))
+        self.assertEqual(
+            {'navtree': True, 'query': '/path'},
+            qp.parse({'navtree': 1, 'query': '/path'}))
+
+    def test_casts_navtree_start_option_to_int(self):
+        qp = ExtendedPathIndexQueryParser()
+        self.assertEqual(
+            {'navtree_start': 42, 'query': '/path'},
+            qp.parse({'navtree_start': '42', 'query': '/path'}))
+
+
+class TestDateIndexQueryParser(unittest.TestCase):
+
+    def test_casts_simple_query_to_zope_date_time(self):
+        qp = DateIndexQueryParser()
+        self.assertEqual(
+            DateTime('2016/12/24 00:00:00 GMT+0'),
+            qp.parse('2016-12-24'))
+
+    def test_casts_complex_query_values_to_zope_date_time(self):
+        qp = DateIndexQueryParser()
+        self.assertEqual(
+            {'query': DateTime('2016/12/24 00:00:00 GMT+0')},
+            qp.parse({'query': '2016-12-24'}))
+
+    def test_casts_range_option_to_string(self):
+        qp = DateIndexQueryParser()
+        self.assertEqual(
+            {'range': '42', 'query': DateTime('2016/12/24 00:00:00 GMT+0')},
+            qp.parse({'range': 42, 'query': '2016-12-24'}))
+
+
+class TestDateRangeIndexQueryParser(unittest.TestCase):
+
+    def test_casts_simple_query_to_zope_date_time(self):
+        qp = DateRangeIndexQueryParser()
+        self.assertEqual(
+            DateTime('2016/12/24 00:00:00 GMT+0'),
+            qp.parse('2016-12-24'))
+
+    def test_casts_complex_query_values_to_zope_date_time(self):
+        qp = DateRangeIndexQueryParser()
+        self.assertEqual(
+            {'query': DateTime('2016/12/24 00:00:00 GMT+0')},
+            qp.parse({'query': '2016-12-24'}))
+
+
+class TestUUIDIndexQueryParser(unittest.TestCase):
+
+    def test_casts_simple_query_to_string(self):
+        qp = UUIDIndexQueryParser()
+        self.assertEqual('42', qp.parse(42))
+
+    def test_casts_complex_query_values_to_string(self):
+        qp = UUIDIndexQueryParser()
+        self.assertEqual({'query': '42'}, qp.parse({'query': 42}))
+
+    def test_casts_range_option_to_string(self):
+        qp = UUIDIndexQueryParser()
+        self.assertEqual(
+            {'range': '42', 'query': '<UID>'},
+            qp.parse({'range': 42, 'query': '<UID>'}))

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -47,6 +47,8 @@ class TestSearchFunctional(unittest.TestCase):
             test_list_field=['Keyword1', 'Keyword2', 'Keyword3'],
             test_bool_field=True,
         )
+        IMutableUUID(self.doc).set('77779ffa110e45afb1ba502f75f77777')
+        self.doc.reindexObject()
 
         # /plone/folder/other-document
         self.doc2 = createContentInContainer(
@@ -94,6 +96,60 @@ class TestSearchFunctional(unittest.TestCase):
              u'/plone/folder/doc',
              u'/plone/folder/other-document'},
             set(result_paths(response.json())))
+
+    def test_partial_metadata_retrieval(self):
+        query = {'SearchableText': 'lorem',
+                 'metadata_fields': ['portal_type', 'review_state']}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertDictContainsSubset(
+            {u'@id': u'http://localhost:55001/plone/folder/doc',
+             u'title': u'Lorem Ipsum',
+             u'portal_type': u'DXTestDocument',
+             u'review_state': u'private'},
+            response.json()['member'][0])
+
+    def test_full_metadata_retrieval(self):
+        query = {'SearchableText': 'lorem', 'metadata_fields': '_all'}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertDictContainsSubset(
+            {u'@id': u'http://localhost:55001/plone/folder/doc',
+             u'Creator': u'test_user_1_',
+             u'Description': u'',
+             u'EffectiveDate': u'None',
+             u'ExpirationDate': u'None',
+             u'Subject': [],
+             u'Title': u'Lorem Ipsum',
+             u'Type': u'DX Test Document',
+             u'UID': u'77779ffa110e45afb1ba502f75f77777',
+             u'author_name': None,
+             u'cmf_uid': None,
+             u'commentators': [],
+             u'description': u'',
+             u'effective': u'1995-01-01T00:00:00+00:00',
+             u'end': None,
+             u'exclude_from_nav': False,
+             u'expires': u'1999-01-01T00:00:00+00:00',
+             u'getId': u'doc',
+             u'getObjSize': u'0 KB',
+             u'getPath': u'/plone/folder/doc',
+             u'getRemoteUrl': None,
+             u'getURL': u'http://localhost:55001/plone/folder/doc',
+             u'id': u'doc',
+             u'in_response_to': None,
+             u'is_folderish': False,
+             u'last_comment_date': None,
+             u'listCreators': [u'test_user_1_'],
+             u'location': None,
+             u'meta_type': u'Dexterity Item',
+             u'portal_type': u'DXTestDocument',
+             u'review_state': u'private',
+             u'start': None,
+             u'sync_uid': None,
+             u'title': u'Lorem Ipsum',
+             u'total_comments': 0},
+            response.json()['member'][0])
 
     # ZCTextIndex
 

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.dexterity.utils import createContentInContainer
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from plone.restapi.testing import RelativeSession
+from plone.restapi.tests.helpers import result_paths
+from Products.CMFCore.utils import getToolByName
+
+import transaction
+import unittest
+
+
+class TestSearchFunctional(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
+        self.request = self.portal.REQUEST
+        self.catalog = getToolByName(self.portal, 'portal_catalog')
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({'Accept': 'application/json'})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+        # /plone/folder
+        self.folder = createContentInContainer(
+            self.portal, u'Folder',
+            id=u'folder',
+            title=u'Some Folder')
+
+        # /plone/folder/doc
+        self.doc = createContentInContainer(
+            self.folder, u'DXTestDocument',
+            id='doc',
+            title=u'Lorem Ipsum',
+        )
+
+        # /plone/folder/other-document
+        self.doc2 = createContentInContainer(
+            self.folder, u'DXTestDocument',
+            id='other-document',
+            title=u'Other Document',
+            description=u'\xdcbersicht',
+        )
+
+        # /plone/doc-outside-folder
+        createContentInContainer(
+            self.portal, u'DXTestDocument',
+            id='doc-outside-folder',
+            title=u'Doc outside folder',
+        )
+
+        transaction.commit()
+
+    def test_overall_response_format(self):
+        response = self.api_session.get('/search')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers.get('Content-Type'),
+            'application/json',
+        )
+
+        results = response.json()
+        self.assertEqual(
+            results[u'items_count'],
+            len(results[u'member']),
+            'items_count property should match actual item count.'
+        )
+
+    def test_fulltext_search(self):
+        query = {'SearchableText': 'lorem'}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    def test_fulltext_search_with_non_ascii_characters(self):
+        query = {'SearchableText': u'\xfcbersicht'}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/other-document'],
+            result_paths(response.json())
+        )

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+from datetime import date
+from DateTime import DateTime
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.dexterity.utils import createContentInContainer
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
 from plone.restapi.tests.helpers import result_paths
+from plone.uuid.interfaces import IMutableUUID
 from Products.CMFCore.utils import getToolByName
 
 import transaction
@@ -37,6 +40,12 @@ class TestSearchFunctional(unittest.TestCase):
             self.folder, u'DXTestDocument',
             id='doc',
             title=u'Lorem Ipsum',
+            created=DateTime(1950, 1, 1, 0, 0),
+            effective=DateTime(1995, 1, 1, 0, 0),
+            expires=DateTime(1999, 1, 1, 0, 0),
+            test_int_field=42,
+            test_list_field=['Keyword1', 'Keyword2', 'Keyword3'],
+            test_bool_field=True,
         )
 
         # /plone/folder/other-document
@@ -45,6 +54,11 @@ class TestSearchFunctional(unittest.TestCase):
             id='other-document',
             title=u'Other Document',
             description=u'\xdcbersicht',
+            created=DateTime(1975, 1, 1, 0, 0),
+            effective=DateTime(2015, 1, 1, 0, 0),
+            expires=DateTime(2020, 1, 1, 0, 0),
+            test_list_field=['Keyword2', 'Keyword3'],
+            test_bool_field=False,
         )
 
         # /plone/doc-outside-folder
@@ -81,6 +95,8 @@ class TestSearchFunctional(unittest.TestCase):
              u'/plone/folder/other-document'},
             set(result_paths(response.json())))
 
+    # ZCTextIndex
+
     def test_fulltext_search(self):
         query = {'SearchableText': 'lorem'}
         response = self.api_session.get('/search', params=query)
@@ -96,5 +112,243 @@ class TestSearchFunctional(unittest.TestCase):
 
         self.assertEqual(
             [u'/plone/folder/other-document'],
+            result_paths(response.json())
+        )
+
+    # KeywordIndex
+
+    def test_keyword_index_str_query(self):
+        query = {'test_list_field': 'Keyword1'}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    def test_keyword_index_str_query_or(self):
+        query = {'test_list_field': ['Keyword2', 'Keyword3']}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc',
+             u'/plone/folder/other-document'],
+            result_paths(response.json())
+        )
+
+    def test_keyword_index_str_query_and(self):
+        query = {
+            'test_list_field.query': ['Keyword1', 'Keyword2'],
+            'test_list_field.operator': 'and',
+        }
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    def test_keyword_index_int_query(self):
+        self.doc.test_list_field = [42, 23]
+        self.doc.reindexObject()
+        transaction.commit()
+
+        query = {'test_list_field:int': 42}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    # BooleanIndex
+
+    def test_boolean_index_query(self):
+        query = {'test_bool_field': True, 'portal_type': 'DXTestDocument'}
+        response = self.api_session.get('/folder/search', params=query)
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+        query = {'test_bool_field': False, 'portal_type': 'DXTestDocument'}
+        response = self.api_session.get('/folder/search', params=query)
+        self.assertEqual(
+            [u'/plone/folder/other-document'],
+            result_paths(response.json())
+        )
+
+    # FieldIndex
+
+    def test_field_index_int_query(self):
+        query = {'test_int_field:int': 42}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    def test_field_index_int_range_query(self):
+        query = {
+            'test_int_field.query:int': [41, 43],
+            'test_int_field.range': 'min:max',
+        }
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    # ExtendedPathIndex
+
+    def test_extended_path_index_query(self):
+        query = {'path': '/'.join(self.folder.getPhysicalPath())}
+
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder',
+             u'/plone/folder/doc',
+             u'/plone/folder/other-document'],
+            result_paths(response.json())
+        )
+
+    def test_extended_path_index_depth_limiting(self):
+        lvl1 = createContentInContainer(self.portal, u'Folder', id=u'lvl1')
+        lvl2 = createContentInContainer(lvl1, u'Folder', id=u'lvl2')
+        createContentInContainer(lvl2, u'Folder', id=u'lvl3')
+        transaction.commit()
+
+        path = '/plone/lvl1'
+
+        # Depth 0 - only object identified by path
+        query = {'path.query': path, 'path.depth': 0}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/lvl1'],
+            result_paths(response.json()))
+
+        # Depth 1 - immediate children
+        query = {'path.query': path, 'path.depth': 1}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/lvl1/lvl2'],
+            result_paths(response.json()))
+
+        # No depth - object itself and all children
+        query = {'path': path}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertSetEqual(
+            {u'/plone/lvl1', u'/plone/lvl1/lvl2', u'/plone/lvl1/lvl2/lvl3'},
+            set(result_paths(response.json())))
+
+    # DateIndex
+
+    def test_date_index_query(self):
+        query = {'created': date(1950, 1, 1).isoformat()}
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    def test_date_index_ranged_query(self):
+        query = {
+            'created.query': [date(1949, 1, 1).isoformat(),
+                              date(1951, 1, 1).isoformat()],
+            'created.range': 'min:max',
+        }
+        response = self.api_session.get('/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    # DateRangeIndex
+
+    def test_date_range_index_query(self):
+        query = {'effectiveRange': date(1997, 1, 1).isoformat()}
+        response = self.api_session.get('/folder/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder',
+             u'/plone/folder/doc'],
+            result_paths(response.json())
+        )
+
+    # DateRecurringIndex
+
+    def test_date_recurring_index_query(self):
+        from datetime import datetime
+        createContentInContainer(
+            self.folder, u'Event', id=u'event',
+            title=u'Event',
+            start=datetime(2013, 1, 1, 0, 0),
+            end=datetime(2013, 1, 1, 23, 59),
+            whole_day=True,
+            recurrence='FREQ=DAILY;COUNT=10;INTERVAL=2',
+            timezone='UTC',
+        )
+        import transaction
+        transaction.commit()
+
+        # First occurrence
+        query = {'start': date(2013, 1, 1).isoformat()}
+        response = self.api_session.get('/folder/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/event'],
+            result_paths(response.json())
+        )
+
+        # No event that day
+        query = {'start': date(2013, 1, 2).isoformat()}
+        response = self.api_session.get('/folder/search', params=query)
+
+        self.assertEqual(
+            [],
+            result_paths(response.json())
+        )
+
+        # Second occurrence
+        query = {'start': date(2013, 1, 3).isoformat()}
+        response = self.api_session.get('/folder/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/event'],
+            result_paths(response.json())
+        )
+
+        # Ranged query
+        query = {
+            'start.query': [date(2013, 1, 1).isoformat(),
+                            date(2013, 1, 5).isoformat()],
+            'start.range': 'min:max',
+        }
+        response = self.api_session.get('/folder/search', params=query)
+
+        self.assertEqual(
+            [u'/plone/folder/event'],
+            result_paths(response.json())
+        )
+
+    # UUIDIndex
+
+    def test_uuid_index_query(self):
+        IMutableUUID(self.doc).set('7777a074cb4240d08c9a129e3a837777')
+        self.doc.reindexObject()
+        transaction.commit()
+
+        query = {'UID': '7777a074cb4240d08c9a129e3a837777'}
+        response = self.api_session.get('/search', params=query)
+        self.assertEqual(
+            [u'/plone/folder/doc'],
             result_paths(response.json())
         )

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -72,6 +72,15 @@ class TestSearchFunctional(unittest.TestCase):
             'items_count property should match actual item count.'
         )
 
+    def test_search_on_context_constrains_query_by_path(self):
+        response = self.api_session.get('/folder/search')
+
+        self.assertSetEqual(
+            {u'/plone/folder',
+             u'/plone/folder/doc',
+             u'/plone/folder/other-document'},
+            set(result_paths(response.json())))
+
     def test_fulltext_search(self):
         query = {'SearchableText': 'lorem'}
         response = self.api_session.get('/search', params=query)

--- a/src/plone/restapi/tests/test_search_utils.py
+++ b/src/plone/restapi/tests/test_search_utils.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.search.utils import unflatten_dotted_dict
+
+import unittest
+
+
+class TestUnflattenDottedDict(unittest.TestCase):
+
+    def test_unflattens_dotted_dict(self):
+        dct = {
+            'a.b.X': 1,
+            'a.b.Y': 2,
+            'a.foo': 3,
+            'bar': 4,
+        }
+        self.assertEqual(
+            {'a': {'b': {'X': 1,
+                         'Y': 2},
+                   'foo': 3},
+             'bar': 4},
+            unflatten_dotted_dict(dct)
+        )
+
+    def test_works_on_empty_dict(self):
+        self.assertEquals({}, unflatten_dotted_dict({}))
+
+    def test_works_with_list_values(self):
+        dct = {
+            'path.query': ['foo', 'bar'],
+            'path.depth': 2,
+        }
+        self.assertEqual(
+            {'path': {'query': ['foo', 'bar'],
+                      'depth': 2}},
+            unflatten_dotted_dict(dct)
+        )
+
+    def test_leaves_regular_keys_untouched(self):
+        dct = {'foo': 1, 'bar': 2}
+        self.assertEqual(dct, unflatten_dotted_dict(dct))

--- a/src/plone/restapi/tests/test_serializer_catalog.py
+++ b/src/plone/restapi/tests/test_serializer_catalog.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from DateTime import DateTime
+from plone.dexterity.utils import createContentInContainer
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
+from Products.CMFCore.utils import getToolByName
+from zope.component import getMultiAdapter
+
+import unittest
+
+
+class TestCatalogSerializers(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.request = self.portal.REQUEST
+        self.catalog = getToolByName(self.portal, 'portal_catalog')
+
+        # /plone/my-folder
+        self.folder = createContentInContainer(
+            self.portal, u'Folder',
+            title=u'My Folder')
+
+        # /plone/my-folder/my-document
+        self.doc = createContentInContainer(
+            self.folder, u'Document',
+            created=DateTime(2015, 12, 31, 23, 45),
+            title=u'My Document')
+
+    def test_lazy_cat_serialization_empty_resultset(self):
+        # Force an empty resultset (Products.ZCatalog.Lazy.LazyCat)
+        lazy_cat = self.catalog(path='doesnt-exist')
+        results = getMultiAdapter((lazy_cat, self.request), ISerializeToJson)()
+
+        self.assertDictEqual(
+            {'member': [], 'items_count': 0},
+            results)
+
+    def test_lazy_map_serialization(self):
+        lazy_map = self.catalog()
+        results = getMultiAdapter((lazy_map, self.request), ISerializeToJson)()
+        self.assertEqual(3, len(results['member']))
+        self.assertDictContainsSubset(
+            {'items_count': 3},
+            results)
+
+    def test_brain_summary_representation(self):
+        lazy_map = self.catalog()
+        results = getMultiAdapter((lazy_map, self.request), ISerializeToJson)()
+        self.assertIn(
+            {'@id': 'http://nohost/plone/my-folder/my-document',
+             'title': 'My Document',
+             'description': ''},
+            results['member'])

--- a/src/plone/restapi/tests/test_serializer_catalog.py
+++ b/src/plone/restapi/tests/test_serializer_catalog.py
@@ -46,9 +46,9 @@ class TestCatalogSerializers(unittest.TestCase):
     def test_lazy_map_serialization(self):
         lazy_map = self.catalog()
         results = getMultiAdapter((lazy_map, self.request), ISerializeToJson)()
-        self.assertEqual(3, len(results['member']))
+        self.assertEqual(2, len(results['member']))
         self.assertDictContainsSubset(
-            {'items_count': 3},
+            {'items_count': 2},
             results)
 
     def test_brain_summary_representation(self):

--- a/src/plone/restapi/tests/test_serializer_catalog.py
+++ b/src/plone/restapi/tests/test_serializer_catalog.py
@@ -46,9 +46,9 @@ class TestCatalogSerializers(unittest.TestCase):
     def test_lazy_map_serialization(self):
         lazy_map = self.catalog()
         results = getMultiAdapter((lazy_map, self.request), ISerializeToJson)()
-        self.assertEqual(2, len(results['member']))
+        self.assertEqual(3, len(results['member']))
         self.assertDictContainsSubset(
-            {'items_count': 2},
+            {'items_count': 3},
             results)
 
     def test_brain_summary_representation(self):

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from DateTime import DateTime
 from datetime import date
+from DateTime import DateTime
 from datetime import time
 from datetime import timedelta
 from persistent.list import PersistentList
@@ -11,9 +11,11 @@ from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from unittest2 import TestCase
 from z3c.relationfield.relation import RelationValue
 from zope.component import getUtility
+from zope.i18nmessageid import MessageFactory
 from zope.intid.interfaces import IIntIds
 
 import json
+import Missing
 
 
 class TestJsonCompatibleConverters(TestCase):
@@ -194,3 +196,11 @@ class TestJsonCompatibleConverters(TestCase):
              'title': 'Document 1',
              'description': 'Description'},
             json_compatible(RelationValue(intids.getId(doc1))))
+
+    def test_i18n_message(self):
+        _ = MessageFactory('plone.restapi.tests')
+        msg = _(u'message_id', default=u'default message')
+        self.assertEquals(u'default message', json_compatible(msg))
+
+    def test_missing_value(self):
+        self.assertEquals(None, json_compatible(Missing.Value))

--- a/versions.cfg
+++ b/versions.cfg
@@ -11,4 +11,3 @@ plone.recipe.codeanalysis = 2.0b1
 Sphinx = 1.3.1
 docutils = 0.12
 Pygments = 2.0
-six = 1.5

--- a/versions.cfg
+++ b/versions.cfg
@@ -11,4 +11,4 @@ plone.recipe.codeanalysis = 2.0b1
 Sphinx = 1.3.1
 docutils = 0.12
 Pygments = 2.0
-six = 1.4
+six = 1.5


### PR DESCRIPTION
This implements a named `GET` service `/search` that can be invoked on any context to search for Plone content.

Usage examples:

```
GET /plone/search?SearchableText=lorem
GET /plone/search?created.query=1949-01-01&created.query=1951-01-01&created.range=min%3Amax
GET /plone/folder/search?sort_on=path&metadata_fields=_all
```

- Search is **contextual** by default (constrained by path of context, unless an explicit `path` query is specified)
- Nested dictionaries can be specified via **dotted notation** (`path.query=foo&path.depth=1`) similar to ZPublisher's [record arguments](http://docs.zope.org/zope2/zdgbook/ObjectPublishing.html?highlight=record#record-arguments), but without the need for the `:record` suffix
- Optional **type information** (if required because of data type ambiguity) can be supplied in ZPublisher's [argument conversion](http://docs.zope.org/zope2/zdgbook/ObjectPublishing.html#argument-conversion) style (`numeric_index=42:int`), but should rarely be required
- Search results are represented as compact **summaries** by default, additional metadata columns that should be retrieved can be specified via the `metadata_fields` parameter

See the [documentation update](https://github.com/plone/plone.restapi/blob/lg-search/docs/source/searching.rst) included in this PR for more details on user-facing usage.