### PR TITLE
Serializers for Archetypes new style collections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name='plone.restapi',
       ],
       extras_require={'test': [
           'Products.Archetypes',
+          'plone.app.collection',
           'plone.app.contenttypes',
           'plone.app.robotframework',
           'plone.app.testing [robot] >= 4.2.2',

--- a/src/plone/restapi/serializer/atcollection.py
+++ b/src/plone/restapi/serializer/atcollection.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from plone.app.collection.interfaces import ICollection
+from plone.restapi.batching import HypermediaBatch
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer.atcontent import SerializeToJson
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(ICollection, Interface)
+class SerializeCollectionToJson(SerializeToJson):
+
+    def __call__(self):
+        collection_metadata = super(SerializeCollectionToJson, self).__call__()
+        results = self.context.results(batch=False)
+        batch = HypermediaBatch(self.context, self.request, results)
+
+        results = collection_metadata
+        results['@id'] = batch.canonical_url
+        results['items_total'] = batch.items_total
+        if batch.links:
+            results['batching'] = batch.links
+
+        results['items'] = [
+            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+            for brain in batch
+        ]
+        return results

--- a/src/plone/restapi/serializer/atfields.py
+++ b/src/plone/restapi/serializer/atfields.py
@@ -12,7 +12,13 @@ from plone.restapi.serializer.converters import json_compatible
 from zope.component import adapter
 from zope.interface import Interface
 from zope.interface import implementer
-from archetypes.querywidget.interfaces import IQueryField
+
+try:
+    from Products.CMFPlone.factory import _IMREALLYPLONE5  # noqa
+except ImportError:
+    from archetypes.querywidget.interfaces import IQueryField
+else:
+    from plone.app.collection.field import IQueryField
 
 
 @adapter(IField, IBaseObject, Interface)

--- a/src/plone/restapi/serializer/atfields.py
+++ b/src/plone/restapi/serializer/atfields.py
@@ -12,6 +12,7 @@ from plone.restapi.serializer.converters import json_compatible
 from zope.component import adapter
 from zope.interface import Interface
 from zope.interface import implementer
+from archetypes.querywidget.interfaces import IQueryField
 
 
 @adapter(IField, IBaseObject, Interface)
@@ -89,3 +90,11 @@ class ReferenceFieldSerializer(DefaultFieldSerializer):
             if refs is None:
                 return None
             return json_compatible(refs.absolute_url())
+
+
+@adapter(IQueryField, IBaseObject, Interface)
+@implementer(IFieldSerializer)
+class QueryFieldSerializer(DefaultFieldSerializer):
+    def __call__(self):
+        raw_value = self.field.getRaw(self.context)
+        return json_compatible(map(dict, raw_value))

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -29,6 +29,7 @@
         <adapter factory=".atfields.ReferenceFieldSerializer" />
         <adapter factory=".atfields.TextFieldSerializer" />
         <adapter factory=".atfields.QueryFieldSerializer" />
+        <adapter factory=".atcollection.SerializeCollectionToJson" />
     </configure>
 
     <adapter factory=".converters.date_converter" />

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -28,6 +28,7 @@
         <adapter factory=".atfields.ImageFieldSerializer" />
         <adapter factory=".atfields.ReferenceFieldSerializer" />
         <adapter factory=".atfields.TextFieldSerializer" />
+        <adapter factory=".atfields.QueryFieldSerializer" />
     </configure>
 
     <adapter factory=".converters.date_converter" />

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -75,6 +75,7 @@ class PloneRestApiATLayer(PloneSandboxLayer):
 
         z2.installProduct(app, 'Products.Archetypes')
         z2.installProduct(app, 'Products.ATContentTypes')
+        z2.installProduct(app, 'plone.app.collection')
         z2.installProduct(app, 'plone.app.blob')
         z2.installProduct(app, 'plone.restapi')
 
@@ -82,6 +83,10 @@ class PloneRestApiATLayer(PloneSandboxLayer):
         if portal.portal_setup.profileExists(
                 'Products.ATContentTypes:default'):
             applyProfile(portal, 'Products.ATContentTypes:default')
+        if portal.portal_setup.profileExists(
+                'plone.app.collection:default'):
+            applyProfile(portal, 'plone.app.collection:default')
+
         applyProfile(portal, 'plone.app.dexterity:default')
         applyProfile(portal, 'plone.restapi:default')
         applyProfile(portal, 'plone.restapi:testing')

--- a/src/plone/restapi/tests/attypes.py
+++ b/src/plone/restapi/tests/attypes.py
@@ -9,7 +9,12 @@ from plone.app.blob.field import FileField
 from plone.app.blob.field import ImageField
 from plone.app.folder.folder import ATFolder
 from plone.app.folder.folder import ATFolderSchema
-from archetypes.querywidget.field import QueryField
+try:
+    from Products.CMFPlone.factory import _IMREALLYPLONE5  # noqa
+except ImportError:
+    from archetypes.querywidget.field import QueryField
+else:
+    from plone.app.collection.field import QueryField
 
 PROJECTNAME = 'plone.restapi.tests'
 

--- a/src/plone/restapi/tests/attypes.py
+++ b/src/plone/restapi/tests/attypes.py
@@ -9,6 +9,7 @@ from plone.app.blob.field import FileField
 from plone.app.blob.field import ImageField
 from plone.app.folder.folder import ATFolder
 from plone.app.folder.folder import ATFolderSchema
+from archetypes.querywidget.field import QueryField
 
 PROJECTNAME = 'plone.restapi.tests'
 
@@ -30,6 +31,7 @@ ATTestDocumentSchema = ATDocumentSchema.copy() + atapi.Schema((
     BlobField('testBlobField'),
     FileField('testBlobFileField'),
     ImageField('testBlobImageField'),
+    QueryField('testQueryField'),
 
     atapi.StringField('testRequiredField', required=True),
     atapi.StringField('testReadonlyField', mode='r'),

--- a/src/plone/restapi/tests/test_atcollection.py
+++ b/src/plone/restapi/tests/test_atcollection.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from DateTime import DateTime
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.testing import PLONE_RESTAPI_AT_INTEGRATION_TESTING
+from zope.component import getMultiAdapter
+
+import unittest
+
+
+class TestATContentSerializer(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_AT_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+        self.doc1 = self.portal[self.portal.invokeFactory(
+            'Collection', id='collection', title='Test Collection')]
+
+        self.doc1.setCreationDate(DateTime('2016-01-21T01:14:48+00:00'))
+        self.doc1.setModificationDate(DateTime('2016-01-21T01:24:11+00:00'))
+        self.doc1._setUID('76644b6611ab44c6881efd9cb17db12e')
+        query_data = [
+            {
+                "i": "portal_type",
+                "o": "plone.app.querystring.operation.selection.is",
+                "v": ["ATTestFolder"]
+            },
+            {
+                "i": "path",
+                "o": "plone.app.querystring.operation.string.path",
+                "v": "/plone/folder"
+            }
+        ]
+
+        self.doc1.setQuery(query_data)
+        self.doc1.setSort_on('created')
+
+    def serialize(self, obj):
+        serializer = getMultiAdapter((obj, self.request),
+                                     ISerializeToJson)
+        return serializer()
+
+    def test_serializer_includes_collection_items(self):
+        folder = self.portal[self.portal.invokeFactory(
+            'ATTestFolder', id='folder', title='Test Folder')]
+        folder.invokeFactory(
+            'ATTestFolder', id='subfolder-1', title='Subfolder 1')
+        folder.invokeFactory(
+            'ATTestFolder', id='subfolder-2', title='Subfolder 2')
+        folder.invokeFactory('ATTestDocument', id='doc', title='A Document')
+        obj = self.serialize(self.doc1)
+        self.assertIn('items', obj)
+        self.assertDictEqual({
+            u'@id': u'http://nohost/plone/folder',
+            u'@type': u'ATTestFolder',
+            u'description': u'',
+            u'title': u'Test Folder'},
+            obj['items'][0])
+        self.assertDictEqual({
+            u'@id': u'http://nohost/plone/folder/subfolder-1',
+            u'@type': u'ATTestFolder',
+            u'description': u'',
+            u'title': u'Subfolder 1'},
+            obj['items'][1])
+        self.assertDictEqual({
+            u'@id': u'http://nohost/plone/folder/subfolder-2',
+            u'@type': u'ATTestFolder',
+            u'description': u'',
+            u'title': u'Subfolder 2'},
+            obj['items'][2])

--- a/src/plone/restapi/tests/test_atfield_deserializer.py
+++ b/src/plone/restapi/tests/test_atfield_deserializer.py
@@ -164,6 +164,23 @@ class TestATFieldDeserializer(unittest.TestCase):
         self.assertEquals('image/gif', kwargs[u'mimetype'])
         self.assertEquals('image.gif', kwargs[u'filename'])
 
+    def test_query_field_deserialization_requests_list(self):
+        query_data = [
+            {
+                "i": "portal_type",
+                "o": "plone.app.querystring.operation.selection.is",
+                "v": ["News Item"]
+            },
+            {
+                "i": "path",
+                "o": "plone.app.querystring.operation.string.path",
+                "v": "/Plone/news"
+            }
+        ]
+        value, kwargs = self.deserialize('testQueryField', query_data)
+        self.assertTrue(isinstance(value, list), 'Not a <list>')
+        self.assertEqual(value, query_data)
+
     def test_reference_field_deserialization_returns_uid_in_list(self):
         value, kwargs = self.deserialize('testReferenceField',
                                          u'0fc0dac495034b869b3b90c9179499a9')

--- a/src/plone/restapi/tests/test_atfield_serializer.py
+++ b/src/plone/restapi/tests/test_atfield_serializer.py
@@ -119,6 +119,23 @@ class TestATFieldSerializer(unittest.TestCase):
         self.assertEqual(
             u'http://nohost/plone/doc1/@@images/testBlobImageField', value)
 
+    def test_query_field_serialization_returns_list(self):
+        query_data = [
+            {
+                "i": "portal_type",
+                "o": "plone.app.querystring.operation.selection.is",
+                "v": ["News Item"]
+            },
+            {
+                "i": "path",
+                "o": "plone.app.querystring.operation.string.path",
+                "v": "/Plone/news"
+            }
+        ]
+        value = self.serialize('testQueryField', query_data)
+        self.assertTrue(isinstance(value, list), 'Not a list')
+        self.assertEqual(value, query_data)
+
     def test_reference_field_serialization_returns_unicode(self):
         doc2 = self.portal[self.portal.invokeFactory(
             'ATTestDocument', id='doc2', title='Referenceable Document')]


### PR DESCRIPTION
Archetypes based plone.app.collection serializer was missing and thus the QueryField serializer for Archetypes too.