### PR TITLE
Fix queries to ensure ordering of container items by getObjectPositionInParent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.0a9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bugfixes:
+
+- Fix queries to ensure ordering of container items by getObjectPositionInParent.
+  [lgraf]
 
 
 1.0a8 (2017-01-12)

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -66,8 +66,8 @@ class SerializeFolderToJson(SerializeToJson):
 
     def _build_query(self):
         path = '/'.join(self.context.getPhysicalPath())
-        query = {'path': {'depth': 1, 'query': path,
-                 'sort_on': 'getObjPositionInParent'}}
+        query = {'path': {'depth': 1, 'query': path},
+                 'sort_on': 'getObjPositionInParent'}
         return query
 
     def __call__(self):

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -95,8 +95,8 @@ class SerializeFolderToJson(SerializeToJson):
 
     def _build_query(self):
         path = '/'.join(self.context.getPhysicalPath())
-        query = {'path': {'depth': 1, 'query': path,
-                 'sort_on': 'getObjPositionInParent'}}
+        query = {'path': {'depth': 1, 'query': path},
+                 'sort_on': 'getObjPositionInParent'}
         return query
 
     def __call__(self):

--- a/src/plone/restapi/tests/test_atcontent_serializer.py
+++ b/src/plone/restapi/tests/test_atcontent_serializer.py
@@ -110,3 +110,32 @@ class TestATContentSerializer(unittest.TestCase):
             'description': '',
             'title': u'A Document'},
             obj['items'][1])
+
+    def test_serializer_orders_folder_items_by_get_object_position_in_parent(self):  # noqa
+        folder = self.portal[self.portal.invokeFactory(
+            'ATTestFolder', id='folder', title='Test Folder')]
+        folder.invokeFactory('ATTestDocument', id='doc1', title='A Document')
+        folder.invokeFactory('ATTestDocument', id='doc2', title='Second doc')
+
+        # Change GOPIP (getObjectPositionInParent) based order
+        folder.moveObjectsUp('doc2')
+
+        obj = self.serialize(folder)
+
+        self.assertIn('items', obj)
+        self.assertEqual(
+            obj['items'],
+            [
+                {
+                    '@id': 'http://nohost/plone/folder/doc2',
+                    '@type': 'ATTestDocument',
+                    'description': '',
+                    'title': u'Second doc',
+                },
+                {
+                    '@id': 'http://nohost/plone/folder/doc1',
+                    '@type': 'ATTestDocument',
+                    'description': '',
+                    'title': u'A Document',
+                },
+            ])

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -135,6 +135,39 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
             ]
         )
 
+    def test_serialize_folder_orders_items_by_get_object_position_in_parent(self):  # noqa
+        self.portal.invokeFactory('Folder', id='folder1', title='Folder 1')
+        self.portal.folder1.invokeFactory('Document', id='doc1')
+        self.portal.folder1.doc1.title = u'Document 1'
+        self.portal.folder1.doc1.description = u'This is a document'
+        self.portal.folder1.doc1.reindexObject()
+
+        self.portal.folder1.invokeFactory('Document', id='doc2')
+        self.portal.folder1.doc2.title = u'Document 2'
+        self.portal.folder1.doc2.description = u'Second doc'
+        self.portal.folder1.doc2.reindexObject()
+
+        # Change GOPIP (getObjectPositionInParent) based order
+        self.portal.folder1.moveObjectsUp('doc2')
+
+        self.assertEqual(
+            self.serialize(self.portal.folder1)['items'],
+            [
+                {
+                    u'@id': u'http://nohost/plone/folder1/doc2',
+                    u'@type': u'Document',
+                    u'description': u'Second doc',
+                    u'title': u'Document 2'
+                },
+                {
+                    u'@id': u'http://nohost/plone/folder1/doc1',
+                    u'@type': u'Document',
+                    u'description': u'This is a document',
+                    u'title': u'Document 1'
+                }
+            ]
+        )
+
     def test_serialize_returns_parent(self):
         self.assertTrue(
             self.serialize(self.portal.doc1).get('parent'),
@@ -175,6 +208,28 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
         self.assertEqual(
             self.serialize(self.portal)['@type'],
             u'Plone Site'
+        )
+
+    def test_serialize_site_orders_items_by_get_object_position_in_parent(self):  # noqa
+        # Change GOPIP (getObjectPositionInParent) based order
+        self.portal.moveObjectsUp('dxdoc')
+
+        self.assertEqual(
+            self.serialize(self.portal)['items'],
+            [
+                {
+                    u'@id': u'http://nohost/plone/dxdoc',
+                    u'@type': u'DXTestDocument',
+                    u'description': u'',
+                    u'title': u'DX Test Document'
+                },
+                {
+                    u'@id': u'http://nohost/plone/doc1',
+                    u'@type': u'Document',
+                    u'description': u'',
+                    u'title': u'Document 1'
+                },
+            ]
         )
 
     def test_serialize_ignores_underscore_values(self):


### PR DESCRIPTION
Fixes the `sort_on` parameter in serializer queries to ensure container items are always ordered by `getObjectPositionInParent`.

Includes regression tests for **AT folders** and **DX folders** (whose queries were incorrect) as well as the **Plone Site** (which was fine).

Closes #182 