### PR TITLE
Update setuptools version to fix travis build (yet again).

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -88,7 +88,7 @@ plone.dexterity = git git://github.com/plone/plone.dexterity.git pushurl=git@git
 plone.rest = git git://github.com/plone/plone.rest.git pushurl=git@github.com:plone/plone.rest.git branch=master
 
 [versions]
-setuptools = 18.5
+setuptools = 18.6.1
 zc.buildout = 2.4.3
 zope.interface = 4.0.5
 coverage = 3.7.1


### PR DESCRIPTION
Yet another setuptools version leading to a [travis build failure](https://travis-ci.org/plone/plone.restapi/builds/93390830). See #40