### PR TITLE
Fix bug where disabling the "Use Keyring" flag wasn't persisted in jwt_auth plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.0a3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bugfixes:
+
+- Fix bug where disabling the "Use Keyring" flag wasn't persisted in jwt_auth plugin.
+  [lgraf]
 
 
 1.0a2 (2016-08-20)

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -137,7 +137,7 @@ class JWTAuthenticationPlugin(BasePlugin):
 
         self.token_timeout = int(REQUEST.form.get('token_timeout',
                                                   self.token_timeout))
-        self.use_keyring = bool(REQUEST.form.get('use_keyring', True))
+        self.use_keyring = bool(REQUEST.form.get('use_keyring', False))
         self.store_tokens = bool(REQUEST.form.get('store_tokens', False))
         if self.store_tokens and self._tokens is None:
             self._tokens = OOBTree()


### PR DESCRIPTION
An unchecked `<input type="checkbox" />` will be omitted entirely from the request if unchecked - so an approach like `bool(REQUEST.form.get('field', True))` will end up always being `True`.

@tisto