### PR TITLE
Disable automatic CSRF protection for @login and @login-renew endpoints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Disable automatic CSRF protection for @login and @login-renew endpoints:
+  If persisting tokens server-side is enabled, those requests need to be allowed
+  to cause DB writes.
+  [lgraf]
+
 - Fixed parameter 'data' to JSON format in JWT Authentication documentation
   [lccruz]
 

--- a/src/plone/restapi/services/auth/login.py
+++ b/src/plone/restapi/services/auth/login.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from Products.CMFCore.utils import getToolByName
-from Products.PluggableAuthService.interfaces.plugins import (
-    IAuthenticationPlugin)
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
+from Products.CMFCore.utils import getToolByName
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
+from zope.interface import alsoProvides
+
+import plone.protect.interfaces
 
 
 class Login(Service):
@@ -33,6 +35,11 @@ class Login(Service):
             return dict(error=dict(
                 type='Missing credentials',
                 message='Login and password must be provided in body.'))
+
+        # Disable CSRF protection
+        if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
+            alsoProvides(self.request,
+                         plone.protect.interfaces.IDisableCSRFProtection)
 
         userid = data['login'].encode('utf8')
         password = data['password'].encode('utf8')

--- a/src/plone/restapi/services/auth/renew.py
+++ b/src/plone/restapi/services/auth/renew.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.utils import getToolByName
-from Products.PluggableAuthService.interfaces.plugins import (
-    IAuthenticationPlugin)
 from plone.restapi.services import Service
+from Products.CMFCore.utils import getToolByName
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
+from zope.interface import alsoProvides
+
+import plone.protect.interfaces
 
 
 class Renew(Service):
@@ -23,6 +25,11 @@ class Renew(Service):
             return dict(error=dict(
                 type='Renew failed',
                 message='JWT authentication plugin not installed.'))
+
+        # Disable CSRF protection
+        if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
+            alsoProvides(self.request,
+                         plone.protect.interfaces.IDisableCSRFProtection)
 
         mtool = getToolByName(self.context, 'portal_membership')
         user = mtool.getAuthenticatedMember()


### PR DESCRIPTION
This disables automatic CSRF protection for the `@login` and `@login-renew` endpoints.

If persisting tokens server-side ("Store Tokens" option on the `jwt_auth` Plugin) is enabled, those requests need to be allowed to cause DB writes, otherwise the transaction might be aborted by `plone.protect`.

**Steps to reproduce**:

- Use `plone.protect` >= 3.0 (and `plone4.csrffixes` if on Plone 4.3)
- Create a fresh Plone Site and install the `plone.restapi:default` profile
- Enable "Store Tokens" in the `acl_users/jwt_auth` Plugin
- Do a `POST` to `@login` while already authenticated (`plone.protect` doesn't (need to) protect requests from Anonymous users)

**Security Considerations**

I've chosen to blanket whitelist those requests using the `IDisableCSRFProtection` request interface. Ideally, it would be better to simply whitelist the specific DB writes that are allowed to occur (storing the tokens) using [`plone.protect.utils.safeWrite()`](https://github.com/plone/plone.protect/blob/75634b413d7fe26e55b2859c25dc16269e8398ff/plone/protect/utils.py#L115).

However, that helper function did not always exist at that location, or even at all across all `plone.protect 3.0.x` versions. So we'd have to use some conditional imports and fallbacks to make sure we don't break `plone.restapi` with some older versions of `plone.protect 3.0.x` - that's why I chose the simpler approach of just whitelisting the entire requests.

From what I can tell, that shouldn't be a security issue:
- For `@login`, we require the user to provide a JSON body with their credentials. I can't see a way how an attacker could force a request upon the user that includes those credentials.
- For `@login-renew`, we require the existing token in an `Authorization: Bearer ...` header. A browser won't send that by itself either.

@tisto

/cc @buchi (*currently on holiday, we've previously discussed this*)
 
 