### PR TITLE
Introduce dedicated permission to use REST API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 1.0a6 (unreleased)
 ------------------
 
+New Features:
+
+- Introduce dedicated permission required to use REST API at all
+  (assigned to everybody by default).
+  [lgraf]
+
+Bugfixes:
+
 - When token expires, PAS plugin should return an empty credential.
   [ebrehault]
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -119,3 +119,23 @@ If invalidation succeeds, the server responds with an empty 204 reponse:
 
 .. literalinclude:: _json/logout.json
    :language: js
+
+
+Permissions
+-----------
+
+In order for a user to use the REST API, the ``plone.restapi: Use REST API``
+permission is required.
+
+By default, installing the ``plone.restapi:default`` profile will assign this
+permission to the ``Anonymous`` role, so everybody is allowed to use the REST
+API by default.
+
+If you wish to control in more detail which roles are allowed to use the REST
+API, please assign this permission accordingly.
+
+As well as the ``plone.restapi: Use REST API`` permission some of the common
+Plone permissions are also required, depending on the particular service.
+For example, retrieving a resource using GET will require ``View``, adding an
+object using POST will require ``Add portal content``, and so on.
+

--- a/src/plone/restapi/configure.zcml
+++ b/src/plone/restapi/configure.zcml
@@ -9,6 +9,8 @@
 
   <five:registerPackage package="." initialize=".initialize" />
 
+  <include file="permissions.zcml" />
+
   <genericsetup:registerProfile
       name="default"
       title="plone.restapi"

--- a/src/plone/restapi/configure.zcml
+++ b/src/plone/restapi/configure.zcml
@@ -51,4 +51,6 @@
   <include package=".types" />
   <include package=".search" />
 
+  <include package=".upgrades" />
+
 </configure>

--- a/src/plone/restapi/permissions.py
+++ b/src/plone/restapi/permissions.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+# # Required to use the REST API at all, in addition to service specific
+# permissions. Granted to Anonymous (i.e. everyone) by default via rolemap.xml
+
+UseRESTAPI = 'plone.restapi: Use REST API'

--- a/src/plone/restapi/permissions.zcml
+++ b/src/plone/restapi/permissions.zcml
@@ -1,0 +1,10 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="plone.restapi">
+
+  <permission
+      id="plone.restapi.UseRESTAPI"
+      title="plone.restapi: Use REST API"
+      />
+
+</configure>

--- a/src/plone/restapi/profiles/default/metadata.xml
+++ b/src/plone/restapi/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>0001</version>
+  <version>0002</version>
 </metadata>

--- a/src/plone/restapi/profiles/default/rolemap.xml
+++ b/src/plone/restapi/profiles/default/rolemap.xml
@@ -1,0 +1,7 @@
+<rolemap>
+  <permissions>
+    <permission name="plone.restapi: Use REST API" acquire="True">
+      <role name="Anonymous"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/src/plone/restapi/services/__init__.py
+++ b/src/plone/restapi/services/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from AccessControl.SecurityManagement import getSecurityManager
 from plone.rest import Service as RestService
+from plone.restapi.permissions import UseRESTAPI
+from zExceptions import Unauthorized
 
 import json
 
@@ -12,10 +15,16 @@ class Service(RestService):
     content_type = 'application/json'
 
     def render(self):
+        self._check_permission()
         content = self.reply()
         if content is not _no_content_marker:
             self.request.response.setHeader("Content-Type", self.content_type)
             return json.dumps(content, indent=2, sort_keys=True)
+
+    def _check_permission(self):
+        sm = getSecurityManager()
+        if not sm.checkPermission(UseRESTAPI, self):
+            raise Unauthorized('Missing %r permission' % UseRESTAPI)
 
     def reply(self):
         """Process the request and return a JSON serializable data structure or

--- a/src/plone/restapi/upgrades/configure.zcml
+++ b/src/plone/restapi/upgrades/configure.zcml
@@ -1,0 +1,25 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="plone.restapi">
+
+    <!-- 0001 -> 0002 -->
+    <genericsetup:upgradeStep
+        title="Assign 'plone.restapi: Use REST API' permission to Anonymous"
+        description=""
+        source="0001"
+        destination="0002"
+        handler="plone.restapi.upgrades.to0002.assign_use_api_permission"
+        profile="plone.restapi:default"
+        />
+
+    <genericsetup:registerProfile
+        name="0002"
+        title="plone.restapi.upgrades.0002"
+        description=""
+        directory="profiles/0002"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+</configure>

--- a/src/plone/restapi/upgrades/profiles/0002/rolemap.xml
+++ b/src/plone/restapi/upgrades/profiles/0002/rolemap.xml
@@ -1,0 +1,7 @@
+<rolemap>
+  <permissions>
+    <permission name="plone.restapi: Use REST API" acquire="True">
+      <role name="Anonymous"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/src/plone/restapi/upgrades/to0002.py
+++ b/src/plone/restapi/upgrades/to0002.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+def assign_use_api_permission(setup_context):
+    """Assign the 'plone.restapi: Use REST API' permission to Anonymous.
+    """
+    setup_context.runImportStepFromProfile(
+        'profile-plone.restapi.upgrades:0002',
+        'rolemap',
+        run_dependencies=False,
+        purge_old=False)


### PR DESCRIPTION
This will introduce a **dedicated permission to use the REST API**:

The permission `plone.restapi: Use REST API` will be required to use the REST API at all, in addition to any service-specific permissions that are required.

This permission will be granted to `Anonymous` (i.e. everybody) by default via `rolemap.xml`. This allows to restrict API access to certain roles, e.g. in order to only allow API access to service users and/or Managers.

@tisto @buchi
/cc @vangheem