### PR TITLE
Docs: Remove duplicate reference to 'types.rst' from ToC.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,7 +40,6 @@ Appendix, Indices and tables
 
 .. toctree::
 
-   Available content types <types>
    http-status-codes
    glossary
 


### PR DESCRIPTION
Remove duplicate reference to `'types.rst'` from ToC.

(See screenshot for what the current issue is).

<img width="315" alt="screen shot 2016-10-23 at 12 41 10" src="https://cloud.githubusercontent.com/assets/405124/19627829/23f6bcde-991e-11e6-8afc-c9702101186d.png">
