### PR TITLE
Make sure image scale URLs contain the actual field name.

### DIFF
--- a/src/plone/restapi/imaging.py
+++ b/src/plone/restapi/imaging.py
@@ -21,10 +21,13 @@ def get_scales(context, field, width, height):
     for name, scale_width, scale_height in get_scale_infos():
         bbox = scale_width, scale_height
         actual_width, actual_height = get_actual_scale((width, height), bbox)
+        url = u'{}/@@images/{}/{}'.format(absolute_url, field.__name__, name)
+
         scales[name] = {
-            u'download': u'{0}/@@images/image/{1}'.format(absolute_url, name),
+            u'download': url,
             u'width': actual_width,
             u'height': actual_height}
+
     return scales
 
 

--- a/src/plone/restapi/tests/test_atfield_serializer.py
+++ b/src/plone/restapi/tests/test_atfield_serializer.py
@@ -95,40 +95,41 @@ class TestATFieldSerializer(unittest.TestCase):
     def test_image_field_serialization_returns_dict(self):
         image_file = os.path.join(os.path.dirname(__file__), u'1024x768.gif')
         image_data = open(image_file, 'rb').read()
-        value = self.serialize('testImageField', image_data,
+        fn = 'testImageField'
+        value = self.serialize(fn, image_data,
                                filename='1024x768.gif', mimetype='image/gif')
         self.assertTrue(isinstance(value, dict), 'Not a <dict>')
 
         self.maxDiff = 99999
         obj_url = self.doc1.absolute_url()
-        download_url = u'{}/@@images/testImageField'.format(obj_url)
+        download_url = u'{}/@@images/{}'.format(obj_url, fn)
         scales = {
             u'listing': {
-                u'download': u'{}/@@images/image/listing'.format(obj_url),
+                u'download': u'{}/@@images/{}/listing'.format(obj_url, fn),
                 u'width': 16,
                 u'height': 12},
             u'icon': {
-                u'download': u'{}/@@images/image/icon'.format(obj_url),
+                u'download': u'{}/@@images/{}/icon'.format(obj_url, fn),
                 u'width': 32,
                 u'height': 24},
             u'tile': {
-                u'download': u'{}/@@images/image/tile'.format(obj_url),
+                u'download': u'{}/@@images/{}/tile'.format(obj_url, fn),
                 u'width': 64,
                 u'height': 48},
             u'thumb': {
-                u'download': u'{}/@@images/image/thumb'.format(obj_url),
+                u'download': u'{}/@@images/{}/thumb'.format(obj_url, fn),
                 u'width': 128,
                 u'height': 96},
             u'mini': {
-                u'download': u'{}/@@images/image/mini'.format(obj_url),
+                u'download': u'{}/@@images/{}/mini'.format(obj_url, fn),
                 u'width': 200,
                 u'height': 150},
             u'preview': {
-                u'download': u'{}/@@images/image/preview'.format(obj_url),
+                u'download': u'{}/@@images/{}/preview'.format(obj_url, fn),
                 u'width': 400,
                 u'height': 300},
             u'large': {
-                u'download': u'{}/@@images/image/large'.format(obj_url),
+                u'download': u'{}/@@images/{}/large'.format(obj_url, fn),
                 u'width': 768,
                 u'height': 576},
         }
@@ -170,39 +171,40 @@ class TestATFieldSerializer(unittest.TestCase):
     def test_blobimage_field_serialization_returns_dict(self):
         image_file = os.path.join(os.path.dirname(__file__), u'1024x768.gif')
         image_data = open(image_file, 'rb').read()
-        value = self.serialize('testBlobImageField', image_data,
+        fn = 'testBlobImageField'
+        value = self.serialize(fn, image_data,
                                filename='1024x768.gif', mimetype='image/gif')
         self.assertTrue(isinstance(value, dict), 'Not a <dict>')
 
         obj_url = self.doc1.absolute_url()
-        download_url = u'{}/@@images/testBlobImageField'.format(obj_url)
+        download_url = u'{}/@@images/{}'.format(obj_url, fn)
         scales = {
             u'listing': {
-                u'download': u'{}/@@images/image/listing'.format(obj_url),
+                u'download': u'{}/@@images/{}/listing'.format(obj_url, fn),
                 u'width': 16,
                 u'height': 12},
             u'icon': {
-                u'download': u'{}/@@images/image/icon'.format(obj_url),
+                u'download': u'{}/@@images/{}/icon'.format(obj_url, fn),
                 u'width': 32,
                 u'height': 24},
             u'tile': {
-                u'download': u'{}/@@images/image/tile'.format(obj_url),
+                u'download': u'{}/@@images/{}/tile'.format(obj_url, fn),
                 u'width': 64,
                 u'height': 48},
             u'thumb': {
-                u'download': u'{}/@@images/image/thumb'.format(obj_url),
+                u'download': u'{}/@@images/{}/thumb'.format(obj_url, fn),
                 u'width': 128,
                 u'height': 96},
             u'mini': {
-                u'download': u'{}/@@images/image/mini'.format(obj_url),
+                u'download': u'{}/@@images/{}/mini'.format(obj_url, fn),
                 u'width': 200,
                 u'height': 150},
             u'preview': {
-                u'download': u'{}/@@images/image/preview'.format(obj_url),
+                u'download': u'{}/@@images/{}/preview'.format(obj_url, fn),
                 u'width': 400,
                 u'height': 300},
             u'large': {
-                u'download': u'{}/@@images/image/large'.format(obj_url),
+                u'download': u'{}/@@images/{}/large'.format(obj_url, fn),
                 u'width': 768,
                 u'height': 576},
         }

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -172,41 +172,42 @@ class TestDexterityFieldSerializing(TestCase):
     def test_namedimage_field_serialization_returns_dict(self):
         image_file = os.path.join(os.path.dirname(__file__), u'1024x768.gif')
         image_data = open(image_file, 'rb').read()
+        fn = 'test_namedimage_field'
         value = self.serialize(
-            'test_namedimage_field',
+            fn,
             NamedImage(data=image_data, contentType=u'image/gif',
                        filename=u'1024x768.gif'))
         self.assertTrue(isinstance(value, dict), 'Not a <dict>')
 
         obj_url = self.doc1.absolute_url()
-        download_url = u'{}/@@images/test_namedimage_field'.format(obj_url)
+        download_url = u'{}/@@images/{}'.format(obj_url, fn)
         scales = {
             u'listing': {
-                u'download': u'{}/@@images/image/listing'.format(obj_url),
+                u'download': u'{}/@@images/{}/listing'.format(obj_url, fn),
                 u'width': 16,
                 u'height': 12},
             u'icon': {
-                u'download': u'{}/@@images/image/icon'.format(obj_url),
+                u'download': u'{}/@@images/{}/icon'.format(obj_url, fn),
                 u'width': 32,
                 u'height': 24},
             u'tile': {
-                u'download': u'{}/@@images/image/tile'.format(obj_url),
+                u'download': u'{}/@@images/{}/tile'.format(obj_url, fn),
                 u'width': 64,
                 u'height': 48},
             u'thumb': {
-                u'download': u'{}/@@images/image/thumb'.format(obj_url),
+                u'download': u'{}/@@images/{}/thumb'.format(obj_url, fn),
                 u'width': 128,
                 u'height': 96},
             u'mini': {
-                u'download': u'{}/@@images/image/mini'.format(obj_url),
+                u'download': u'{}/@@images/{}/mini'.format(obj_url, fn),
                 u'width': 200,
                 u'height': 150},
             u'preview': {
-                u'download': u'{}/@@images/image/preview'.format(obj_url),
+                u'download': u'{}/@@images/{}/preview'.format(obj_url, fn),
                 u'width': 400,
                 u'height': 300},
             u'large': {
-                u'download': u'{}/@@images/image/large'.format(obj_url),
+                u'download': u'{}/@@images/{}/large'.format(obj_url, fn),
                 u'width': 768,
                 u'height': 576},
         }
@@ -240,41 +241,42 @@ class TestDexterityFieldSerializing(TestCase):
     def test_namedblobimage_field_serialization_returns_dict(self):
         image_file = os.path.join(os.path.dirname(__file__), u'1024x768.gif')
         image_data = open(image_file, 'rb').read()
+        fn = 'test_namedblobimage_field'
         value = self.serialize(
-            'test_namedblobimage_field',
+            fn,
             NamedBlobImage(data=image_data, contentType=u'image/gif',
                            filename=u'1024x768.gif'))
         self.assertTrue(isinstance(value, dict), 'Not a <dict>')
 
         obj_url = self.doc1.absolute_url()
-        download_url = u'{}/@@images/test_namedblobimage_field'.format(obj_url)
+        download_url = u'{}/@@images/{}'.format(obj_url, fn)
         scales = {
             u'listing': {
-                u'download': u'{}/@@images/image/listing'.format(obj_url),
+                u'download': u'{}/@@images/{}/listing'.format(obj_url, fn),
                 u'width': 16,
                 u'height': 12},
             u'icon': {
-                u'download': u'{}/@@images/image/icon'.format(obj_url),
+                u'download': u'{}/@@images/{}/icon'.format(obj_url, fn),
                 u'width': 32,
                 u'height': 24},
             u'tile': {
-                u'download': u'{}/@@images/image/tile'.format(obj_url),
+                u'download': u'{}/@@images/{}/tile'.format(obj_url, fn),
                 u'width': 64,
                 u'height': 48},
             u'thumb': {
-                u'download': u'{}/@@images/image/thumb'.format(obj_url),
+                u'download': u'{}/@@images/{}/thumb'.format(obj_url, fn),
                 u'width': 128,
                 u'height': 96},
             u'mini': {
-                u'download': u'{}/@@images/image/mini'.format(obj_url),
+                u'download': u'{}/@@images/{}/mini'.format(obj_url, fn),
                 u'width': 200,
                 u'height': 150},
             u'preview': {
-                u'download': u'{}/@@images/image/preview'.format(obj_url),
+                u'download': u'{}/@@images/{}/preview'.format(obj_url, fn),
                 u'width': 400,
                 u'height': 300},
             u'large': {
-                u'download': u'{}/@@images/image/large'.format(obj_url),
+                u'download': u'{}/@@images/{}/large'.format(obj_url, fn),
                 u'width': 768,
                 u'height': 576},
         }


### PR DESCRIPTION
This fixes scale URLs for image field serialization.

The field name was [hardcoded as `image` in `get_scales()`](https://github.com/plone/plone.restapi/blob/275ff821aa44f2f6da869f74788e181251ea82ed/src/plone/restapi/imaging.py#L25), which is why the results were correct for the Plone stock image content type, but incorrect for custom types with image fields with different field names.

Fixes #123 