### PR TITLE
Fixed parameter 'data' to JSON format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Fixed parameter 'data' to JSON format in JWT Authentication documentation
+  [lccruz]
+
 - Fail tests on uncommitted changes to docs/source/_json/
   [lgraf]
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -69,7 +69,7 @@ endpoint.
 
     requests.post('http://localhost:8080/Plone/@login',
                   headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
-                  data={'login': 'admin', 'password': 'admin'})
+                  data='{"login": "admin", "password": "admin"}')
 
 
 The server responds with a JSON object containing the token.


### PR DESCRIPTION
Fixed parameter "data" to JSON format

Before commit:

In [137]: requests.post('http://localhost:8080/Plone/@login',
   .....:               headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
   .....:               data={'login': 'admin', 'password': 'admin'})
Out[137]: <Response [500]>

2016-08-10 15:41:06 ERROR Zope.SiteErrorLog 1470854466.590.500058837151 http://localhost:8080/Plone/@login
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.rest.service, line 20, in __call__
  Module plone.restapi.services, line 15, in render
  Module plone.restapi.services.auth.login, line 16, in reply
  Module plone.restapi.deserializer, line 11, in json_body
DeserializationError: 'No JSON object could be decoded'


After commit:

In [138]: requests.post('http://localhost:8080/Plone/@login',
              headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
              data='{"login": "admin", "password": "admin"}')
Out[138]: <Response [200]>