### PR TITLE
Rename 'member' attribute to 'items' for collection-like resources

### DIFF
--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -21,9 +21,7 @@ content-type: application/json
   "exclude_from_nav": false, 
   "expires": null, 
   "item_count": 30, 
-  "language": "", 
-  "limit": 1000, 
-  "member": [
+  "items": [
     {
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
@@ -43,6 +41,8 @@ content-type: application/json
       "title": "Document 2"
     }
   ], 
+  "language": "", 
+  "limit": 1000, 
   "modified": "2016-01-21T08:24:11+00:00", 
   "parent": {
     "@id": "http://localhost:55001/plone", 

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -19,8 +19,7 @@ content-type: application/json
   "effective": null, 
   "exclude_from_nav": false, 
   "expires": null, 
-  "language": "", 
-  "member": [
+  "items": [
     {
       "@id": "http://localhost:55001/plone/folder/doc1", 
       "@type": "Document", 
@@ -34,6 +33,7 @@ content-type: application/json
       "title": "A document within a folder"
     }
   ], 
+  "language": "", 
   "modified": "2016-01-21T07:24:11+00:00", 
   "nextPreviousEnabled": false, 
   "parent": {

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -5,8 +5,7 @@ HTTP 200 OK
 content-type: application/json
 
 {
-  "items_count": 2, 
-  "member": [
+  "items": [
     {
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
@@ -19,5 +18,6 @@ content-type: application/json
       "description": "", 
       "title": "Test Folder"
     }
-  ]
+  ], 
+  "items_count": 2
 }

--- a/docs/source/_json/siteroot.json
+++ b/docs/source/_json/siteroot.json
@@ -7,7 +7,7 @@ content-type: application/json
 {
   "@id": "http://localhost:55001/plone", 
   "@type": "Plone Site", 
-  "member": [
+  "items": [
     {
       "@id": "http://localhost:55001/plone/robot-test-folder", 
       "@type": "Folder", 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -30,7 +30,7 @@ The `@id` property can be used to navigate through the web API by following the 
 
 `@type` sets the data type of a node or typed value
 
-`member` is a list that contains all objects within that resource.
+`items` is a list that contains all objects within that resource.
 
 A client application can "follow" the links (by calling the @id property) to other resources.
 This allows to build a losely coupled client that does not break if some of the URLs change, only the entry point of the entire API (in our case the portal root) needs to be known in advance.

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -56,8 +56,8 @@ class SerializeFolderToJson(SerializeToJson):
 
     def __call__(self):
         result = super(SerializeFolderToJson, self).__call__()
-        result['member'] = [
-            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
-            for member in self.context.objectValues()
+        result['items'] = [
+            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
+            for item in self.context.objectValues()
         ]
         return result

--- a/src/plone/restapi/serializer/catalog.py
+++ b/src/plone/restapi/serializer/catalog.py
@@ -70,7 +70,7 @@ class LazyCatalogResultSerializer(object):
     def __call__(self, metadata_fields=()):
         results = {}
         results['items_count'] = self.lazy_resultset.actual_result_count
-        results['member'] = []
+        results['items'] = []
 
         for brain in self.lazy_resultset:
             result = getMultiAdapter(
@@ -82,5 +82,5 @@ class LazyCatalogResultSerializer(object):
                     ISerializeToJson)(metadata_fields=metadata_fields)
                 result.update(metadata)
 
-            results['member'].append(result)
+            results['items'].append(result)
         return results

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -15,8 +15,8 @@ class SerializeCollectionToJson(SerializeToJson):
 
     def __call__(self):
         result = super(SerializeCollectionToJson, self).__call__()
-        result['member'] = [
-            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
-            for member in self.context.results()
+        result['items'] = [
+            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
+            for item in self.context.results()
         ]
         return result

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -85,8 +85,8 @@ class SerializeFolderToJson(SerializeToJson):
 
     def __call__(self):
         result = super(SerializeFolderToJson, self).__call__()
-        result['member'] = [
-            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
-            for member in self.context.objectValues()
+        result['items'] = [
+            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
+            for item in self.context.objectValues()
         ]
         return result

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -24,9 +24,9 @@ class SerializeSiteRootToJson(object):
             '@type': 'Plone Site',
             'parent': {},
         }
-        result['member'] = [
-            getMultiAdapter((member, self.request), ISerializeToJsonSummary)()
-            for member in self.context.objectValues()
-            if IContentish.providedBy(member)
+        result['items'] = [
+            getMultiAdapter((item, self.request), ISerializeToJsonSummary)()
+            for item in self.context.objectValues()
+            if IContentish.providedBy(item)
         ]
         return result

--- a/src/plone/restapi/tests/helpers.py
+++ b/src/plone/restapi/tests/helpers.py
@@ -12,7 +12,7 @@ def result_paths(results):
             return item['getPath']
         return urlparse(item['@id']).path
 
-    return [get_path(item) for item in results['member']]
+    return [get_path(item) for item in results['items']]
 
 
 def add_catalog_indexes(portal, indexes):

--- a/src/plone/restapi/tests/test_atcontent_serializer.py
+++ b/src/plone/restapi/tests/test_atcontent_serializer.py
@@ -87,16 +87,16 @@ class TestATContentSerializer(unittest.TestCase):
         folder.invokeFactory('ATTestFolder', id='subfolder', title='Subfolder')
         folder.invokeFactory('ATTestDocument', id='doc', title='A Document')
         obj = self.serialize(folder)
-        self.assertIn('member', obj)
+        self.assertIn('items', obj)
         self.assertDictEqual({
             '@id': 'http://nohost/plone/folder/subfolder',
             '@type': 'ATTestFolder',
             'description': '',
             'title': u'Subfolder'},
-            obj['member'][0])
+            obj['items'][0])
         self.assertDictEqual({
             '@id': 'http://nohost/plone/folder/doc',
             '@type': 'ATTestDocument',
             'description': '',
             'title': u'A Document'},
-            obj['member'][1])
+            obj['items'][1])

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -84,7 +84,7 @@ class TestSearchFunctional(unittest.TestCase):
         results = response.json()
         self.assertEqual(
             results[u'items_count'],
-            len(results[u'member']),
+            len(results[u'items']),
             'items_count property should match actual item count.'
         )
 
@@ -107,7 +107,7 @@ class TestSearchFunctional(unittest.TestCase):
              u'title': u'Lorem Ipsum',
              u'portal_type': u'DXTestDocument',
              u'review_state': u'private'},
-            response.json()['member'][0])
+            response.json()['items'][0])
 
     def test_full_metadata_retrieval(self):
         query = {'SearchableText': 'lorem', 'metadata_fields': '_all'}
@@ -149,7 +149,7 @@ class TestSearchFunctional(unittest.TestCase):
              u'sync_uid': None,
              u'title': u'Lorem Ipsum',
              u'total_comments': 0},
-            response.json()['member'][0])
+            response.json()['items'][0])
 
     # ZCTextIndex
 

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -116,13 +116,13 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
             '2017-01-01T00:00:00'
         )
 
-    def test_serialize_on_folder_returns_member_attr(self):
+    def test_serialize_on_folder_returns_items_attr(self):
         self.portal.invokeFactory('Folder', id='folder1', title='Folder 1')
         self.portal.folder1.invokeFactory('Document', id='doc1')
         self.portal.folder1.doc1.title = u'Document 1'
         self.portal.folder1.doc1.description = u'This is a document'
         self.assertEqual(
-            self.serialize(self.portal.folder1)['member'],
+            self.serialize(self.portal.folder1)['items'],
             [
                 {
                     u'@id': u'http://nohost/plone/folder1/doc1',
@@ -252,5 +252,5 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
                     u'title': u'Document 2'
                 }
             ],
-            self.serialize(self.portal.collection1).get('member')
+            self.serialize(self.portal.collection1).get('items')
         )

--- a/src/plone/restapi/tests/test_serializer_catalog.py
+++ b/src/plone/restapi/tests/test_serializer_catalog.py
@@ -40,13 +40,13 @@ class TestCatalogSerializers(unittest.TestCase):
         results = getMultiAdapter((lazy_cat, self.request), ISerializeToJson)()
 
         self.assertDictEqual(
-            {'member': [], 'items_count': 0},
+            {'items': [], 'items_count': 0},
             results)
 
     def test_lazy_map_serialization(self):
         lazy_map = self.catalog()
         results = getMultiAdapter((lazy_map, self.request), ISerializeToJson)()
-        self.assertEqual(3, len(results['member']))
+        self.assertEqual(3, len(results['items']))
         self.assertDictContainsSubset(
             {'items_count': 3},
             results)
@@ -59,7 +59,7 @@ class TestCatalogSerializers(unittest.TestCase):
              '@type': 'Document',
              'title': 'My Document',
              'description': ''},
-            results['member'])
+            results['items'])
 
     def test_brain_partial_metadata_representation(self):
         lazy_map = self.catalog(path='/plone/my-folder/my-document')
@@ -74,7 +74,7 @@ class TestCatalogSerializers(unittest.TestCase):
              'description': '',
              'portal_type': u'Document',
              'review_state': u'private'},
-            results['member'][0])
+            results['items'][0])
 
     def test_brain_full_metadata_representation(self):
         lazy_map = self.catalog(path='/plone/my-folder/my-document')
@@ -119,4 +119,4 @@ class TestCatalogSerializers(unittest.TestCase):
              'sync_uid': None,
              'title': 'My Document',
              'total_comments': 0},
-            results['member'][0])
+            results['items'][0])


### PR DESCRIPTION
The `member` attribute on collection-like resources was an artifact from the Hydra `Collection` type. We're only loosely following Hydra at this point, so we're choosing to name it somewhat more sensibly.