### PR TITLE
No longer use plone.dexterity from source (plip-680 branch).

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -14,7 +14,6 @@ parts =
 develop = .
 sources-dir = extras
 auto-checkout =
-    plone.dexterity
     plone.rest
 
 [instance]
@@ -84,7 +83,6 @@ output = ${buildout:directory}/bin/deploy-to-heroku
 mode = 755
 
 [sources]
-plone.dexterity = git git://github.com/plone/plone.dexterity.git pushurl=git@github.com:plone/plone.dexterity.git branch=plip-680
 plone.rest = git git://github.com/plone/plone.rest.git pushurl=git@github.com:plone/plone.rest.git branch=master
 
 [versions]


### PR DESCRIPTION
The changes in https://github.com/plone/plone.dexterity/pull/34 are no longer needed.
The PR has already been closed. @tisto, @bloodbare I would suggest to also delete the branch plip-680.
