### PR TITLE
Add review_state to content serializations

### DIFF
--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -58,6 +58,7 @@ content-type: application/json
     }
   ], 
   "relatedItems": [], 
+  "review_state": "private", 
   "rights": "", 
   "sort_on": null, 
   "sort_reversed": null, 

--- a/docs/source/_json/document.json
+++ b/docs/source/_json/document.json
@@ -29,6 +29,7 @@ content-type: application/json
     "title": "Plone site"
   }, 
   "relatedItems": [], 
+  "review_state": "private", 
   "rights": "", 
   "subjects": [], 
   "table_of_contents": null, 

--- a/docs/source/_json/event.json
+++ b/docs/source/_json/event.json
@@ -38,6 +38,7 @@ content-type: application/json
   }, 
   "recurrence": null, 
   "relatedItems": [], 
+  "review_state": "private", 
   "rights": "", 
   "start": null, 
   "subjects": [], 

--- a/docs/source/_json/file.json
+++ b/docs/source/_json/file.json
@@ -29,6 +29,7 @@ content-type: application/json
     "title": "Plone site"
   }, 
   "relatedItems": [], 
+  "review_state": null, 
   "rights": "", 
   "subjects": [], 
   "title": "My File"

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -43,6 +43,7 @@ content-type: application/json
     "title": "Plone site"
   }, 
   "relatedItems": [], 
+  "review_state": "private", 
   "rights": "", 
   "subjects": [], 
   "title": "My Folder"

--- a/docs/source/_json/image.json
+++ b/docs/source/_json/image.json
@@ -38,6 +38,7 @@ content-type: application/json
     "title": "Plone site"
   }, 
   "relatedItems": [], 
+  "review_state": null, 
   "rights": "", 
   "subjects": [], 
   "title": "My Image"

--- a/docs/source/_json/link.json
+++ b/docs/source/_json/link.json
@@ -29,6 +29,7 @@ content-type: application/json
     "title": "Plone site"
   }, 
   "remoteUrl": "http://", 
+  "review_state": "private", 
   "rights": "", 
   "subjects": [], 
   "title": "My Link"

--- a/docs/source/_json/newsitem.json
+++ b/docs/source/_json/newsitem.json
@@ -40,6 +40,7 @@ content-type: application/json
     "title": "Plone site"
   }, 
   "relatedItems": [], 
+  "review_state": "private", 
   "rights": "", 
   "subjects": [], 
   "text": {

--- a/src/plone/restapi/profiles/testing/workflows.xml
+++ b/src/plone/restapi/profiles/testing/workflows.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+ <bindings>
+   <type type_id="DXTestDocument">
+     <bound-workflow workflow_id="simple_publication_workflow" />
+   </type>
+   <type type_id="ATTestFolder">
+     <bound-workflow workflow_id="simple_publication_workflow" />
+   </type>
+   <type type_id="ATTestDocument">
+     <bound-workflow workflow_id="simple_publication_workflow" />
+   </type>
+ </bindings>
+</object>

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from Products.Archetypes.interfaces import IBaseFolder
-from Products.Archetypes.interfaces import IBaseObject
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
+from Products.Archetypes.interfaces import IBaseFolder
+from Products.Archetypes.interfaces import IBaseObject
+from Products.CMFCore.utils import getToolByName
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
 
 
 @implementer(ISerializeToJson)
@@ -30,6 +31,7 @@ class SerializeToJson(object):
             '@id': self.context.absolute_url(),
             '@type': self.context.portal_type,
             'parent': parent_summary,
+            'review_state': self._get_workflow_state(),
             'UID': self.context.UID(),
         }
 
@@ -48,6 +50,12 @@ class SerializeToJson(object):
                 result[name] = serializer()
 
         return result
+
+    def _get_workflow_state(self):
+        wftool = getToolByName(self.context, 'portal_workflow')
+        review_state = wftool.getInfoFor(
+            ob=self.context, name='review_state', default=None)
+        return review_state
 
 
 @implementer(ISerializeToJson)

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -11,12 +11,13 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from plone.supermodel.utils import mergedTaggedValueDict
+from Products.CMFCore.utils import getToolByName
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
 from zope.schema import getFields
 from zope.security.interfaces import IPermission
 
@@ -42,6 +43,7 @@ class SerializeToJson(object):
             'parent': parent_summary,
             'created': json_compatible(self.context.created()),
             'modified': json_compatible(self.context.modified()),
+            'review_state': self._get_workflow_state(),
             'UID': self.context.UID(),
         }
 
@@ -62,6 +64,12 @@ class SerializeToJson(object):
                 result[json_compatible(name)] = value
 
         return result
+
+    def _get_workflow_state(self):
+        wftool = getToolByName(self.context, 'portal_workflow')
+        review_state = wftool.getInfoFor(
+            ob=self.context, name='review_state', default=None)
+        return review_state
 
     def check_permission(self, permission_name):
         if permission_name is None:

--- a/src/plone/restapi/tests/test_atcontent_serializer.py
+++ b/src/plone/restapi/tests/test_atcontent_serializer.py
@@ -53,6 +53,11 @@ class TestATContentSerializer(unittest.TestCase):
         self.assertIn(u'@type', obj)
         self.assertEqual(self.doc1.portal_type, obj[u'@type'])
 
+    def test_serializer_includes_review_state(self):
+        obj = self.serialize(self.doc1)
+        self.assertIn(u'review_state', obj)
+        self.assertEqual(u'private', obj[u'review_state'])
+
     def test_serializer_includes_uid(self):
         obj = self.serialize(self.doc1)
         self.assertIn(u'UID', obj)

--- a/src/plone/restapi/tests/test_dxcontent_serializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_serializer.py
@@ -81,6 +81,11 @@ class TestDXContentSerializer(unittest.TestCase):
         self.assertIn(u'@type', obj)
         self.assertEqual(self.portal.doc1.portal_type, obj[u'@type'])
 
+    def test_serializer_includes_review_state(self):
+        obj = self.serialize()
+        self.assertIn(u'review_state', obj)
+        self.assertEqual(u'private', obj[u'review_state'])
+
     def test_serializer_includes_uid(self):
         obj = self.serialize()
         self.assertIn(u'UID', obj)


### PR DESCRIPTION
Includes the workflow state in the `review_state` attribute in content serializations.