### PR TITLE
Update types_document.json to be up-to-date with current implementation.

### DIFF
--- a/docs/source/_json/types_document.json
+++ b/docs/source/_json/types_document.json
@@ -61,13 +61,11 @@ content-type: application/json+schema
         "Yes", 
         "No"
       ], 
-      "required": false, 
       "title": "Allow discussion", 
       "type": "string"
     }, 
     "changeNote": {
       "description": "Enter a comment that describes the changes you made.", 
-      "required": false, 
       "title": "Change Note", 
       "type": "string"
     }, 
@@ -76,11 +74,9 @@ content-type: application/json+schema
       "description": "The names of people that have contributed to this item. Each contributor should be on a separate line.", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Contributors", 
       "type": "array", 
       "uniqueItems": true
@@ -90,11 +86,9 @@ content-type: application/json+schema
       "description": "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Creators", 
       "type": "array", 
       "uniqueItems": true
@@ -102,27 +96,23 @@ content-type: application/json+schema
     "description": {
       "description": "Used in item listings and search results.", 
       "minLength": 0, 
-      "required": false, 
       "title": "Summary", 
       "type": "string", 
       "widget": "textarea"
     }, 
     "effective": {
       "description": "If this date is in the future, the content will not show up in listings and searches until this date.", 
-      "required": false, 
       "title": "Publishing Date", 
       "type": "string"
     }, 
     "exclude_from_nav": {
       "default": false, 
       "description": "If selected, this item will not appear in the navigation tree", 
-      "required": true, 
       "title": "Exclude from navigation", 
       "type": "boolean"
     }, 
     "expires": {
       "description": "When this date is reached, the content will nolonger be visible in listings and searches.", 
-      "required": false, 
       "title": "Expiration Date", 
       "type": "string"
     }, 
@@ -159,7 +149,6 @@ content-type: application/json+schema
         "Espa\u00f1ol", 
         "Fran\u00e7ais"
       ], 
-      "required": false, 
       "title": "Language", 
       "type": "string"
     }, 
@@ -169,11 +158,9 @@ content-type: application/json+schema
       "description": "", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "Related", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Related Items", 
       "type": "array", 
       "uniqueItems": true
@@ -181,7 +168,6 @@ content-type: application/json+schema
     "rights": {
       "description": "Copyright statement or other rights information on this item.", 
       "minLength": 0, 
-      "required": false, 
       "title": "Rights", 
       "type": "string", 
       "widget": "textarea"
@@ -191,31 +177,26 @@ content-type: application/json+schema
       "description": "Tags are commonly used for ad-hoc organization of content.", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Tags", 
       "type": "array", 
       "uniqueItems": true
     }, 
     "table_of_contents": {
       "description": "If selected, this will show a table of contents at the top of the page.", 
-      "required": false, 
       "title": "Table of contents", 
       "type": "boolean"
     }, 
     "text": {
       "description": "", 
-      "required": false, 
       "title": "Text", 
       "type": "string", 
       "widget": "richtext"
     }, 
     "title": {
       "description": "", 
-      "required": true, 
       "title": "Title", 
       "type": "string"
     }


### PR DESCRIPTION
The JSON dump in `types_document.json` is out of sync with the current implementation since merging #131.

As far as I can tell, what happened here is
- `required` (on the field level) was introduced in #129 (9384a5a0)
- reverted in #130 (5820fce6)
- and #131 wasn't up-to-date with `master` when producing and checking in the output from `bin/test -t test_documentation`

*(No changelog entry on purpose, because this changeset should have been part of commits that are already merged)* 

@tisto @ebrehault 