### PR TITLE
Implement Batching

### DIFF
--- a/docs/source/_json/batching.json
+++ b/docs/source/_json/batching.json
@@ -5,7 +5,7 @@ HTTP 200 OK
 content-type: application/json
 
 {
-  "@id": "http://localhost:55001/plone/folder/@search?sort_on=path", 
+  "@id": "http://localhost:55001/plone/folder/@search", 
   "batching": {
     "@id": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path", 
     "first": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path&b_start=0", 

--- a/docs/source/_json/batching.json
+++ b/docs/source/_json/batching.json
@@ -1,0 +1,48 @@
+GET /plone/folder/@search?b_size=5&sort_on=path
+Accept: application/json
+
+HTTP 200 OK
+content-type: application/json
+
+{
+  "@id": "http://localhost:55001/plone/folder/@search?sort_on=path", 
+  "batching": {
+    "@id": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path", 
+    "first": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path&b_start=0", 
+    "last": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path&b_start=5", 
+    "next": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path&b_start=5"
+  }, 
+  "items": [
+    {
+      "@id": "http://localhost:55001/plone/folder", 
+      "@type": "Folder", 
+      "description": "", 
+      "title": "Folder"
+    }, 
+    {
+      "@id": "http://localhost:55001/plone/folder/doc-1", 
+      "@type": "Document", 
+      "description": "", 
+      "title": "Document 1"
+    }, 
+    {
+      "@id": "http://localhost:55001/plone/folder/doc-2", 
+      "@type": "Document", 
+      "description": "", 
+      "title": "Document 2"
+    }, 
+    {
+      "@id": "http://localhost:55001/plone/folder/doc-3", 
+      "@type": "Document", 
+      "description": "", 
+      "title": "Document 3"
+    }, 
+    {
+      "@id": "http://localhost:55001/plone/folder/doc-4", 
+      "@type": "Document", 
+      "description": "", 
+      "title": "Document 4"
+    }
+  ], 
+  "items_total": 8
+}

--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -9,11 +9,6 @@ content-type: application/json
   "@type": "Collection", 
   "UID": "d0c89bc77f874ce1aad5720921d875c0", 
   "allow_discussion": null, 
-  "batching": {
-    "@id": "http://localhost:55001/plone/collection", 
-    "first": "http://localhost:55001/plone/collection?b_start=0", 
-    "last": "http://localhost:55001/plone/collection?b_start=0"
-  }, 
   "contributors": [], 
   "created": "2016-01-21T08:14:48+00:00", 
   "creators": [

--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -9,6 +9,11 @@ content-type: application/json
   "@type": "Collection", 
   "UID": "d0c89bc77f874ce1aad5720921d875c0", 
   "allow_discussion": null, 
+  "batching": {
+    "@id": "http://localhost:55001/plone/collection", 
+    "first": "http://localhost:55001/plone/collection?b_start=0", 
+    "last": "http://localhost:55001/plone/collection?b_start=0"
+  }, 
   "contributors": [], 
   "created": "2016-01-21T08:14:48+00:00", 
   "creators": [
@@ -41,6 +46,7 @@ content-type: application/json
       "title": "Document 2"
     }
   ], 
+  "items_total": 3, 
   "language": "", 
   "limit": 1000, 
   "modified": "2016-01-21T08:24:11+00:00", 

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -9,6 +9,11 @@ content-type: application/json
   "@type": "Folder", 
   "UID": "fc7881c46d61452db4177bc059d9dcb5", 
   "allow_discussion": null, 
+  "batching": {
+    "@id": "http://localhost:55001/plone/folder", 
+    "first": "http://localhost:55001/plone/folder?b_start=0", 
+    "last": "http://localhost:55001/plone/folder?b_start=0"
+  }, 
   "contributors": [], 
   "created": "2016-01-21T07:14:48+00:00", 
   "creators": [
@@ -33,6 +38,7 @@ content-type: application/json
       "title": "A document within a folder"
     }
   ], 
+  "items_total": 2, 
   "language": "", 
   "modified": "2016-01-21T07:24:11+00:00", 
   "nextPreviousEnabled": false, 

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -9,11 +9,6 @@ content-type: application/json
   "@type": "Folder", 
   "UID": "fc7881c46d61452db4177bc059d9dcb5", 
   "allow_discussion": null, 
-  "batching": {
-    "@id": "http://localhost:55001/plone/folder", 
-    "first": "http://localhost:55001/plone/folder?b_start=0", 
-    "last": "http://localhost:55001/plone/folder?b_start=0"
-  }, 
   "contributors": [], 
   "created": "2016-01-21T07:14:48+00:00", 
   "creators": [

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -6,11 +6,6 @@ content-type: application/json
 
 {
   "@id": "http://localhost:55001/plone/@search", 
-  "batching": {
-    "@id": "http://localhost:55001/plone/@search?sort_on=path", 
-    "first": "http://localhost:55001/plone/@search?sort_on=path&b_start=0", 
-    "last": "http://localhost:55001/plone/@search?sort_on=path&b_start=0"
-  }, 
   "items": [
     {
       "@id": "http://localhost:55001/plone/front-page", 

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -5,6 +5,12 @@ HTTP 200 OK
 content-type: application/json
 
 {
+  "@id": "http://localhost:55001/plone/@search?sort_on=path", 
+  "batching": {
+    "@id": "http://localhost:55001/plone/@search?sort_on=path", 
+    "first": "http://localhost:55001/plone/@search?sort_on=path&b_start=0", 
+    "last": "http://localhost:55001/plone/@search?sort_on=path&b_start=0"
+  }, 
   "items": [
     {
       "@id": "http://localhost:55001/plone/front-page", 
@@ -19,5 +25,5 @@ content-type: application/json
       "title": "Test Folder"
     }
   ], 
-  "items_count": 2
+  "items_total": 2
 }

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -5,7 +5,7 @@ HTTP 200 OK
 content-type: application/json
 
 {
-  "@id": "http://localhost:55001/plone/@search?sort_on=path", 
+  "@id": "http://localhost:55001/plone/@search", 
   "batching": {
     "@id": "http://localhost:55001/plone/@search?sort_on=path", 
     "first": "http://localhost:55001/plone/@search?sort_on=path&b_start=0", 

--- a/docs/source/_json/siteroot.json
+++ b/docs/source/_json/siteroot.json
@@ -7,6 +7,11 @@ content-type: application/json
 {
   "@id": "http://localhost:55001/plone", 
   "@type": "Plone Site", 
+  "batching": {
+    "@id": "http://localhost:55001/plone", 
+    "first": "http://localhost:55001/plone?b_start=0", 
+    "last": "http://localhost:55001/plone?b_start=0"
+  }, 
   "items": [
     {
       "@id": "http://localhost:55001/plone/robot-test-folder", 
@@ -21,5 +26,6 @@ content-type: application/json
       "title": "Welcome to Plone"
     }
   ], 
+  "items_total": 2, 
   "parent": {}
 }

--- a/docs/source/_json/siteroot.json
+++ b/docs/source/_json/siteroot.json
@@ -7,11 +7,6 @@ content-type: application/json
 {
   "@id": "http://localhost:55001/plone", 
   "@type": "Plone Site", 
-  "batching": {
-    "@id": "http://localhost:55001/plone", 
-    "first": "http://localhost:55001/plone?b_start=0", 
-    "last": "http://localhost:55001/plone?b_start=0"
-  }, 
   "items": [
     {
       "@id": "http://localhost:55001/plone/robot-test-folder", 

--- a/docs/source/batching.rst
+++ b/docs/source/batching.rst
@@ -1,0 +1,76 @@
+Batching
+========
+
+Representations of collection-like resources are batched / paginated:
+
+.. code:: json
+
+    {
+      "@id": "http://.../folder/search",
+      "batching": {
+        "@id": "http://.../folder/search?b_size=10&b_start=20",
+        "first": "http://.../plone/folder/search?b_size=10&b_start=0",
+        "last": "http://.../plone/folder/search?b_size=10&b_start=170",
+        "prev": "http://.../plone/folder/search?b_size=10&b_start=10",
+        "next": "http://.../plone/folder/search?b_size=10&b_start=30"
+      },
+      "items": [
+        "..."
+      ],
+      "items_total": 175,
+    }
+
+
+Top-level attributes
+--------------------
+
+================ ===========================================================
+Attribute        Description
+================ ===========================================================
+``@id``          Canonical base URL for the resource, without any
+                 batching parameters
+``items``        Current batch of items / members of the collection-like
+                 resource
+``items_total``  Total number of items
+``batching``     Batching related navigation links (see below)
+================ ===========================================================
+
+
+Batching links
+--------------
+
+The top-level attribute ``batching`` contains a dictionary with links that
+can be used to navigate batches in a Hypermedia fashion:
+
+================ ===========================================================
+Attribute        Description
+================ ===========================================================
+``@id``          Link to the current batch page
+``first``        Link to the first batch page
+``prev``         Link to the previous batch page (*if applicable*)
+``next``         Link to the next batch page (*if applicable*)
+``last``         Link to the last batch page
+================ ===========================================================
+
+
+
+Parameters
+----------
+
+Batching can be controlled with two query string parameters. In order to
+address a specific batch page, the ``b_start`` parameter can be used to
+request a specific batch page, containing ``b_size`` items starting from
+``b_start``.
+
+================ ===========================================================
+Parameter        Description
+================ ===========================================================
+``b_size``       Batch size (default is 25)
+``b_start``      First item of the batch
+================ ===========================================================
+
+
+Full example of a batched response:
+
+.. literalinclude:: _json/batching.json
+   :language: js

--- a/docs/source/batching.rst
+++ b/docs/source/batching.rst
@@ -1,7 +1,8 @@
 Batching
 ========
 
-Representations of collection-like resources are batched / paginated:
+Representations of collection-like resources are batched / paginated if the
+size of the resulset exceeds the batching size:
 
 .. code:: json
 
@@ -19,6 +20,9 @@ Representations of collection-like resources are batched / paginated:
       ],
       "items_total": 175,
     }
+
+If the entire resulset fits into a single batch page (as determined by
+``b_size``), the top-level ``batching`` links will be omitted.
 
 
 Top-level attributes
@@ -39,8 +43,10 @@ Attribute        Description
 Batching links
 --------------
 
-The top-level attribute ``batching`` contains a dictionary with links that
-can be used to navigate batches in a Hypermedia fashion:
+If, and only if, the resultset has been batched over several pages, the
+response body will contain a top-level attribute ``batching`` that contains
+batching links. These links that can be used to navigate batches in a
+Hypermedia fashion:
 
 ================ ===========================================================
 Attribute        Description

--- a/docs/source/crud.rst
+++ b/docs/source/crud.rst
@@ -165,6 +165,11 @@ If a resource has been retrieved successfully, the server responds with :term:`2
 .. literalinclude:: _json/document.json
    :language: js
 
+.. note::
+        For folderish types, collections or search results, the results will
+        be **batched** if the size of the resultset exceeds the batch size.
+        See :doc:`/batching` for more details on how to work with batched
+        results.
 
 Unsuccessful response (404 Not Found)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Contents
 
    authentication
    crud
+   batching
    workflow
    registry
    serialization

--- a/docs/source/plone-content.rst
+++ b/docs/source/plone-content.rst
@@ -4,6 +4,11 @@ Plone Content
 How to get all standard Plone content representations.
 The syntax is given in various tools, click on 'curl', 'http-request' or 'python-requests' to see examples.
 
+.. note::
+        For folderish types, collections or search results, the results will
+        be **batched** if the size of the resultset exceeds the batch size.
+        See :doc:`/batching` for more details on how to work with batched
+        results.
 
 
 Plone Portal Root:

--- a/docs/source/searching.rst
+++ b/docs/source/searching.rst
@@ -21,6 +21,11 @@ Search results are represented similar to collections:
 The default representation for search results is a summary that contains only the most basic information.
 In order to return specific metadata columns, see the documentation of the ``metadata_fields`` parameter below.
 
+.. note::
+        Search results results will be **batched** if the size of the
+        resultset exceeds the batch size. See :doc:`/batching` for more
+        details on how to work with batched results.
+
 
 Query format
 ------------

--- a/src/plone/restapi/batching.py
+++ b/src/plone/restapi/batching.py
@@ -61,6 +61,10 @@ class HypermediaBatch(object):
     def links(self):
         """Get a dictionary with batching links.
         """
+        # Don't provide batching links if resultset isn't batched
+        if self.items_total <= self.b_size:
+            return None
+
         links = {}
 
         first = self._batch_for_page(1)

--- a/src/plone/restapi/batching.py
+++ b/src/plone/restapi/batching.py
@@ -38,8 +38,9 @@ class HypermediaBatch(object):
         url = self.request['ACTUAL_URL']
         qs_params = dict(parse_qsl(self.request['QUERY_STRING']))
 
-        # Remove any batching related parameters
-        for key in ('b_size', 'b_start'):
+        # Remove any batching / sorting related parameters
+        for key in ('b_size', 'b_start',
+                    'sort_on', 'sort_order', 'sort_limit'):
             qs_params.pop(key, None)
 
         qs = urlencode(qs_params)

--- a/src/plone/restapi/batching.py
+++ b/src/plone/restapi/batching.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from plone.batching.batch import Batch
+from urllib import urlencode
+from urlparse import parse_qsl
+
+
+DEFAULT_BATCH_SIZE = 25
+
+
+class HypermediaBatch(object):
+
+    def __init__(self, context, request, results):
+        self.context = context
+        self.request = request
+
+        self.b_start = int(self.request.form.get('b_start', 0))
+        self.b_size = int(self.request.form.get('b_size', DEFAULT_BATCH_SIZE))
+
+        self.batch = Batch(results, self.b_size, self.b_start)
+
+    def __iter__(self):
+        """Iterate over items in current batch.
+        """
+        return iter(self.batch)
+
+    @property
+    def items_total(self):
+        """Return the number of total items in underlying sequence.
+        """
+        return self.batch.sequence_length
+
+    @property
+    def canonical_url(self):
+        """Return the canonical URL to the batched collection-like resource,
+        preserving query string params, but stripping all batching related
+        params from it.
+        """
+        url = self.request['ACTUAL_URL']
+        qs_params = dict(parse_qsl(self.request['QUERY_STRING']))
+
+        # Remove any batching related parameters
+        for key in ('b_size', 'b_start'):
+            qs_params.pop(key, None)
+
+        qs = urlencode(qs_params)
+
+        if qs_params:
+            url = '?'.join((url, qs))
+        return url
+
+    @property
+    def current_batch_url(self):
+        url = self.request['ACTUAL_URL']
+        qs = self.request['QUERY_STRING']
+        if qs:
+            url = '?'.join((url, qs))
+        return url
+
+    @property
+    def links(self):
+        """Get a dictionary with batching links.
+        """
+        links = {}
+
+        first = self._batch_for_page(1)
+        last = self._batch_for_page(self.batch.lastpage)
+        next = self.batch.next
+        prev = self.batch.previous
+
+        links['@id'] = self.current_batch_url
+        links['first'] = self._url_for_batch(first)
+        links['last'] = self._url_for_batch(last)
+
+        if next:
+            links['next'] = self._url_for_batch(next)
+
+        if prev:
+            links['prev'] = self._url_for_batch(prev)
+
+        return links
+
+    def _batch_for_page(self, pagenumber):
+        """Return a new Batch object for the given pagenumber.
+        """
+        new_batch = Batch.fromPagenumber(
+            self.batch._sequence,
+            pagesize=self.b_size,
+            pagenumber=pagenumber)
+        return new_batch
+
+    def _url_for_batch(self, batch):
+        """Return URL that points to the given batch.
+        """
+        # Calculate the start for the new batch page.
+        # Make sure we account for plone.batching's one-based indexing and
+        # that the start never drops below zero
+        new_start = max(0, batch.start - 1)
+        url = self._url_with_params(params={'b_start': new_start})
+        return url
+
+    def _url_with_params(self, params):
+        """Build an URL based on the actual URL of the current request URL
+        and add or update some query string parameters in it.
+        """
+        url = self.request['ACTUAL_URL']
+        qs_params = dict(parse_qsl(self.request['QUERY_STRING']))
+        for key, value in params.items():
+            qs_params[key] = value
+        qs = urlencode(qs_params)
+
+        if qs_params:
+            url = '?'.join((url, qs))
+        return url

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -48,7 +48,8 @@ class SearchHandler(object):
         results = {}
         results['@id'] = batch.canonical_url
         results['items_total'] = batch.items_total
-        results['batching'] = batch.links
+        if batch.links:
+            results['batching'] = batch.links
 
         results['items'] = []
         for brain in batch:

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+from plone.restapi.batching import HypermediaBatch
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.interfaces import IZCatalogCompatibleQuery
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
@@ -38,8 +40,28 @@ class SearchHandler(object):
         query = self._parse_query(query)
         self._constrain_query_by_path(query)
 
-        lazy_resultset = self.catalog.searchResults(query)
-        results = getMultiAdapter(
-            (lazy_resultset, self.request),
-            ISerializeToJson)(metadata_fields=metadata_fields)
+        catalog = getToolByName(self.context, 'portal_catalog')
+        brains = catalog(query)
+
+        batch = HypermediaBatch(self.context, self.request, brains)
+
+        results = {}
+        results['@id'] = batch.canonical_url
+        results['items_total'] = batch.items_total
+        results['batching'] = batch.links
+
+        results['items'] = []
+        for brain in batch:
+            result = getMultiAdapter(
+                (brain, self.request), ISerializeToJsonSummary)()
+
+            if metadata_fields:
+                # Merge additional metadata into the summary we already have
+                metadata = getMultiAdapter(
+                    (brain, self.request),
+                    ISerializeToJson)(metadata_fields=metadata_fields)
+                result.update(metadata)
+
+            results['items'].append(result)
+
         return results

--- a/src/plone/restapi/search/query.py
+++ b/src/plone/restapi/search/query.py
@@ -72,6 +72,8 @@ class ZCatalogCompatibleQueryAdapter(object):
         'sort_on': str,
         'sort_order': str,
         'sort_limit': int,
+        'b_start': int,
+        'b_size': int,
     }
 
     def __init__(self, context, request):

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -81,7 +81,8 @@ class SerializeFolderToJson(SerializeToJson):
         result = folder_metadata
         result['@id'] = batch.canonical_url
         result['items_total'] = batch.items_total
-        result['batching'] = batch.links
+        if batch.links:
+            result['batching'] = batch.links
 
         result['items'] = [
             getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -62,10 +62,22 @@ class SerializeToJson(object):
 @adapter(IBaseFolder, Interface)
 class SerializeFolderToJson(SerializeToJson):
 
+    def _build_query(self):
+        path = '/'.join(self.context.getPhysicalPath())
+        query = {'path': {'depth': 1, 'query': path}}
+        return query
+
     def __call__(self):
-        result = super(SerializeFolderToJson, self).__call__()
+        folder_metadata = super(SerializeFolderToJson, self).__call__()
+        query = self._build_query()
+
+        catalog = getToolByName(self.context, 'portal_catalog')
+        brains = catalog(query)
+
+        result = folder_metadata
+
         result['items'] = [
-            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
-            for item in self.context.objectValues()
+            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+            for brain in brains
         ]
         return result

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from plone.restapi.batching import HypermediaBatch
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
@@ -75,10 +76,15 @@ class SerializeFolderToJson(SerializeToJson):
         catalog = getToolByName(self.context, 'portal_catalog')
         brains = catalog(query)
 
+        batch = HypermediaBatch(self.context, self.request, brains)
+
         result = folder_metadata
+        result['@id'] = batch.canonical_url
+        result['items_total'] = batch.items_total
+        result['batching'] = batch.links
 
         result['items'] = [
             getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
-            for brain in brains
+            for brain in batch
         ]
         return result

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -64,7 +64,8 @@ class SerializeFolderToJson(SerializeToJson):
 
     def _build_query(self):
         path = '/'.join(self.context.getPhysicalPath())
-        query = {'path': {'depth': 1, 'query': path}}
+        query = {'path': {'depth': 1, 'query': path,
+                 'sort_on': 'getObjPositionInParent'}}
         return query
 
     def __call__(self):

--- a/src/plone/restapi/serializer/catalog.py
+++ b/src/plone/restapi/serializer/catalog.py
@@ -4,7 +4,6 @@ from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.interfaces import ICatalogBrain
-from Products.ZCatalog.Lazy import Lazy
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
@@ -38,7 +37,10 @@ class BrainSerializer(object):
     def __call__(self, metadata_fields=('_all',)):
         metadata_to_include = self._get_metadata_to_include(metadata_fields)
 
-        result = {}
+        # Start with a summary representation as our base
+        result = getMultiAdapter(
+            (self.brain, self.request), ISerializeToJsonSummary)()
+
         for attr in metadata_to_include:
             value = getattr(self.brain, attr, None)
 
@@ -54,33 +56,3 @@ class BrainSerializer(object):
             result[attr] = value
 
         return result
-
-
-@implementer(ISerializeToJson)
-@adapter(Lazy, Interface)
-class LazyCatalogResultSerializer(object):
-    """Serializes a ZCatalog resultset (one of the subclasses of `Lazy`) to
-    a Python data structure that can in turn be serialized to JSON.
-    """
-
-    def __init__(self, lazy_resultset, request):
-        self.lazy_resultset = lazy_resultset
-        self.request = request
-
-    def __call__(self, metadata_fields=()):
-        results = {}
-        results['items_count'] = self.lazy_resultset.actual_result_count
-        results['items'] = []
-
-        for brain in self.lazy_resultset:
-            result = getMultiAdapter(
-                (brain, self.request), ISerializeToJsonSummary)()
-
-            if metadata_fields:
-                metadata = getMultiAdapter(
-                    (brain, self.request),
-                    ISerializeToJson)(metadata_fields=metadata_fields)
-                result.update(metadata)
-
-            results['items'].append(result)
-        return results

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -22,7 +22,8 @@ class SerializeCollectionToJson(SerializeToJson):
         results = collection_metadata
         results['@id'] = batch.canonical_url
         results['items_total'] = batch.items_total
-        results['batching'] = batch.links
+        if batch.links:
+            results['batching'] = batch.links
 
         results['items'] = [
             getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.interfaces import ICollection
+from plone.restapi.batching import HypermediaBatch
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.dxcontent import SerializeToJson
 from zope.component import adapter
-from zope.interface import Interface
 from zope.component import getMultiAdapter
 from zope.interface import implementer
+from zope.interface import Interface
 
 
 @implementer(ISerializeToJson)
@@ -14,9 +15,17 @@ from zope.interface import implementer
 class SerializeCollectionToJson(SerializeToJson):
 
     def __call__(self):
-        result = super(SerializeCollectionToJson, self).__call__()
-        result['items'] = [
-            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
-            for item in self.context.results()
+        collection_metadata = super(SerializeCollectionToJson, self).__call__()
+        results = self.context.results(batch=False)
+        batch = HypermediaBatch(self.context, self.request, results)
+
+        results = collection_metadata
+        results['@id'] = batch.canonical_url
+        results['items_total'] = batch.items_total
+        results['batching'] = batch.links
+
+        results['items'] = [
+            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+            for brain in batch
         ]
-        return result
+        return results

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -53,6 +53,5 @@
     </configure>
 
     <adapter factory=".catalog.BrainSerializer" />
-    <adapter factory=".catalog.LazyCatalogResultSerializer" />
 
 </configure>

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -91,10 +91,23 @@ class SerializeToJson(object):
 @adapter(IDexterityContainer, Interface)
 class SerializeFolderToJson(SerializeToJson):
 
+    def _build_query(self):
+        path = '/'.join(self.context.getPhysicalPath())
+        query = {'path': {'depth': 1, 'query': path}}
+        return query
+
     def __call__(self):
-        result = super(SerializeFolderToJson, self).__call__()
+        folder_metadata = super(SerializeFolderToJson, self).__call__()
+
+        query = self._build_query()
+
+        catalog = getToolByName(self.context, 'portal_catalog')
+        brains = catalog(query)
+
+        result = folder_metadata
+
         result['items'] = [
-            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
-            for item in self.context.objectValues()
+            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+            for brain in brains
         ]
         return result

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -111,7 +111,8 @@ class SerializeFolderToJson(SerializeToJson):
         result = folder_metadata
         result['@id'] = batch.canonical_url
         result['items_total'] = batch.items_total
-        result['batching'] = batch.links
+        if batch.links:
+            result['batching'] = batch.links
 
         result['items'] = [
             getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -93,7 +93,8 @@ class SerializeFolderToJson(SerializeToJson):
 
     def _build_query(self):
         path = '/'.join(self.context.getPhysicalPath())
-        query = {'path': {'depth': 1, 'query': path}}
+        query = {'path': {'depth': 1, 'query': path,
+                 'sort_on': 'getObjPositionInParent'}}
         return query
 
     def __call__(self):

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -40,7 +40,8 @@ class SerializeSiteRootToJson(object):
         }
 
         result['items_total'] = batch.items_total
-        result['batching'] = batch.links
+        if batch.links:
+            result['batching'] = batch.links
 
         result['items'] = [
             getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -19,7 +19,8 @@ class SerializeSiteRootToJson(object):
 
     def _build_query(self):
         path = '/'.join(self.context.getPhysicalPath())
-        query = {'path': {'depth': 1, 'query': path}}
+        query = {'path': {'depth': 1, 'query': path,
+                 'sort_on': 'getObjPositionInParent'}}
         return query
 
     def __call__(self):

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.interfaces import IContentish
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import adapter
 from zope.component import getMultiAdapter
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
 
 
 @implementer(ISerializeToJson)
@@ -17,16 +17,27 @@ class SerializeSiteRootToJson(object):
         self.context = context
         self.request = request
 
+    def _build_query(self):
+        path = '/'.join(self.context.getPhysicalPath())
+        query = {'path': {'depth': 1, 'query': path}}
+        return query
+
     def __call__(self):
+        query = self._build_query()
+
+        catalog = getToolByName(self.context, 'portal_catalog')
+        brains = catalog(query)
+
         result = {
             # '@context': 'http://www.w3.org/ns/hydra/context.jsonld',
             '@id': self.context.absolute_url(),
             '@type': 'Plone Site',
             'parent': {},
         }
+
         result['items'] = [
-            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
-            for item in self.context.objectValues()
-            if IContentish.providedBy(item)
+            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+            for brain in brains
         ]
+
         return result

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -230,6 +230,60 @@ class TestBatchingDXFolders(TestBatchingDXBase):
         self.assertEqual(5, response.json()['items_total'])
 
 
+class TestBatchingSiteRoot(TestBatchingDXBase):
+
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestBatchingSiteRoot, self).setUp()
+
+        for i in range(5):
+            self._create_doc(self.portal, i)
+        transaction.commit()
+
+    def test_contains_canonical_url(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/?b_start=2&b_size=2')
+
+        # Response should contain canonical URL without batching params
+        self.assertEqual(
+            response.json()['@id'],
+            u'http://localhost:55001/plone/')
+
+    def test_contains_batching_links(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/?b_start=2&b_size=2')
+
+        # Batch info in response should contain appropriate batching links
+        batch_info = response.json()['batching']
+
+        self.assertDictEqual(
+            {u'@id': self.portal_url + '/?b_start=2&b_size=2',
+             u'first': self.portal_url + '/?b_size=2&b_start=0',
+             u'next': self.portal_url + '/?b_size=2&b_start=4',
+             u'prev': self.portal_url + '/?b_size=2&b_start=0',
+             u'last': self.portal_url + '/?b_size=2&b_start=4',
+             },
+            batch_info)
+
+    def test_contains_correct_batch_of_items(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/?b_start=2&b_size=2')
+
+        # Response should contain second batch of items
+        self.assertEquals([
+            u'/plone/doc-3',
+            u'/plone/doc-4'],
+            result_paths(response.json()))
+
+    def test_total_item_count_is_correct(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/?b_start=2&b_size=2')
+
+        # Total count of items should be in items_total
+        self.assertEqual(5, response.json()['items_total'])
+
+
 class TestBatchingArchetypes(unittest.TestCase):
 
     layer = PLONE_RESTAPI_AT_FUNCTIONAL_TESTING

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -449,6 +449,19 @@ class TestHypermediaBatch(unittest.TestCase):
         self.assertEquals('nohost', parsed_url.netloc)
         self.assertEquals('', parsed_url.path)
 
+    def test_canonical_url_strips_sorting_params(self):
+        items = range(1, 26)
+
+        self.request['QUERY_STRING'] = 'one=1&sort_on=path&two=2'
+        batch = HypermediaBatch(self.portal, self.request, items)
+
+        parsed_url = urlparse(batch.canonical_url)
+        qs_params = dict(parse_qsl(parsed_url.query))
+
+        self.assertEquals({'one': '1', 'two': '2'}, qs_params)
+        self.assertEquals('nohost', parsed_url.netloc)
+        self.assertEquals('', parsed_url.path)
+
     def test_current_batch_url(self):
         items = range(1, 26)
 

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -171,6 +171,10 @@ class TestBatchingCollections(TestBatchingDXBase):
         # Total count of items should be in items_total
         self.assertEqual(6, response.json()['items_total'])
 
+    def test_batching_links_omitted_if_resulset_fits_in_single_batch(self):
+        response = self.api_session.get('/collection?b_size=100')
+        self.assertNotIn('batching', response.json().keys())
+
 
 class TestBatchingDXFolders(TestBatchingDXBase):
 
@@ -229,6 +233,10 @@ class TestBatchingDXFolders(TestBatchingDXBase):
         # Total count of items should be in items_total
         self.assertEqual(5, response.json()['items_total'])
 
+    def test_batching_links_omitted_if_resulset_fits_in_single_batch(self):
+        response = self.api_session.get('/folder?b_size=100')
+        self.assertNotIn('batching', response.json().keys())
+
 
 class TestBatchingSiteRoot(TestBatchingDXBase):
 
@@ -282,6 +290,10 @@ class TestBatchingSiteRoot(TestBatchingDXBase):
 
         # Total count of items should be in items_total
         self.assertEqual(5, response.json()['items_total'])
+
+    def test_batching_links_omitted_if_resulset_fits_in_single_batch(self):
+        response = self.api_session.get('/folder?b_size=100')
+        self.assertNotIn('batching', response.json().keys())
 
 
 class TestBatchingArchetypes(unittest.TestCase):
@@ -358,6 +370,10 @@ class TestBatchingArchetypes(unittest.TestCase):
 
         # Total count of items should be in items_total
         self.assertEqual(5, response.json()['items_total'])
+
+    def test_batching_links_omitted_if_resulset_fits_in_single_batch(self):
+        response = self.api_session.get('/folder?b_size=100')
+        self.assertNotIn('batching', response.json().keys())
 
 
 class TestHypermediaBatch(unittest.TestCase):
@@ -471,6 +487,13 @@ class TestHypermediaBatch(unittest.TestCase):
         batch = HypermediaBatch(self.portal, self.request, items)
         self.assertEqual(
             'http://nohost?b_size=10&b_start=20', batch.current_batch_url)
+
+    def test_batching_links_omitted_if_resultset_fits_in_single_batch(self):
+        items = range(1, 5)
+
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertEqual(None, batch.links)
 
     def test_first_link_contained(self):
         items = range(1, 26)

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from DateTime import DateTime
+from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
 from plone.dexterity.utils import createContentInContainer
 from plone.restapi.batching import DEFAULT_BATCH_SIZE
 from plone.restapi.batching import HypermediaBatch
+from plone.restapi.testing import PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from plone.restapi.testing import RelativeSession
@@ -183,6 +186,82 @@ class TestBatchingDXFolders(TestBatchingDXBase):
         for i in range(5):
             self._create_doc(folder, i)
         transaction.commit()
+
+    def test_contains_canonical_url(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder?b_start=2&b_size=2')
+
+        # Response should contain canonical URL without batching params
+        self.assertEqual(
+            response.json()['@id'],
+            self.portal_url + '/folder')
+
+    def test_contains_batching_links(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder?b_start=2&b_size=2')
+
+        # Batch info in response should contain appropriate batching links
+        batch_info = response.json()['batching']
+
+        self.assertDictEqual(
+            {u'@id': self.portal_url + '/folder?b_start=2&b_size=2',
+             u'first': self.portal_url + '/folder?b_size=2&b_start=0',
+             u'next': self.portal_url + '/folder?b_size=2&b_start=4',
+             u'prev': self.portal_url + '/folder?b_size=2&b_start=0',
+             u'last': self.portal_url + '/folder?b_size=2&b_start=4',
+             },
+            batch_info)
+
+    def test_contains_correct_batch_of_items(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder?b_start=2&b_size=2')
+
+        # Response should contain second batch of items
+        self.assertEquals([
+            u'/plone/folder/doc-3',
+            u'/plone/folder/doc-4'],
+            result_paths(response.json()))
+
+    def test_total_item_count_is_correct(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder?b_start=2&b_size=2')
+
+        # Total count of items should be in items_total
+        self.assertEqual(5, response.json()['items_total'])
+
+
+class TestBatchingArchetypes(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
+        self.request = self.portal.REQUEST
+
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'Contributor'])
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({'Accept': 'application/json'})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+        folder = self.portal[self.portal.invokeFactory(
+            'Folder',
+            id='folder',
+            title='Some Folder',
+        )]
+
+        for i in range(5):
+            self._create_doc(folder, i)
+        transaction.commit()
+
+    def _create_doc(self, container, number):
+        container.invokeFactory(
+            'Document',
+            id='doc-%s' % str(number + 1),
+            title='Document %s' % str(number + 1),
+        )
 
     def test_contains_canonical_url(self):
         # Fetch the second page of the batch

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -102,6 +102,73 @@ class TestBatchingSearch(TestBatchingDXBase):
         self.assertEqual(6, response.json()['items_total'])
 
 
+class TestBatchingCollections(TestBatchingDXBase):
+
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestBatchingCollections, self).setUp()
+
+        folder = createContentInContainer(
+            self.portal, u'Folder',
+            id=u'folder')
+
+        for i in range(5):
+            self._create_doc(folder, i)
+
+        collection = createContentInContainer(
+            self.portal, u'Collection',
+            id='collection')
+        collection.query = [
+            {"i": "path",
+             "o": "plone.app.querystring.operation.string.path",
+             "v": "/plone/folder/"},
+        ]
+        transaction.commit()
+
+    def test_contains_canonical_url(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/collection?b_start=2&b_size=2')
+
+        # Response should contain canonical URL without batching params
+        self.assertEqual(
+            response.json()['@id'],
+            self.portal_url + '/collection')
+
+    def test_contains_batching_links(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/collection?b_start=2&b_size=2')
+
+        # Batch info in response should contain appropriate batching links
+        batch_info = response.json()['batching']
+
+        self.assertDictEqual(
+            {u'@id': self.portal_url + '/collection?b_start=2&b_size=2',
+             u'first': self.portal_url + '/collection?b_size=2&b_start=0',
+             u'next': self.portal_url + '/collection?b_size=2&b_start=4',
+             u'prev': self.portal_url + '/collection?b_size=2&b_start=0',
+             u'last': self.portal_url + '/collection?b_size=2&b_start=4',
+             },
+            batch_info)
+
+    def test_contains_correct_batch_of_items(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/collection?b_start=2&b_size=2')
+
+        # Response should contain second batch of items
+        self.assertEquals([
+            u'/plone/folder/doc-2',
+            u'/plone/folder/doc-3'],
+            result_paths(response.json()))
+
+    def test_total_item_count_is_correct(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/collection?b_start=2&b_size=2')
+
+        # Total count of items should be in items_total
+        self.assertEqual(6, response.json()['items_total'])
+
+
 class TestHypermediaBatch(unittest.TestCase):
 
     layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+from DateTime import DateTime
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.dexterity.utils import createContentInContainer
+from plone.restapi.batching import DEFAULT_BATCH_SIZE
+from plone.restapi.batching import HypermediaBatch
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
+from plone.restapi.testing import RelativeSession
+from plone.restapi.tests.helpers import result_paths
+from urlparse import parse_qsl
+from urlparse import urlparse
+
+import transaction
+import unittest
+
+
+class TestBatchingDXBase(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
+        self.request = self.portal.REQUEST
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({'Accept': 'application/json'})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+        # Delete robot test folder to get a clean fixture
+        self.portal.manage_delObjects(['robot-test-folder'])
+
+    def _create_doc(self, container, number):
+        createContentInContainer(
+            container, u'DXTestDocument',
+            id='doc-%s' % str(number + 1),
+            title=u'Document %s' % str(number + 1),
+            created=DateTime(1975, 1, 1, 0, 0),
+            effective=DateTime(2015, 1, 1, 0, 0),
+            expires=DateTime(2020, 1, 1, 0, 0),
+        )
+
+
+class TestBatchingSearch(TestBatchingDXBase):
+
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestBatchingSearch, self).setUp()
+
+        folder = createContentInContainer(
+            self.portal, u'Folder',
+            id=u'folder')
+
+        for i in range(5):
+            self._create_doc(folder, i)
+        transaction.commit()
+
+    def test_contains_canonical_url(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder/@search?b_start=2&b_size=2')
+
+        # Response should contain canonical URL without batching params
+        self.assertEqual(
+            response.json()['@id'],
+            self.portal_url + '/folder/@search')
+
+    def test_contains_batching_links(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder/@search?b_start=2&b_size=2')
+
+        # Batch info in response should contain appropriate batching links
+        batch_info = response.json()['batching']
+
+        self.assertDictEqual(
+            {u'@id': self.portal_url + '/folder/@search?b_start=2&b_size=2',
+             u'first': self.portal_url + '/folder/@search?b_size=2&b_start=0',
+             u'next': self.portal_url + '/folder/@search?b_size=2&b_start=4',
+             u'prev': self.portal_url + '/folder/@search?b_size=2&b_start=0',
+             u'last': self.portal_url + '/folder/@search?b_size=2&b_start=4',
+             },
+            batch_info)
+
+    def test_contains_correct_batch_of_items(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder/@search?b_start=2&b_size=2')
+
+        # Response should contain second batch of items
+        self.assertEquals([
+            u'/plone/folder/doc-2',
+            u'/plone/folder/doc-3'],
+            result_paths(response.json()))
+
+    def test_total_item_count_is_correct(self):
+        # Fetch the second page of the batch
+        response = self.api_session.get('/folder/@search?b_start=2&b_size=2')
+
+        # Total count of items should be in items_total
+        self.assertEqual(6, response.json()['items_total'])
+
+
+class TestHypermediaBatch(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.portal.REQUEST
+
+    def test_items_total(self):
+        items = range(1, 26)
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        # items_total should be total number of items in the sequence
+        self.assertEqual(
+            25, batch.items_total)
+
+    def test_default_batch_size(self):
+        items = range(1, 27)
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertEqual(DEFAULT_BATCH_SIZE, len(list(batch)))
+
+    def test_custom_batch_size(self):
+        items = range(1, 26)
+        self.request.form['b_size'] = 5
+        batch = HypermediaBatch(self.portal, self.request, items)
+        # Batch size should be customizable via request
+        self.assertEqual(
+            5, len(list(batch)))
+
+    def test_default_batch_start(self):
+        items = range(1, 26)
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        # Batch should start on first item by default
+        self.assertEqual(
+            range(1, 11), list(batch))
+
+    def test_custom_batch_start(self):
+        items = range(1, 26)
+        self.request.form['b_size'] = 10
+        self.request.form['b_start'] = 5
+        batch = HypermediaBatch(self.portal, self.request, items)
+        # Batch start should be customizable via request
+        self.assertEqual(
+            range(6, 16), list(batch))
+
+    def test_custom_start_and_size_can_be_combined(self):
+        items = range(1, 26)
+        self.request.form['b_size'] = 5
+        self.request.form['b_start'] = 5
+        batch = HypermediaBatch(self.portal, self.request, items)
+        # Should be able to combine custom batch start and size
+        self.assertListEqual(
+            range(6, 11), list(batch))
+
+    def test_canonical_url(self):
+        items = range(1, 26)
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertEqual('http://nohost', batch.canonical_url)
+
+    def test_canonical_url_preserves_query_string_params(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        self.request['QUERY_STRING'] = 'one=1&two=2'
+        batch = HypermediaBatch(self.portal, self.request, items)
+
+        parsed_url = urlparse(batch.canonical_url)
+        qs_params = dict(parse_qsl(parsed_url.query))
+
+        self.assertEquals({'one': '1', 'two': '2'}, qs_params)
+        self.assertEquals('nohost', parsed_url.netloc)
+        self.assertEquals('', parsed_url.path)
+
+    def test_canonical_url_strips_batching_params(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        self.request['QUERY_STRING'] = 'one=1&b_size=10&b_start=20&two=2'
+        batch = HypermediaBatch(self.portal, self.request, items)
+
+        parsed_url = urlparse(batch.canonical_url)
+        qs_params = dict(parse_qsl(parsed_url.query))
+
+        self.assertEquals({'one': '1', 'two': '2'}, qs_params)
+        self.assertEquals('nohost', parsed_url.netloc)
+        self.assertEquals('', parsed_url.path)
+
+    def test_current_batch_url(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        self.request['ACTUAL_URL'] = 'http://nohost'
+        self.request['QUERY_STRING'] = 'b_size=10&b_start=20'
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertEqual(
+            'http://nohost?b_size=10&b_start=20', batch.current_batch_url)
+
+    def test_first_link_contained(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertDictContainsSubset(
+            {'first': 'http://nohost?b_start=0'}, batch.links)
+
+    def test_last_link_contained(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertDictContainsSubset(
+            {'last': 'http://nohost?b_start=20'}, batch.links)
+
+    def test_next_link_contained_if_necessary(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertDictContainsSubset(
+            {'next': 'http://nohost?b_start=10'}, batch.links)
+
+    def test_next_link_omitted_on_last_page(self):
+        items = range(1, 26)
+
+        # Start on last page
+        self.request.form['b_size'] = 10
+        self.request.form['b_start'] = 20
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertSetEqual(
+            set(['@id', 'first', 'prev', 'last']),
+            set(batch.links.keys()))
+
+    def test_prev_link_contained_if_necessary(self):
+        items = range(1, 26)
+
+        # Start on third page
+        self.request.form['b_size'] = 10
+        self.request.form['b_start'] = 20
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertDictContainsSubset(
+            {'prev': 'http://nohost?b_start=10'}, batch.links)
+
+    def test_prev_link_omitted_on_first_page(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertSetEqual(
+            set(['@id', 'first', 'next', 'last']),
+            set(batch.links.keys()))
+
+    def test_no_gaps_or_duplicates_between_pages(self):
+        items = range(1, 26)
+        items_from_all_batches = []
+
+        size = 10
+        self.request.form['b_size'] = size
+
+        for pagenumber in range(3):
+            self.request.form['b_start'] = pagenumber * size
+            batch = HypermediaBatch(self.portal, self.request, items)
+            items_from_all_batches.extend(list(batch))
+
+        self.assertEqual(items, items_from_all_batches)
+
+    def test_batch_start_never_drops_below_zero(self):
+        items = range(1, 26)
+
+        # Start in the middle of what would otherwise be the first batch
+        self.request.form['b_size'] = 10
+        self.request.form['b_start'] = 5
+        batch = HypermediaBatch(self.portal, self.request, items)
+        self.assertEquals(
+            'http://nohost?b_start=0', batch.links['prev'])

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -1,25 +1,26 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
-from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
-from plone.restapi.testing import RelativeSession
+from DateTime import DateTime
 from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
 from plone.app.textfield.value import RichTextValue
-from plone.namedfile.file import NamedBlobImage
 from plone.namedfile.file import NamedBlobFile
+from plone.namedfile.file import NamedBlobImage
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from plone.restapi.testing import RelativeSession
 from plone.testing.z2 import Browser
 from plone.uuid.interfaces import IMutableUUID
-from DateTime import DateTime
-
 from z3c.relationfield import RelationValue
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
 import json
 import os
+import transaction
 import unittest2 as unittest
+
 
 REQUEST_HEADER_KEYS = [
     'accept'
@@ -345,3 +346,22 @@ class TestTraversal(unittest.TestCase):
             '{}/@logout'.format(self.portal.absolute_url()),
             headers={'Authorization': 'Bearer {}'.format(token)})
         save_response_for_documentation('logout.json', response)
+
+    def test_documentation_batching(self):
+        folder = self.portal[self.portal.invokeFactory(
+            'Folder',
+            id='folder',
+            title='Folder'
+        )]
+        for i in range(7):
+            folder.invokeFactory(
+                'Document',
+                id='doc-%s' % str(i + 1),
+                title='Document %s' % str(i + 1)
+            )
+        transaction.commit()
+
+        query = {'sort_on': 'path'}
+        response = self.api_session.get(
+            '/folder/@search?b_size=5', params=query)
+        save_response_for_documentation('batching.json', response)

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -83,9 +83,9 @@ class TestSearchFunctional(unittest.TestCase):
 
         results = response.json()
         self.assertEqual(
-            results[u'items_count'],
+            results[u'items_total'],
             len(results[u'items']),
-            'items_count property should match actual item count.'
+            'items_total property should match actual item count.'
         )
 
     def test_search_on_context_constrains_query_by_path(self):

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -121,6 +121,7 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
         self.portal.folder1.invokeFactory('Document', id='doc1')
         self.portal.folder1.doc1.title = u'Document 1'
         self.portal.folder1.doc1.description = u'This is a document'
+        self.portal.folder1.doc1.reindexObject()
         self.assertEqual(
             self.serialize(self.portal.folder1)['items'],
             [


### PR DESCRIPTION
Implements batching for

- Plone Site Root children
- Dexterity Folder
- Archetypes Folders
- Collections
- Search Results

Also changes implementation for `GET` on folderish contexts so catalog queries are used instead of `objectValues()`.

TODO:
- [x] Documentation
- [x] Use Plone's default batch size as the default (*turns out Plone doesn't have a configurable default batch sizes. It seems to be hard coded to `25` in most places, so I changed the default in `plone.restapi.batching` to that as well*)
- [x] Rename `items_count` to `total_items`
- [x] Refactor tests

Closes #8 