### PR TITLE
Use IContentListing adapters to produce content listings

### DIFF
--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -50,9 +50,7 @@ Register the adapter in ZCML:
 .. code:: xml
 
     <configure xmlns="http://namespaces.zope.org/zope">
-
         <adapter factory=".serializer.CustomFieldSerializer" />
-
     </configure>
 
 
@@ -67,3 +65,114 @@ adapter can be registered. The name may either be the full dottedname
 of the field
 (``plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation.exclude_from_nav``)
 or the shortname of the field (``exclude_from_nav``).
+
+
+Content listings
+================
+
+In places where content listings are returned (children of containers, members
+of collections, ...), these are produced by adapting the set of objects to be
+listed to ``IContentListing``.
+
+That content listing is then used to get ``IContentListingObject`` adapters
+for the individual objects, in order to get a uniform interface to access
+common properties used in summaries, like URL, title and description.
+
+Using the ``IContentListingObject`` interface a serializeable summary
+representation of the objects is produced, by looking for an
+``IContentListingObjectSerializer`` that can turn that
+``IContentListingObject`` into a JSON compatible, compact representation.
+
+
+Customization via browser layer
+-------------------------------
+
+If you wish to control that summary representation, for example to include
+additional metadata, you can register an ``IContentListingObjectSerializer``
+on a browser layer specific to your project:
+
+.. code:: python
+
+    from your.project import IProjectSpecificLayer
+
+    from plone.app.contentlisting.interfaces import IContentListingObject
+    from plone.restapi.interfaces import IContentListingObjectSerializer
+    from plone.restapi.serializer.listing import ContentListingObjectSerializer
+    from zope.component import adapter
+    from zope.interface import implementer
+
+
+    @implementer(IContentListingObjectSerializer)
+    @adapter(IContentListingObject, IProjectSpecificLayer)
+    class ProjectContentListingObjectSerializer(ContentListingObjectSerializer):
+
+        def __call__(self):
+            obj = self.listing_obj    # See IContentListingObject interface
+            # ...
+            result = super(ProjectContentListingObjectSerializer, self).__call__()
+            result['extra'] = '--PROJECT SPECIFC--'
+            return result
+
+Then register the adapter in ZCML:
+
+.. code:: xml
+
+    <configure xmlns="http://namespaces.zope.org/zope">
+        <adapter factory=".serializer.ProjectContentListingObjectSerializer" />
+    </configure>
+
+
+Type-specific customization
+---------------------------
+
+If you want to control the summary representation for a **specific type**,
+there's a little bit of indirection needed:
+
+You'll need to introduce an interface that inherits from
+``IContentListingObject``, and is therefore more specific. For that interface
+you then register an adapter that adapts your custom type and provides an
+``IContentListingObject`` implementation.
+
+That interface can then be used to register your type specific
+``IContentListingObjectSerializer``:
+
+.. code:: python
+
+    from your.project import ICustomType
+
+    from plone.app.contentlisting.realobject import RealContentListingObject
+    from zope.interface import implementer_only
+
+
+    class ICustomTypeContentListingObject(IContentListingObject):
+        """Type specific IContentListingObject interface.
+        """
+
+
+    @implementer_only(ICustomTypeContentListingObject)
+    @adapter(ICustomType)
+    class CustomTypeContentListingObject(RealContentListingObject):
+        """Type specific ContentListingObject implementation.
+
+        You can inherit from the default implementation for that type of object,
+        or provide your own implementation of IContentListingObject.
+        """
+
+
+    @implementer(IContentListingObjectSerializer)
+    @adapter(ICustomTypeContentListingObject, IProjectSpecificLayer)
+    class CustomTypeContentListingObjectSerializer(ContentListingObjectSerializer):
+
+        def __call__(self):
+            result = super(CustomTypeContentListingObjectSerializer, self).__call__()
+            result['extra'] = '--TYPE SPECIFIC--'
+            return result
+
+Register the adapters in ZCML:
+
+.. code:: xml
+
+    <configure xmlns="http://namespaces.zope.org/zope">
+        <adapter factory=".serializer.CustomTypeContentListingObjectSerializer" />
+        <adapter factory=".serializer.CustomTypeContentListingObject" />
+    </configure>

--- a/src/plone/restapi/interfaces.py
+++ b/src/plone/restapi/interfaces.py
@@ -56,3 +56,36 @@ class IFieldDeserializer(Interface):
     def __call__(value):
         """Convert the provided JSON value to a field value.
         """
+
+
+class IContentListingSerializer(Interface):
+    """Adapter to serialize an IContentListing into a JSON compatible
+    representation.
+
+    This is used to produce compact content listings that only contain the
+    most basic information about the listed objects.
+    """
+
+    def __init__(listing, request):
+        """Adapts an IContentListing and the request.
+        """
+
+    def __call__():
+        """Returns a JSON compatible Python list containing summarized
+        representations of the objects wrapped by the adapted IContentListing.
+        """
+
+
+class IContentListingObjectSerializer(Interface):
+    """Adapter to serialize an IContentListingObject into a compact JSON
+    compatible representation for use in content listings.
+    """
+
+    def __init__(listing_obj, request):
+        """Adapts an IContentListingObject and the request.
+        """
+
+    def __call__():
+        """Returns a summarized representation of the object wrapped by the
+        adapted IContentListingObject (as JSON compatible Python data).
+        """

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -2,9 +2,12 @@
 from Acquisition import aq_parent
 from Products.Archetypes.interfaces import IBaseFolder
 from Products.Archetypes.interfaces import IBaseObject
+from plone.app.contentlisting.interfaces import IContentListing
+from plone.restapi.interfaces import IContentListingSerializer
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.interface import Interface
 from zope.interface import implementer
@@ -54,12 +57,10 @@ class SerializeFolderToJson(SerializeToJson):
 
     def __call__(self):
         result = super(SerializeFolderToJson, self).__call__()
-        result['member'] = [
-            {
-                '@id': member.absolute_url(),
-                'title': member.Title(),
-                'description': member.Description(),
-            }
-            for member in self.context.objectValues()
-        ]
+
+        members = self.context.objectValues() or []
+        result['member'] = getMultiAdapter(
+            (IContentListing(members), self.request),
+            IContentListingSerializer)()
+
         return result

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
+from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.contenttypes.interfaces import ICollection
+from plone.restapi.interfaces import IContentListingSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.serializer.dxcontent import SerializeToJson
 from zope.component import adapter
 from zope.interface import Interface
+from zope.component import getMultiAdapter
 from zope.interface import implementer
-from zope.site.hooks import getSite
 
 
 @implementer(ISerializeToJson)
@@ -14,16 +16,19 @@ class SerializeCollectionToJson(SerializeToJson):
 
     def __call__(self):
         result = super(SerializeCollectionToJson, self).__call__()
-        portal = getSite()
-        result['member'] = [
-            {
-                '@id': '{0}/{1}'.format(
-                    portal.absolute_url(),
-                    '/'.join(member.getPhysicalPath())
-                ),
-                'title': member.title,
-                'description': member.description
-            }
-            for member in self.context.results()
-        ]
+
+        # XXX: collection.results() claims to return an IContentListing
+        # based result, but it doesn't. It returns a Batch object.
+        # -> Need to traverse to the @@contentlisting view for now for
+        # Plone 5, or fall back to accessing Batch._sequence for Plone 4.
+        try:
+            members = self.context.restrictedTraverse('@@contentlisting')()
+        except AttributeError:
+            batch = self.context.results()
+            members = batch._sequence
+
+        result['member'] = getMultiAdapter(
+            (IContentListing(members), self.request),
+            IContentListingSerializer)()
+
         return result

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -6,6 +6,8 @@
     <adapter factory=".site.SerializeSiteRootToJson" />
     <adapter factory=".dxcontent.SerializeToJson" />
     <adapter factory=".dxcontent.SerializeFolderToJson" />
+    <adapter factory=".listing.ContentListingObjectSerializer" />
+    <adapter factory=".listing.ContentListingSerializer" />
 
     <configure zcml:condition="installed plone.app.contenttypes">
         <adapter factory=".collection.SerializeCollectionToJson" />

--- a/src/plone/restapi/serializer/converters.py
+++ b/src/plone/restapi/serializer/converters.py
@@ -8,11 +8,15 @@ from datetime import time
 from datetime import timedelta
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
+from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.app.textfield.interfaces import IRichTextValue
+from plone.restapi.interfaces import IContentListingObjectSerializer
 from plone.restapi.interfaces import IJsonCompatible
 from z3c.relationfield.interfaces import IRelationValue
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
 from zope.interface import Interface
 from zope.interface import implementer
 
@@ -142,4 +146,6 @@ def richtext_converter(value):
 @implementer(IJsonCompatible)
 def relationvalue_converter(value):
     if value.to_object:
-        return json_compatible(value.to_object.absolute_url())
+        return getMultiAdapter(
+            (IContentListingObject(value.to_object), getRequest()),
+            IContentListingObjectSerializer)()

--- a/src/plone/restapi/serializer/listing.py
+++ b/src/plone/restapi/serializer/listing.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from plone.app.contentlisting.interfaces import IContentListing
+from plone.app.contentlisting.interfaces import IContentListingObject
+from plone.restapi.interfaces import IContentListingObjectSerializer
+from plone.restapi.interfaces import IContentListingSerializer
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IContentListingSerializer)
+@adapter(IContentListing, Interface)
+class ContentListingSerializer(object):
+
+    def __init__(self, listing, request):
+        self.listing = listing
+        self.request = request
+
+    def __call__(self):
+        result = []
+        for listing_obj in self.listing:
+            entry = getMultiAdapter(
+                (listing_obj, self.request),
+                IContentListingObjectSerializer)()
+            result.append(entry)
+
+        return result
+
+
+@implementer(IContentListingObjectSerializer)
+@adapter(IContentListingObject, Interface)
+class ContentListingObjectSerializer(object):
+
+    def __init__(self, listing_obj, request):
+        self.listing_obj = listing_obj
+        self.request = request
+
+    def __call__(self):
+        entry = {
+            '@id': self.listing_obj.getURL(),
+            'title': self.listing_obj.Title(),
+            'description': self.listing_obj.Description(),
+        }
+        return entry

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+from plone.app.contentlisting.interfaces import IContentListing
+from plone.restapi.interfaces import IContentListingSerializer
+from plone.restapi.interfaces import ISerializeToJson
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFPlone.interfaces import IPloneSiteRoot
-from plone.restapi.interfaces import ISerializeToJson
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.interface import Interface
 from zope.interface import implementer
 
@@ -22,13 +25,12 @@ class SerializeSiteRootToJson(object):
             '@type': 'Plone Site',
             'parent': {},
         }
-        result['member'] = [
-            {
-                '@id': member.absolute_url(),
-                'title': member.title,
-                'description': member.description
-            }
-            for member in self.context.objectValues()
-            if IContentish.providedBy(member)
-        ]
+
+        members = [obj for obj in self.context.objectValues()
+                   if IContentish.providedBy(obj)]
+
+        result['member'] = getMultiAdapter(
+            (IContentListing(members), self.request),
+            IContentListingSerializer)()
+
         return result

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -88,8 +88,9 @@ class TestTraversal(unittest.TestCase):
             'text/html'
         )
         self.document.creation_date = DateTime('2016-01-21T01:14:48+00:00')
-        self.document.modification_date = DateTime('2016-01-21T01:24:11+00:00')
         IMutableUUID(self.document).set('1f699ffa110e45afb1ba502f75f7ec33')
+        self.document.reindexObject()
+        self.document.modification_date = DateTime('2016-01-21T01:24:11+00:00')
         import transaction
         transaction.commit()
         self.browser = Browser(self.app)

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -212,21 +212,43 @@ class TestDexterityFieldSerializing(TestCase):
             u'thumb': u'{}/@@images/image/thumb'.format(obj_url),
             u'tile': u'{}/@@images/image/tile'.format(obj_url)}, value)
 
-    def test_relationchoice_field_serialization_returns_unicode(self):
+    def test_relationchoice_field_serialization_returns_summary_dict(self):
         doc2 = self.portal[self.portal.invokeFactory(
-            'DXTestDocument', id='doc2', title='Referenceable Document')]
+            'DXTestDocument', id='doc2',
+            title='Referenceable Document',
+            description='Description 2',
+        )]
         value = self.serialize('test_relationchoice_field', doc2)
-        self.assertTrue(isinstance(value, unicode), 'Not an <unicode>')
-        self.assertEqual(doc2.absolute_url(), value)
+        self.assertEqual(
+            {'@id': 'http://nohost/plone/doc2',
+             'title': 'Referenceable Document',
+             'description': 'Description 2',
+             },
+            value)
 
     def test_relationlist_field_serialization_returns_list(self):
         doc2 = self.portal[self.portal.invokeFactory(
-            'DXTestDocument', id='doc2', title='Referenceable Document')]
+            'DXTestDocument', id='doc2',
+            title='Referenceable Document',
+            description='Description 2',
+        )]
         doc3 = self.portal[self.portal.invokeFactory(
-            'DXTestDocument', id='doc3', title='Referenceable Document')]
+            'DXTestDocument', id='doc3',
+            title='Referenceable Document',
+            description='Description 3'
+        )]
         value = self.serialize('test_relationlist_field', [doc2, doc3])
         self.assertTrue(isinstance(value, list), 'Not a <list>')
-        self.assertEqual([doc2.absolute_url(), doc3.absolute_url()], value)
+        self.assertEqual([
+            {'@id': 'http://nohost/plone/doc2',
+             'title': 'Referenceable Document',
+             'description': 'Description 2',
+             },
+            {'@id': 'http://nohost/plone/doc3',
+             'title': 'Referenceable Document',
+             'description': 'Description 3',
+             }],
+            value)
 
 
 class TestDexterityFieldSerializers(TestCase):

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -183,7 +183,14 @@ class TestJsonCompatibleConverters(TestCase):
 
     def test_relation_value(self):
         portal = self.layer['portal']
-        doc1 = portal[portal.invokeFactory('DXTestDocument', id='doc1')]
+        doc1 = portal[portal.invokeFactory(
+            'DXTestDocument', id='doc1',
+            title='Document 1',
+            description='Description',
+        )]
         intids = getUtility(IIntIds)
-        self.assertEquals(doc1.absolute_url(),
-                          json_compatible(RelationValue(intids.getId(doc1))))
+        self.assertEquals(
+            {'@id': 'http://nohost/plone/doc1',
+             'title': 'Document 1',
+             'description': 'Description'},
+            json_compatible(RelationValue(intids.getId(doc1))))

--- a/src/plone/restapi/tests/test_serializer_listing.py
+++ b/src/plone/restapi/tests/test_serializer_listing.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from plone.app.contentlisting.interfaces import IContentListing
+from plone.app.contentlisting.interfaces import IContentListingObject
+from plone.dexterity.utils import createContentInContainer
+from plone.restapi.interfaces import IContentListingObjectSerializer
+from plone.restapi.interfaces import IContentListingSerializer
+from plone.restapi.serializer.listing import ContentListingObjectSerializer
+from plone.restapi.serializer.listing import ContentListingSerializer
+from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
+from unittest2 import TestCase
+from zope.component import getMultiAdapter
+from zope.interface.verify import verifyClass
+
+
+class TestContentListingSerialization(TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.portal.REQUEST
+
+        self.folder = createContentInContainer(
+            self.portal, u'Folder',
+            title=u'Folder',
+        )
+
+        self.doc1 = createContentInContainer(
+            self.folder, u'Document',
+            title=u'Document 1',
+            description=u'Foo',
+        )
+
+        self.doc2 = createContentInContainer(
+            self.folder, u'Document',
+            title=u'Document 2',
+            description=u'Bar',
+        )
+
+    def test_content_listing_serialization(self):
+        listing = getMultiAdapter(
+            (IContentListing(self.folder.objectValues()), self.request),
+            IContentListingSerializer)()
+
+        self.assertEquals([
+            {'@id': 'http://nohost/plone/folder/document-1',
+             'title': 'Document 1',
+             'description': 'Foo'},
+            {'@id': 'http://nohost/plone/folder/document-2',
+             'title': 'Document 2',
+             'description': 'Bar'}],
+            listing)
+
+    def test_content_listing_object_serialization(self):
+        entry = getMultiAdapter(
+            (IContentListingObject(self.doc1), self.request),
+            IContentListingObjectSerializer)()
+
+        self.assertEquals(
+            {'@id': 'http://nohost/plone/folder/document-1',
+             'title': 'Document 1',
+             'description': 'Foo'},
+            entry)
+
+    def test_content_listing_serializer_implements_iface(self):
+        verifyClass(
+            IContentListingSerializer, ContentListingSerializer)
+
+    def test_content_listing_object_serializer_implements_iface(self):
+        verifyClass(
+            IContentListingObjectSerializer, ContentListingObjectSerializer)


### PR DESCRIPTION
This change unifies the generation of content listings by introducing adapters for the [`IContentListing`](https://github.com/plone/plone.app.contentlisting/blob/06cc9124362aaccb9f63edef7b5069053da1983c/plone/app/contentlisting/interfaces.py#L6-L7) and [`IContentListingObject`](https://github.com/plone/plone.app.contentlisting/blob/06cc9124362aaccb9f63edef7b5069053da1983c/plone/app/contentlisting/interfaces.py#L10-L88) interfaces provided by [`plone.app.contentlisting`](https://github.com/plone/plone.app.contentlisting/#listing-and-working-with-plone-content-objects-using-ploneappcontentlisting).

Using adapters makes the listings themselves and the particularly the summarized representations of objects **customizable**, and avoids code duplication.

This concerns the listings for:

- Children of the site root
- Children of Dexterity containers
- Children of Archetypes containers
- Collection members
- Relations

For everything except Relations the actual representation didn't change - it's just the implementation that has been unified.

In addition to that, I also made the serialization of `RelationValues` use the `IContentListing` adapters, so their serialization now includes title and description as well, and follows the same structure as other content listings.

---

One thing I should point out is that the `RealContentListingObject` implementation in `p.a.contentlisting` [proxies attribute access to the acquisition **unwrapped** object](https://github.com/plone/plone.app.contentlisting/blob/06cc9124362aaccb9f63edef7b5069053da1983c/plone/app/contentlisting/realobject.py#L37). That's fine for attributes, but because the `Title()` and `Description()` accessors aren't implemented on `RealContentListingObject` or its superclass, they will be proxied and therefore won't have an acquisition context (no access to parent object, ...).

This is [different for `getURL()` and `getPath()`](https://github.com/plone/plone.app.contentlisting/blob/06cc9124362aaccb9f63edef7b5069053da1983c/plone/app/contentlisting/realobject.py#L53-L57), which obviously wouldn't work otherwise, and therefore delegate to the respective methods on the acquisition wrapped object.

If this is a concern, we could simply do the same for `Title()` and `Description()`.