### PR TITLE
Use latest Plone versions in tests

### DIFF
--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -12,13 +12,7 @@ content-type: application/json
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
       "title": "Welcome to Plone"
-    }, 
-    {
-      "@id": "http://localhost:55001/plone/robot-test-folder", 
-      "@type": "Folder", 
-      "description": "", 
-      "title": "Test Folder"
     }
   ], 
-  "items_total": 2
+  "items_total": 1
 }

--- a/docs/source/_json/siteroot.json
+++ b/docs/source/_json/siteroot.json
@@ -9,18 +9,12 @@ content-type: application/json
   "@type": "Plone Site", 
   "items": [
     {
-      "@id": "http://localhost:55001/plone/robot-test-folder", 
-      "@type": "Folder", 
-      "description": "", 
-      "title": "Test Folder"
-    }, 
-    {
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
       "title": "Welcome to Plone"
     }
   ], 
-  "items_total": 2, 
+  "items_total": 1, 
   "parent": {}
 }

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -3,6 +3,3 @@ extends =
     base.cfg
     http://dist.plone.org/release/4.3.9/versions.cfg
     versions.cfg
-
-[versions]
-plone.app.contenttypes = 1.1b5

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -1,8 +1,5 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.0.2/versions.cfg
+    http://dist.plone.org/release/5.0.4/versions.cfg
     versions.cfg
-
-[versions]
-plone.app.contenttypes = 1.2.8

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -4,11 +4,16 @@
 # E1002: Use of super on an old style class
 
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
-from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import applyProfile
+from plone.app.testing import login
+from plone.app.testing import setRoles
 from plone.restapi.tests.dxtypes import INDEXES as DX_TYPES_INDEXES
 from plone.restapi.tests.helpers import add_catalog_indexes
 from urlparse import urljoin
@@ -41,6 +46,10 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
         z2.installProduct(app, 'plone.restapi')
 
     def setUpPloneSite(self, portal):
+        portal.acl_users.userFolderAddUser(
+            SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
+        login(portal, SITE_OWNER_NAME)
+        setRoles(portal, TEST_USER_ID, ['Manager'])
         applyProfile(portal, 'plone.restapi:default')
         applyProfile(portal, 'plone.restapi:testing')
         add_catalog_indexes(portal, DX_TYPES_INDEXES)

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -33,9 +33,6 @@ class TestBatchingDXBase(unittest.TestCase):
         self.api_session.headers.update({'Accept': 'application/json'})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
-        # Delete robot test folder to get a clean fixture
-        self.portal.manage_delObjects(['robot-test-folder'])
-
     def _create_doc(self, container, number):
         createContentInContainer(
             container, u'DXTestDocument',


### PR DESCRIPTION
- Update test setup to use Plone 5.0.4 and Plone 4.3.9 without downpinning p.a.contenttypes
- Create `SITE_OWNER_NAME` user in test layer (was previously done in p.a.contenttypes)
- Grant `Manager` role to `TEST_USER_ID` (was previously done in p.a.contenttypes)
