### PR TITLE
do not break if jwt.ExpiredSignatureError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.0a6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- When token expires, PAS plugin should return an empty credential.
+  [ebrehault]
 
 
 1.0a5 (2016-10-07)

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -156,6 +156,8 @@ class JWTAuthenticationPlugin(BasePlugin):
                     payload = jwt.decode(token, secret)
                 except jwt.DecodeError:
                     pass
+                except jwt.ExpiredSignatureError:
+                    pass
                 else:
                     break
         else:


### PR DESCRIPTION
When token expires, PAS plugin should return an empty credential