### PR TITLE
Reintroduce LazyCatalogResultSerializer with batching logic

### DIFF
--- a/src/plone/restapi/batching.py
+++ b/src/plone/restapi/batching.py
@@ -9,8 +9,7 @@ DEFAULT_BATCH_SIZE = 25
 
 class HypermediaBatch(object):
 
-    def __init__(self, context, request, results):
-        self.context = context
+    def __init__(self, request, results):
         self.request = request
 
         self.b_start = int(self.request.form.get('b_start', 0))

--- a/src/plone/restapi/serializer/atcollection.py
+++ b/src/plone/restapi/serializer/atcollection.py
@@ -17,7 +17,7 @@ class SerializeCollectionToJson(SerializeToJson):
     def __call__(self):
         collection_metadata = super(SerializeCollectionToJson, self).__call__()
         results = self.context.results(batch=False)
-        batch = HypermediaBatch(self.context, self.request, results)
+        batch = HypermediaBatch(self.request, results)
 
         results = collection_metadata
         results['@id'] = batch.canonical_url

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -76,7 +76,7 @@ class SerializeFolderToJson(SerializeToJson):
         catalog = getToolByName(self.context, 'portal_catalog')
         brains = catalog(query)
 
-        batch = HypermediaBatch(self.context, self.request, brains)
+        batch = HypermediaBatch(self.request, brains)
 
         result = folder_metadata
         result['@id'] = batch.canonical_url

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -17,7 +17,7 @@ class SerializeCollectionToJson(SerializeToJson):
     def __call__(self):
         collection_metadata = super(SerializeCollectionToJson, self).__call__()
         results = self.context.results(batch=False)
-        batch = HypermediaBatch(self.context, self.request, results)
+        batch = HypermediaBatch(self.request, results)
 
         results = collection_metadata
         results['@id'] = batch.canonical_url

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -55,5 +55,6 @@
     </configure>
 
     <adapter factory=".catalog.BrainSerializer" />
+    <adapter factory=".catalog.LazyCatalogResultSerializer" />
 
 </configure>

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -106,7 +106,7 @@ class SerializeFolderToJson(SerializeToJson):
         catalog = getToolByName(self.context, 'portal_catalog')
         brains = catalog(query)
 
-        batch = HypermediaBatch(self.context, self.request, brains)
+        batch = HypermediaBatch(self.request, brains)
 
         result = folder_metadata
         result['@id'] = batch.canonical_url

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -30,7 +30,7 @@ class SerializeSiteRootToJson(object):
         catalog = getToolByName(self.context, 'portal_catalog')
         brains = catalog(query)
 
-        batch = HypermediaBatch(self.context, self.request, brains)
+        batch = HypermediaBatch(self.request, brains)
 
         result = {
             # '@context': 'http://www.w3.org/ns/hydra/context.jsonld',

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -384,20 +384,20 @@ class TestHypermediaBatch(unittest.TestCase):
     def test_items_total(self):
         items = range(1, 26)
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         # items_total should be total number of items in the sequence
         self.assertEqual(
             25, batch.items_total)
 
     def test_default_batch_size(self):
         items = range(1, 27)
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertEqual(DEFAULT_BATCH_SIZE, len(list(batch)))
 
     def test_custom_batch_size(self):
         items = range(1, 26)
         self.request.form['b_size'] = 5
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         # Batch size should be customizable via request
         self.assertEqual(
             5, len(list(batch)))
@@ -405,7 +405,7 @@ class TestHypermediaBatch(unittest.TestCase):
     def test_default_batch_start(self):
         items = range(1, 26)
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         # Batch should start on first item by default
         self.assertEqual(
             range(1, 11), list(batch))
@@ -414,7 +414,7 @@ class TestHypermediaBatch(unittest.TestCase):
         items = range(1, 26)
         self.request.form['b_size'] = 10
         self.request.form['b_start'] = 5
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         # Batch start should be customizable via request
         self.assertEqual(
             range(6, 16), list(batch))
@@ -423,7 +423,7 @@ class TestHypermediaBatch(unittest.TestCase):
         items = range(1, 26)
         self.request.form['b_size'] = 5
         self.request.form['b_start'] = 5
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         # Should be able to combine custom batch start and size
         self.assertListEqual(
             range(6, 11), list(batch))
@@ -431,7 +431,7 @@ class TestHypermediaBatch(unittest.TestCase):
     def test_canonical_url(self):
         items = range(1, 26)
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertEqual('http://nohost', batch.canonical_url)
 
     def test_canonical_url_preserves_query_string_params(self):
@@ -439,7 +439,7 @@ class TestHypermediaBatch(unittest.TestCase):
 
         self.request.form['b_size'] = 10
         self.request['QUERY_STRING'] = 'one=1&two=2'
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
 
         parsed_url = urlparse(batch.canonical_url)
         qs_params = dict(parse_qsl(parsed_url.query))
@@ -453,7 +453,7 @@ class TestHypermediaBatch(unittest.TestCase):
 
         self.request.form['b_size'] = 10
         self.request['QUERY_STRING'] = 'one=1&b_size=10&b_start=20&two=2'
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
 
         parsed_url = urlparse(batch.canonical_url)
         qs_params = dict(parse_qsl(parsed_url.query))
@@ -466,7 +466,7 @@ class TestHypermediaBatch(unittest.TestCase):
         items = range(1, 26)
 
         self.request['QUERY_STRING'] = 'one=1&sort_on=path&two=2'
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
 
         parsed_url = urlparse(batch.canonical_url)
         qs_params = dict(parse_qsl(parsed_url.query))
@@ -481,7 +481,7 @@ class TestHypermediaBatch(unittest.TestCase):
         self.request.form['b_size'] = 10
         self.request['ACTUAL_URL'] = 'http://nohost'
         self.request['QUERY_STRING'] = 'b_size=10&b_start=20'
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertEqual(
             'http://nohost?b_size=10&b_start=20', batch.current_batch_url)
 
@@ -489,14 +489,14 @@ class TestHypermediaBatch(unittest.TestCase):
         items = range(1, 5)
 
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertEqual(None, batch.links)
 
     def test_first_link_contained(self):
         items = range(1, 26)
 
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertDictContainsSubset(
             {'first': 'http://nohost?b_start=0'}, batch.links)
 
@@ -504,7 +504,7 @@ class TestHypermediaBatch(unittest.TestCase):
         items = range(1, 26)
 
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertDictContainsSubset(
             {'last': 'http://nohost?b_start=20'}, batch.links)
 
@@ -512,7 +512,7 @@ class TestHypermediaBatch(unittest.TestCase):
         items = range(1, 26)
 
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertDictContainsSubset(
             {'next': 'http://nohost?b_start=10'}, batch.links)
 
@@ -522,7 +522,7 @@ class TestHypermediaBatch(unittest.TestCase):
         # Start on last page
         self.request.form['b_size'] = 10
         self.request.form['b_start'] = 20
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertSetEqual(
             set(['@id', 'first', 'prev', 'last']),
             set(batch.links.keys()))
@@ -533,7 +533,7 @@ class TestHypermediaBatch(unittest.TestCase):
         # Start on third page
         self.request.form['b_size'] = 10
         self.request.form['b_start'] = 20
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertDictContainsSubset(
             {'prev': 'http://nohost?b_start=10'}, batch.links)
 
@@ -541,7 +541,7 @@ class TestHypermediaBatch(unittest.TestCase):
         items = range(1, 26)
 
         self.request.form['b_size'] = 10
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertSetEqual(
             set(['@id', 'first', 'next', 'last']),
             set(batch.links.keys()))
@@ -555,7 +555,7 @@ class TestHypermediaBatch(unittest.TestCase):
 
         for pagenumber in range(3):
             self.request.form['b_start'] = pagenumber * size
-            batch = HypermediaBatch(self.portal, self.request, items)
+            batch = HypermediaBatch(self.request, items)
             items_from_all_batches.extend(list(batch))
 
         self.assertEqual(items, items_from_all_batches)
@@ -566,6 +566,6 @@ class TestHypermediaBatch(unittest.TestCase):
         # Start in the middle of what would otherwise be the first batch
         self.request.form['b_size'] = 10
         self.request.form['b_start'] = 5
-        batch = HypermediaBatch(self.portal, self.request, items)
+        batch = HypermediaBatch(self.request, items)
         self.assertEquals(
             'http://nohost?b_start=0', batch.links['prev'])

--- a/src/plone/restapi/tests/test_serializer_catalog.py
+++ b/src/plone/restapi/tests/test_serializer_catalog.py
@@ -35,6 +35,24 @@ class TestCatalogSerializers(unittest.TestCase):
         IMutableUUID(self.doc).set('77779ffa110e45afb1ba502f75f77777')
         self.doc.reindexObject()
 
+    def test_lazy_cat_serialization_empty_resultset(self):
+        # Force an empty resultset (Products.ZCatalog.Lazy.LazyCat)
+        lazy_cat = self.catalog(path='doesnt-exist')
+        results = getMultiAdapter((lazy_cat, self.request), ISerializeToJson)()
+
+        self.assertDictEqual(
+            {'@id': 'http://nohost', 'items': [], 'items_total': 0},
+            results)
+
+    def test_lazy_map_serialization(self):
+        # Test serialization of a Products.ZCatalog.Lazy.LazyMap
+        lazy_map = self.catalog()
+        results = getMultiAdapter((lazy_map, self.request), ISerializeToJson)()
+
+        self.assertDictContainsSubset({'@id': 'http://nohost'}, results)
+        self.assertDictContainsSubset({'items_total': 2}, results)
+        self.assertEqual(2, len(results['items']))
+
     def test_brain_summary_representation(self):
         lazy_map = self.catalog(path='/plone/my-folder/my-document')
         brain = lazy_map[0]


### PR DESCRIPTION
The `LazyCatalogResultSerializer` has been removed in #99 without a pressing need to do so ([see here](https://github.com/plone/plone.restapi/commit/d5e84ca1cfb52187ef33c975a4a7929e3c2edcf2#commitcomment-17748938)). Therefore we reintroduce it here and make it handle the batching logic that was previously left to the `SearchHandler`.

@tisto @sneridagh 