### PR TITLE
Tests: Use `freezegun` to freeze hard to control timestamps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Tests: Use `freezegun` to freeze hard to control timestamps in
+  response dumps used for documentation.
+  [lgraf]
+
 - Tests: Limit available languages to a small set to avoid excessive
   language lists in response dumps used for documentation.
   [lgraf]

--- a/docs/source/_json/workflow_get.json
+++ b/docs/source/_json/workflow_get.json
@@ -11,7 +11,7 @@ content-type: application/json
       "actor": "test_user_1_", 
       "comments": "", 
       "review_state": "private", 
-      "time": "2016-05-19T10:32:40+00:00"
+      "time": "2016-10-21T19:00:00+00:00"
     }
   ], 
   "transitions": [

--- a/docs/source/_json/workflow_post.json
+++ b/docs/source/_json/workflow_post.json
@@ -9,5 +9,5 @@ content-type: application/json
   "actor": "admin", 
   "comments": "", 
   "review_state": "published", 
-  "time": "2016-05-19T10:32:40+00:00"
+  "time": "2016-10-21T19:05:00+00:00"
 }

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name='plone.restapi',
           'plone.app.robotframework',
           'plone.app.testing [robot] >= 4.2.2',  # ROBOT_TEST_LEVEL added
           'requests',
+          'freezegun',
       ]},
       entry_points="""
       # -*- Entry points: -*-

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 from DateTime import DateTime
+from datetime import timedelta
+from freezegun import freeze_time
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -67,6 +69,9 @@ class TestTraversal(unittest.TestCase):
         self.portal = self.layer['portal']
         self.portal_url = self.portal.absolute_url()
 
+        self.time_freezer = freeze_time("2016-10-21 19:00:00")
+        self.frozen_time = self.time_freezer.start()
+
         self.api_session = RelativeSession(self.portal_url)
         self.api_session.headers.update({'Accept': 'application/json'})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
@@ -97,6 +102,9 @@ class TestTraversal(unittest.TestCase):
             'Authorization',
             'Basic %s:%s' % (SITE_OWNER_NAME, SITE_OWNER_PASSWORD,)
         )
+
+    def tearDown(self):
+        self.time_freezer.stop()
 
     def test_documentation_document(self):
         response = self.api_session.get(self.document.absolute_url())
@@ -273,6 +281,7 @@ class TestTraversal(unittest.TestCase):
         save_response_for_documentation('workflow_get.json', response)
 
     def test_documentation_workflow_transition(self):
+        self.frozen_time.tick(timedelta(minutes=5))
         response = self.api_session.post(
             '{}/@workflow/publish'.format(self.document.absolute_url()))
         save_response_for_documentation('workflow_post.json', response)


### PR DESCRIPTION
Use [`freezegun`](https://github.com/spulec/freezegun) to freeze hard to control timestamps in response dumps used for documentation.

This really just addresses the constantly changing timestamps in the `@workflow` response dumps. I considered rewriting all the other places where we set creation / modification dates manually, but I don't think it currently adds any value - so I suggest to just use `freezegun` to target the timestamps that would otherwise be hard to control.

@tisto
 
Closes #133 