### PR TITLE
Crud Documentation: Update examples

### DIFF
--- a/docs/source/crud.rst
+++ b/docs/source/crud.rst
@@ -45,7 +45,7 @@ If we want to create a new document within an existing folder, we send a POST re
 
   .. code-block:: python-requests
 
-    requests.post('http://localhost:8080/Plone/folder', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'@type': 'Document'})
+    requests.post('http://localhost:8080/Plone/folder', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'@type': 'Document', 'title': 'My Document'})
 
 By setting the 'Accept' header, we tell the server that we would like to receive the response in the 'application/json' representation format.
 
@@ -229,13 +229,12 @@ PATCH allows to provide just a subset of the resource (the values you actually w
     Content-Type: application/json
 
     {
-        '@type': 'Document',
         'title': 'My New Document Title',
     }
 
   .. code-block:: curl
 
-    curl -i -H "Accept: application/json" -H "Content-type: application/json" --data-raw '{title": "My Document"}' --user admin:admin -X PATCH http://localhost:8080/Plone/folder/my-document
+    curl -i -H "Accept: application/json" -H "Content-type: application/json" --data-raw '{title": "My New Document Title"}' --user admin:admin -X PATCH http://localhost:8080/Plone/folder/my-document
 
   .. code-block:: httpie
 

--- a/docs/source/crud.rst
+++ b/docs/source/crud.rst
@@ -45,7 +45,7 @@ If we want to create a new document within an existing folder, we send a POST re
 
   .. code-block:: python-requests
 
-    requests.post('http://localhost:8080/Plone/folder', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, params={'@type': 'Document'})
+    requests.post('http://localhost:8080/Plone/folder', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'@type': 'Document'})
 
 By setting the 'Accept' header, we tell the server that we would like to receive the response in the 'application/json' representation format.
 
@@ -243,7 +243,7 @@ PATCH allows to provide just a subset of the resource (the values you actually w
 
   .. code-block:: python-requests
 
-    requests.patch('http://localhost:8080/Plone/folder/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, data={'title': 'My New Document Title'})
+    requests.patch('http://localhost:8080/Plone/folder/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'title': 'My New Document Title'})
 
 
 Successful Response (204 No Content)
@@ -290,7 +290,7 @@ To replace an existing resource we send a PUT request to the server:
 
   .. code-block:: python-requests
 
-    requests.put('http://localhost:8080/Plone/folder/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, data={'title': 'My New Document Title', ...})
+    requests.put('http://localhost:8080/Plone/folder/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'title': 'My New Document Title', ...})
 
 In accordance with the HTTP specification, a successful PUT will not create a new resource or produce a new URL.
 


### PR DESCRIPTION
1) Use `json=` for requests library.
   -> `data=` sends multipart/form-data encoded data
   -> `params=` sends params as URL params
   ->  `json=` encodes the dict as json and sends that as payload
That means for non-GET-requests we usually want `json=`, for GET-requests we want `params=` (e.g. for search filters).

2) Sync `POST` and `PATCH` examples:
Make sure that the `http-request`, `curl`, `httpie` and `python-requests`  examples send the same data in the examples.
I have not changed `PUT`, although it is not in sync, because it is not yet implemented and I do not know which example is the correct one.

---

Is a changelog required for such changes? It does not change any behavior.