### PR TITLE
Fail tests on uncommitted changes to docs/source/_json/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 script:
   - bin/code-analysis
   - bin/test
+  - bin/test-no-uncommitted-doc-changes
 after_success:
   - bin/test-coverage
   - bin/createcoverage

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Fail tests on uncommitted changes to docs/source/_json/
+  [lgraf]
+
 - Implements navigation and breadcrumbs components (copied from barcelona-mocks)
   [ebrehault]
 

--- a/base.cfg
+++ b/base.cfg
@@ -5,6 +5,7 @@ parts =
     test
     coverage
     test-coverage
+    test-no-uncommitted-doc-changes
     code-analysis
     releaser
     sphinxbuilder
@@ -48,6 +49,13 @@ input = inline:
     # when test coverage is below 100%.
 output = ${buildout:directory}/bin/test-coverage
 mode = 755
+
+[test-no-uncommitted-doc-changes]
+recipe = collective.recipe.template
+input = test-no-uncommitted-doc-changes.in
+output = bin/test-no-uncommitted-doc-changes
+mode = 755
+
 
 [code-analysis]
 recipe = plone.recipe.codeanalysis

--- a/docs/source/_json/types_document.json
+++ b/docs/source/_json/types_document.json
@@ -61,13 +61,11 @@ content-type: application/json+schema
         "Yes", 
         "No"
       ], 
-      "required": false, 
       "title": "Allow discussion", 
       "type": "string"
     }, 
     "changeNote": {
       "description": "Enter a comment that describes the changes you made.", 
-      "required": false, 
       "title": "Change Note", 
       "type": "string"
     }, 
@@ -76,11 +74,9 @@ content-type: application/json+schema
       "description": "The names of people that have contributed to this item. Each contributor should be on a separate line.", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Contributors", 
       "type": "array", 
       "uniqueItems": true
@@ -90,11 +86,9 @@ content-type: application/json+schema
       "description": "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Creators", 
       "type": "array", 
       "uniqueItems": true
@@ -102,27 +96,23 @@ content-type: application/json+schema
     "description": {
       "description": "Used in item listings and search results.", 
       "minLength": 0, 
-      "required": false, 
       "title": "Summary", 
       "type": "string", 
       "widget": "textarea"
     }, 
     "effective": {
       "description": "If this date is in the future, the content will not show up in listings and searches until this date.", 
-      "required": false, 
       "title": "Publishing Date", 
       "type": "string"
     }, 
     "exclude_from_nav": {
       "default": false, 
       "description": "If selected, this item will not appear in the navigation tree", 
-      "required": true, 
       "title": "Exclude from navigation", 
       "type": "boolean"
     }, 
     "expires": {
       "description": "When this date is reached, the content will nolonger be visible in listings and searches.", 
-      "required": false, 
       "title": "Expiration Date", 
       "type": "string"
     }, 
@@ -159,7 +149,6 @@ content-type: application/json+schema
         "Espa\u00f1ol", 
         "Fran\u00e7ais"
       ], 
-      "required": false, 
       "title": "Language", 
       "type": "string"
     }, 
@@ -169,11 +158,9 @@ content-type: application/json+schema
       "description": "", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "Related", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Related Items", 
       "type": "array", 
       "uniqueItems": true
@@ -181,7 +168,6 @@ content-type: application/json+schema
     "rights": {
       "description": "Copyright statement or other rights information on this item.", 
       "minLength": 0, 
-      "required": false, 
       "title": "Rights", 
       "type": "string", 
       "widget": "textarea"
@@ -191,31 +177,26 @@ content-type: application/json+schema
       "description": "Tags are commonly used for ad-hoc organization of content.", 
       "items": {
         "description": "", 
-        "required": true, 
         "title": "", 
         "type": "string"
       }, 
-      "required": false, 
       "title": "Tags", 
       "type": "array", 
       "uniqueItems": true
     }, 
     "table_of_contents": {
       "description": "If selected, this will show a table of contents at the top of the page.", 
-      "required": false, 
       "title": "Table of contents", 
       "type": "boolean"
     }, 
     "text": {
       "description": "", 
-      "required": false, 
       "title": "Text", 
       "type": "string", 
       "widget": "richtext"
     }, 
     "title": {
       "description": "", 
-      "required": true, 
       "title": "Title", 
       "type": "string"
     }

--- a/test-no-uncommitted-doc-changes.in
+++ b/test-no-uncommitted-doc-changes.in
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# CI test that should fail if there are uncommitted changes to the directory
+# containing the request/response dumps
+#
+# (To be executed after running tests in test_documentation.py)
+
+DUMPS_DIR="docs/source/_json/"
+
+function red {
+    RED=$(tput setaf 1)
+    RESET=$(tput sgr0)
+    echo "$RED $1 $RESET"
+}
+
+if [ "$PLONE_VERSION" = "5.0.x" ]; then
+    # request/response dumps have known differences for Plone 5
+    # => skip, we can't have the Plone 5 build fail because of those
+    echo "Skipping checks for undocumented changes for Plone 5.0.x"
+    exit 0
+fi
+
+changes=$(git diff --exit-code $DUMPS_DIR)
+if [ $? -ne 0 ]; then
+    red "ERROR: There are modified files in $DUMPS_DIR after running test_documentation.py!"
+    red
+    red "That means your changeset introduced API changes that cause a different behavior"
+    red "than what is currently documented, and docs probably need to be updated."
+    red
+    red "Please review the changes below, and"
+    red "1) verify that those behavior changes are actually *intended*"
+    red "2) if they are, add and commit them using git and include them with your changeset"
+    red
+
+    git diff --exit-code $DUMPS_DIR
+    exit 1
+fi


### PR DESCRIPTION
⚠️  Based on #138 to not have tests for this one fail, merge that one first ⚠️ 

This adds a CI test that will fail if there are uncommitted changes (dirty working dir) to any of the files in `docs/source/_json` after running the tests from `test_documentation.py`.

The purpose of this is to stop having the dynamically produced request/response dumps that are included in the docs get out of sync with the actual implementation. This addresses one of the points mentioned in #137.

Implementation:
- A new script `bin/test-no-uncommitted-doc-changes` that fails if there are modified files in `docs/source/_json`, and provides a message including the diff of changed files
- An entry in `.travis.yml` that calls this script *after* `bin/test` has been run
- A condition in `bin/test-no-uncommitted-doc-changes` that skips the check for the Plone 5 build on Travis

See this Travis build log for an example of how a test failure will look:
https://travis-ci.org/plone/plone.restapi/jobs/150433706

@tisto @bloodbare @ebrehault 