### PR TITLE
Add portal_type to summary representations

### DIFF
--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -27,16 +27,19 @@ content-type: application/json
   "member": [
     {
       "@id": "http://localhost:55001/plone/front-page", 
+      "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
       "title": "Welcome to Plone"
     }, 
     {
       "@id": "http://localhost:55001/plone/doc1", 
+      "@type": "Document", 
       "description": "", 
       "title": "Document 1"
     }, 
     {
       "@id": "http://localhost:55001/plone/doc2", 
+      "@type": "Document", 
       "description": "", 
       "title": "Document 2"
     }
@@ -44,6 +47,7 @@ content-type: application/json
   "modified": "2016-01-21T08:24:11+00:00", 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/document.json
+++ b/docs/source/_json/document.json
@@ -25,6 +25,7 @@ content-type: application/json
   "modified": "2016-01-21T01:24:11+00:00", 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/event.json
+++ b/docs/source/_json/event.json
@@ -33,6 +33,7 @@ content-type: application/json
   "open_end": null, 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/file.json
+++ b/docs/source/_json/file.json
@@ -25,6 +25,7 @@ content-type: application/json
   "modified": "2016-01-21T05:24:11+00:00", 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -24,11 +24,13 @@ content-type: application/json
   "member": [
     {
       "@id": "http://localhost:55001/plone/folder/doc1", 
+      "@type": "Document", 
       "description": "", 
       "title": "A document within a folder"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc2", 
+      "@type": "Document", 
       "description": "", 
       "title": "A document within a folder"
     }
@@ -37,6 +39,7 @@ content-type: application/json
   "nextPreviousEnabled": false, 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/image.json
+++ b/docs/source/_json/image.json
@@ -34,6 +34,7 @@ content-type: application/json
   "modified": "2016-01-21T06:24:11+00:00", 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/link.json
+++ b/docs/source/_json/link.json
@@ -25,6 +25,7 @@ content-type: application/json
   "modified": "2016-01-21T04:24:11+00:00", 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/newsitem.json
+++ b/docs/source/_json/newsitem.json
@@ -36,6 +36,7 @@ content-type: application/json
   "modified": "2016-01-21T02:24:11+00:00", 
   "parent": {
     "@id": "http://localhost:55001/plone", 
+    "@type": "Plone Site", 
     "description": "", 
     "title": "Plone site"
   }, 

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -9,6 +9,7 @@ content-type: application/json
   "member": [
     {
       "@id": "http://localhost:55001/plone/front-page", 
+      "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
       "title": "Welcome to Plone"
     }

--- a/docs/source/_json/siteroot.json
+++ b/docs/source/_json/siteroot.json
@@ -11,6 +11,7 @@ content-type: application/json
   "member": [
     {
       "@id": "http://localhost:55001/plone/front-page", 
+      "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
       "title": "Welcome to Plone"
     }

--- a/src/plone/restapi/serializer/summary.py
+++ b/src/plone/restapi/serializer/summary.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer.converters import json_compatible
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import adapter
 from zope.interface import implementer
@@ -22,12 +23,12 @@ class DefaultJSONSummarySerializer(object):
 
     def __call__(self):
         obj = IContentListingObject(self.context)
-        summary = {
+        summary = json_compatible({
             '@id': obj.getURL(),
             '@type': obj.PortalType(),
             'title': obj.Title(),
             'description': obj.Description()
-        }
+        })
         return summary
 
 
@@ -42,10 +43,10 @@ class SiteRootJSONSummarySerializer(object):
         self.request = request
 
     def __call__(self):
-        summary = {
+        summary = json_compatible({
             '@id': self.context.absolute_url(),
             '@type': self.context.portal_type,
             'title': self.context.title,
             'description': self.context.description
-        }
+        })
         return summary

--- a/src/plone/restapi/serializer/summary.py
+++ b/src/plone/restapi/serializer/summary.py
@@ -24,6 +24,7 @@ class DefaultJSONSummarySerializer(object):
         obj = IContentListingObject(self.context)
         summary = {
             '@id': obj.getURL(),
+            '@type': obj.PortalType(),
             'title': obj.Title(),
             'description': obj.Description()
         }
@@ -43,6 +44,7 @@ class SiteRootJSONSummarySerializer(object):
     def __call__(self):
         summary = {
             '@id': self.context.absolute_url(),
+            '@type': self.context.portal_type,
             'title': self.context.title,
             'description': self.context.description
         }

--- a/src/plone/restapi/tests/test_atcontent_serializer.py
+++ b/src/plone/restapi/tests/test_atcontent_serializer.py
@@ -89,11 +89,13 @@ class TestATContentSerializer(unittest.TestCase):
         self.assertIn('member', obj)
         self.assertDictEqual({
             '@id': 'http://nohost/plone/folder/subfolder',
+            '@type': 'ATTestFolder',
             'description': '',
             'title': u'Subfolder'},
             obj['member'][0])
         self.assertDictEqual({
             '@id': 'http://nohost/plone/folder/doc',
+            '@type': 'ATTestDocument',
             'description': '',
             'title': u'A Document'},
             obj['member'][1])

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -221,6 +221,7 @@ class TestDexterityFieldSerializing(TestCase):
         value = self.serialize('test_relationchoice_field', doc2)
         self.assertEqual(
             {'@id': 'http://nohost/plone/doc2',
+             '@type': 'DXTestDocument',
              'title': 'Referenceable Document',
              'description': 'Description 2',
              },
@@ -241,10 +242,12 @@ class TestDexterityFieldSerializing(TestCase):
         self.assertTrue(isinstance(value, list), 'Not a <list>')
         self.assertEqual([
             {'@id': 'http://nohost/plone/doc2',
+             '@type': 'DXTestDocument',
              'title': 'Referenceable Document',
              'description': 'Description 2',
              },
             {'@id': 'http://nohost/plone/doc3',
+             '@type': 'DXTestDocument',
              'title': 'Referenceable Document',
              'description': 'Description 3',
              }],

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -125,6 +125,7 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
             [
                 {
                     u'@id': u'http://nohost/plone/folder1/doc1',
+                    u'@type': u'Document',
                     u'description': u'This is a document',
                     u'title': u'Document 1'
                 }
@@ -139,6 +140,7 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
         self.assertEqual(
             {
                 '@id': self.portal.absolute_url(),
+                '@type': self.portal.portal_type,
                 'title': self.portal.title,
                 'description': self.portal.description
             },
@@ -154,6 +156,7 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
         self.assertEqual(
             {
                 '@id': self.portal.absolute_url(),
+                '@type': self.portal.portal_type,
                 'title': self.portal.title,
                 'description': self.portal.description
             },
@@ -237,11 +240,13 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
             [
                 {
                     u'@id': self.portal.doc1.absolute_url(),
+                    u'@type': u'Document',
                     u'description': u'',
                     u'title': u'Document 1'
                 },
                 {
                     u'@id': self.portal.doc2.absolute_url(),
+                    u'@type': u'Document',
                     u'description': u'',
                     u'title': u'Document 2'
                 }

--- a/src/plone/restapi/tests/test_serializer_catalog.py
+++ b/src/plone/restapi/tests/test_serializer_catalog.py
@@ -56,6 +56,7 @@ class TestCatalogSerializers(unittest.TestCase):
         results = getMultiAdapter((lazy_map, self.request), ISerializeToJson)()
         self.assertIn(
             {'@id': 'http://nohost/plone/my-folder/my-document',
+             '@type': 'Document',
              'title': 'My Document',
              'description': ''},
             results['member'])
@@ -68,6 +69,7 @@ class TestCatalogSerializers(unittest.TestCase):
 
         self.assertDictEqual(
             {'@id': 'http://nohost/plone/my-folder/my-document',
+             '@type': 'Document',
              'title': 'My Document',
              'description': '',
              'portal_type': u'Document',

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -193,6 +193,7 @@ class TestJsonCompatibleConverters(TestCase):
         intids = getUtility(IIntIds)
         self.assertEquals(
             {'@id': 'http://nohost/plone/doc1',
+             '@type': 'DXTestDocument',
              'title': 'Document 1',
              'description': 'Description'},
             json_compatible(RelationValue(intids.getId(doc1))))

--- a/src/plone/restapi/tests/test_serializer_summary.py
+++ b/src/plone/restapi/tests/test_serializer_summary.py
@@ -9,6 +9,7 @@ from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
 
+import Missing
 import unittest
 
 
@@ -62,6 +63,20 @@ class TestSummarySerializers(unittest.TestCase):
              '@type': 'DXTestDocument',
              'title': 'Lorem Ipsum',
              'description': 'Description'},
+            summary)
+
+    def test_brain_summary_with_missing_value(self):
+        brain = self.catalog(UID=self.doc1.UID())[0]
+        brain.Description = Missing.Value
+
+        summary = getMultiAdapter(
+            (brain, self.request), ISerializeToJsonSummary)()
+
+        self.assertDictEqual(
+            {'@id': 'http://nohost/plone/doc1',
+             '@type': 'DXTestDocument',
+             'title': 'Lorem Ipsum',
+             'description': None},
             summary)
 
     def test_dx_type_summary(self):

--- a/src/plone/restapi/tests/test_serializer_summary.py
+++ b/src/plone/restapi/tests/test_serializer_summary.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+from plone.app.contentlisting.interfaces import IContentListingObject
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.utils import createContentInContainer
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.testing import PLONE_RESTAPI_AT_INTEGRATION_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
+from Products.CMFCore.utils import getToolByName
+from zope.component import getMultiAdapter
+
+import unittest
+
+
+class TestSummarySerializers(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.catalog = getToolByName(self.portal, 'portal_catalog')
+
+        self.doc1 = createContentInContainer(
+            self.portal, u'DXTestDocument',
+            id=u'doc1',
+            title=u'Lorem Ipsum',
+            description=u'Description')
+
+    def test_site_root_summary(self):
+        summary = getMultiAdapter(
+            (self.portal, self.request), ISerializeToJsonSummary)()
+
+        self.assertDictEqual(
+            {'@id': 'http://nohost/plone',
+             '@type': 'Plone Site',
+             'title': 'Plone site',
+             'description': ''},
+            summary)
+
+    def test_brain_summary(self):
+        brain = self.catalog(UID=self.doc1.UID())[0]
+        summary = getMultiAdapter(
+            (brain, self.request), ISerializeToJsonSummary)()
+
+        self.assertDictEqual(
+            {'@id': 'http://nohost/plone/doc1',
+             '@type': 'DXTestDocument',
+             'title': 'Lorem Ipsum',
+             'description': 'Description'},
+            summary)
+
+        # Must also work if we're dealing with a CatalogContentListingObject
+        # (because the brain has already been adapted to IContentListingObject,
+        # as is the case for collection results)
+        listing_obj = IContentListingObject(brain)
+        summary = getMultiAdapter(
+            (listing_obj, self.request), ISerializeToJsonSummary)()
+
+        self.assertDictEqual(
+            {'@id': 'http://nohost/plone/doc1',
+             '@type': 'DXTestDocument',
+             'title': 'Lorem Ipsum',
+             'description': 'Description'},
+            summary)
+
+    def test_dx_type_summary(self):
+        summary = getMultiAdapter(
+            (self.doc1, self.request), ISerializeToJsonSummary)()
+
+        self.assertDictEqual(
+            {'@id': 'http://nohost/plone/doc1',
+             '@type': 'DXTestDocument',
+             'title': 'Lorem Ipsum',
+             'description': 'Description'},
+            summary)
+
+
+class TestSummarySerializersATTypes(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_AT_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+
+        self.doc1 = self.portal[self.portal.invokeFactory(
+            'ATTestDocument',
+            id='doc1',
+            title='Lorem Ipsum',
+            description='Description')]
+
+    def test_at_type_summary(self):
+        summary = getMultiAdapter(
+            (self.doc1, self.request), ISerializeToJsonSummary)()
+
+        self.assertDictEqual(
+            {'@id': 'http://nohost/plone/doc1',
+             '@type': 'ATTestDocument',
+             'title': 'Lorem Ipsum',
+             'description': 'Description'},
+            summary)


### PR DESCRIPTION
This adds the object's `portal_type` to its summary representation, as discussed in #76.

Also includes:
- some more specific tests for summary serializers that cover all the types of objects we're currently producing summaries of
- a small bugfix: Making sure we always return JSON compatible data from summary serializers

```json
    {
      "@id": "http://localhost:55001/plone/front-page",
      "description": "Congratulations! You have successfully installed Plone.",
      "title": "Welcome to Plone"
    }
```
=>
```json
    {
      "@id": "http://localhost:55001/plone/front-page",
      "@type": "Document",
      "description": "Congratulations! You have successfully installed Plone.",
      "title": "Welcome to Plone"
    }
```

Closes #76