### PR TITLE
Make summary representations customizable

### DIFF
--- a/src/plone/restapi/interfaces.py
+++ b/src/plone/restapi/interfaces.py
@@ -22,6 +22,12 @@ class ISerializeToJson(Interface):
     """
 
 
+class ISerializeToJsonSummary(Interface):
+    """Adapter to serialize an object into a JSON compatible summary that
+    contains only the most basic information.
+    """
+
+
 class IJsonCompatible(Interface):
     """Convert a value to a JSON compatible data structure.
     """

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_inner
 from Acquisition import aq_parent
 from Products.Archetypes.interfaces import IBaseFolder
 from Products.Archetypes.interfaces import IBaseObject
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.interface import Interface
 from zope.interface import implementer
@@ -19,15 +22,14 @@ class SerializeToJson(object):
         self.request = request
 
     def __call__(self):
+        parent = aq_parent(aq_inner(self.context))
+        parent_summary = getMultiAdapter(
+            (parent, self.request), ISerializeToJsonSummary)()
         result = {
             '@context': 'http://www.w3.org/ns/hydra/context.jsonld',
             '@id': self.context.absolute_url(),
             '@type': self.context.portal_type,
-            'parent': {
-                '@id': aq_parent(self.context).absolute_url(),
-                'title': aq_parent(self.context).Title(),
-                'description': aq_parent(self.context).Description()
-            },
+            'parent': parent_summary,
             'UID': self.context.UID(),
         }
 
@@ -55,11 +57,7 @@ class SerializeFolderToJson(SerializeToJson):
     def __call__(self):
         result = super(SerializeFolderToJson, self).__call__()
         result['member'] = [
-            {
-                '@id': member.absolute_url(),
-                'title': member.Title(),
-                'description': member.Description(),
-            }
+            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
             for member in self.context.objectValues()
         ]
         return result

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.interfaces import ICollection
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.dxcontent import SerializeToJson
 from zope.component import adapter
 from zope.interface import Interface
+from zope.component import getMultiAdapter
 from zope.interface import implementer
-from zope.site.hooks import getSite
 
 
 @implementer(ISerializeToJson)
@@ -14,16 +15,8 @@ class SerializeCollectionToJson(SerializeToJson):
 
     def __call__(self):
         result = super(SerializeCollectionToJson, self).__call__()
-        portal = getSite()
         result['member'] = [
-            {
-                '@id': '{0}/{1}'.format(
-                    portal.absolute_url(),
-                    '/'.join(member.getPhysicalPath())
-                ),
-                'title': member.title,
-                'description': member.description
-            }
+            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
             for member in self.context.results()
         ]
         return result

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -11,6 +11,9 @@
         <adapter factory=".collection.SerializeCollectionToJson" />
     </configure>
 
+    <adapter factory=".summary.DefaultJSONSummarySerializer" />
+    <adapter factory=".summary.SiteRootJSONSummarySerializer" />
+
     <adapter factory=".dxfields.DefaultFieldSerializer" />
     <adapter factory=".dxfields.FileFieldSerializer" />
     <adapter factory=".dxfields.ImageFieldSerializer" />

--- a/src/plone/restapi/serializer/converters.py
+++ b/src/plone/restapi/serializer/converters.py
@@ -10,10 +10,13 @@ from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
 from plone.app.textfield.interfaces import IRichTextValue
 from plone.restapi.interfaces import IJsonCompatible
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from z3c.relationfield.interfaces import IRelationValue
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
 from zope.interface import Interface
+from zope.globalrequest import getRequest
 from zope.interface import implementer
 
 
@@ -142,4 +145,6 @@ def richtext_converter(value):
 @implementer(IJsonCompatible)
 def relationvalue_converter(value):
     if value.to_object:
-        return json_compatible(value.to_object.absolute_url())
+        summary = getMultiAdapter(
+            (value.to_object, getRequest()), ISerializeToJsonSummary)()
+        return json_compatible(summary)

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -8,9 +8,11 @@ from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import iterSchemata
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from plone.supermodel.utils import mergedTaggedValueDict
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
 from zope.interface import Interface
@@ -30,15 +32,14 @@ class SerializeToJson(object):
         self.permission_cache = {}
 
     def __call__(self):
+        parent = aq_parent(aq_inner(self.context))
+        parent_summary = getMultiAdapter(
+            (parent, self.request), ISerializeToJsonSummary)()
         result = {
             '@context': 'http://www.w3.org/ns/hydra/context.jsonld',
             '@id': self.context.absolute_url(),
             '@type': self.context.portal_type,
-            'parent': {
-                '@id': aq_parent(aq_inner(self.context)).absolute_url(),
-                'title': aq_parent(aq_inner(self.context)).title,
-                'description': aq_parent(aq_inner(self.context)).description
-            },
+            'parent': parent_summary,
             'created': json_compatible(self.context.created()),
             'modified': json_compatible(self.context.modified()),
             'UID': self.context.UID(),
@@ -85,11 +86,7 @@ class SerializeFolderToJson(SerializeToJson):
     def __call__(self):
         result = super(SerializeFolderToJson, self).__call__()
         result['member'] = [
-            {
-                '@id': member.absolute_url(),
-                'title': member.title,
-                'description': member.description
-            }
+            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
             for member in self.context.objectValues()
         ]
         return result

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -2,7 +2,9 @@
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.interface import Interface
 from zope.interface import implementer
 
@@ -23,11 +25,7 @@ class SerializeSiteRootToJson(object):
             'parent': {},
         }
         result['member'] = [
-            {
-                '@id': member.absolute_url(),
-                'title': member.title,
-                'description': member.description
-            }
+            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
             for member in self.context.objectValues()
             if IContentish.providedBy(member)
         ]

--- a/src/plone/restapi/serializer/summary.py
+++ b/src/plone/restapi/serializer/summary.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from plone.app.contentlisting.interfaces import IContentListingObject
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJsonSummary)
+@adapter(Interface, Interface)
+class DefaultJSONSummarySerializer(object):
+    """Default ISerializeToJsonSummary adapter.
+
+    Requires context to be adaptable to IContentListingObject, which is
+    the case for all content objects providing IContentish.
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self):
+        obj = IContentListingObject(self.context)
+        summary = {
+            '@id': obj.getURL(),
+            'title': obj.Title(),
+            'description': obj.Description()
+        }
+        return summary
+
+
+@implementer(ISerializeToJsonSummary)
+@adapter(IPloneSiteRoot, Interface)
+class SiteRootJSONSummarySerializer(object):
+    """ISerializeToJsonSummary adapter for the Plone Site root.
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self):
+        summary = {
+            '@id': self.context.absolute_url(),
+            'title': self.context.title,
+            'description': self.context.description
+        }
+        return summary

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -88,8 +88,9 @@ class TestTraversal(unittest.TestCase):
             'text/html'
         )
         self.document.creation_date = DateTime('2016-01-21T01:14:48+00:00')
-        self.document.modification_date = DateTime('2016-01-21T01:24:11+00:00')
         IMutableUUID(self.document).set('1f699ffa110e45afb1ba502f75f7ec33')
+        self.document.reindexObject()
+        self.document.modification_date = DateTime('2016-01-21T01:24:11+00:00')
         import transaction
         transaction.commit()
         self.browser = Browser(self.app)

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -212,21 +212,43 @@ class TestDexterityFieldSerializing(TestCase):
             u'thumb': u'{}/@@images/image/thumb'.format(obj_url),
             u'tile': u'{}/@@images/image/tile'.format(obj_url)}, value)
 
-    def test_relationchoice_field_serialization_returns_unicode(self):
+    def test_relationchoice_field_serialization_returns_summary_dict(self):
         doc2 = self.portal[self.portal.invokeFactory(
-            'DXTestDocument', id='doc2', title='Referenceable Document')]
+            'DXTestDocument', id='doc2',
+            title='Referenceable Document',
+            description='Description 2',
+        )]
         value = self.serialize('test_relationchoice_field', doc2)
-        self.assertTrue(isinstance(value, unicode), 'Not an <unicode>')
-        self.assertEqual(doc2.absolute_url(), value)
+        self.assertEqual(
+            {'@id': 'http://nohost/plone/doc2',
+             'title': 'Referenceable Document',
+             'description': 'Description 2',
+             },
+            value)
 
     def test_relationlist_field_serialization_returns_list(self):
         doc2 = self.portal[self.portal.invokeFactory(
-            'DXTestDocument', id='doc2', title='Referenceable Document')]
+            'DXTestDocument', id='doc2',
+            title='Referenceable Document',
+            description='Description 2',
+        )]
         doc3 = self.portal[self.portal.invokeFactory(
-            'DXTestDocument', id='doc3', title='Referenceable Document')]
+            'DXTestDocument', id='doc3',
+            title='Referenceable Document',
+            description='Description 3',
+        )]
         value = self.serialize('test_relationlist_field', [doc2, doc3])
         self.assertTrue(isinstance(value, list), 'Not a <list>')
-        self.assertEqual([doc2.absolute_url(), doc3.absolute_url()], value)
+        self.assertEqual([
+            {'@id': 'http://nohost/plone/doc2',
+             'title': 'Referenceable Document',
+             'description': 'Description 2',
+             },
+            {'@id': 'http://nohost/plone/doc3',
+             'title': 'Referenceable Document',
+             'description': 'Description 3',
+             }],
+            value)
 
 
 class TestDexterityFieldSerializers(TestCase):

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -183,7 +183,14 @@ class TestJsonCompatibleConverters(TestCase):
 
     def test_relation_value(self):
         portal = self.layer['portal']
-        doc1 = portal[portal.invokeFactory('DXTestDocument', id='doc1')]
+        doc1 = portal[portal.invokeFactory(
+            'DXTestDocument', id='doc1',
+            title='Document 1',
+            description='Description',
+        )]
         intids = getUtility(IIntIds)
-        self.assertEquals(doc1.absolute_url(),
-                          json_compatible(RelationValue(intids.getId(doc1))))
+        self.assertEquals(
+            {'@id': 'http://nohost/plone/doc1',
+             'title': 'Document 1',
+             'description': 'Description'},
+            json_compatible(RelationValue(intids.getId(doc1))))


### PR DESCRIPTION
This **unifies** the implementation for producing **summary representations** of objects, and makes it **customizable** by introducing an `ISerializeToJsonSummary` adapter (adapts `context` and `request`).

In addition to unifying the implementation (which doesn't change the behavior, pure refactoring), I also used the summary representation for serializing relation values - this means their representation now also includes `title` and `description` instead of just the URL.

The `ISerializeToJsonSummary` adapter is used to create representations in the following places:

- Children of the Plone site root
- Children of folderish AT objects
- Children of folderish DX objects
- Parent of AT objects
- Parent of DX objects
- Members of collections
- Relation values

Once search is implemented, this will also be used for catalog brains.

Supersedes #68