### PR TITLE
Include mode attribute in json schema / types endpoint.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0a9 (unreleased)
 ------------------
 
+New Features:
+
+- Make @types endpoint include a 'mode' attribute. This fixes https://github.com/plone/plone.restapi/issues/198.
+  [timo]
+
 Bugfixes:
 
 - Fix queries to ensure ordering of container items by getObjectPositionInParent.

--- a/src/plone/restapi/tests/test_types.py
+++ b/src/plone/restapi/tests/test_types.py
@@ -7,6 +7,7 @@ from zope.component import getMultiAdapter
 from zope import schema
 from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
 from plone.app.textfield import RichText
+from plone.autoform import directives as form
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from plone.supermodel import model
 from Products.CMFCore.utils import getToolByName
@@ -26,6 +27,12 @@ class IDummySchema(model.Schema):
 
     field2 = schema.TextLine(
         title=u"Bar",
+        description=u"",
+    )
+
+    form.mode(secret='hidden')
+    secret = schema.TextLine(
+        title=u"Secret",
         description=u"",
     )
 
@@ -50,6 +57,11 @@ class TestJsonSchemaUtils(TestCase):
                 'description': u'',
                 'type': 'string'
             },
+            'secret': {
+                'title': u'Secret',
+                'description': u'',
+                'type': 'string',
+            }
         }
         self.assertEqual(info, expected)
 
@@ -67,7 +79,11 @@ class TestJsonSchemaUtils(TestCase):
         self.assertIn('title', jsonschema['fieldsets'][0]['fields'])
 
         jsonschema = get_jsonschema_for_fti(
-            ttool['Document'], portal, request, excluded_fields=['title'])
+            ttool['Document'],
+            portal,
+            request,
+            excluded_fields=['title']
+        )
         self.assertNotIn('title', jsonschema['properties'].keys())
 
     def test_get_jsonschema_for_portal_type(self):
@@ -83,7 +99,11 @@ class TestJsonSchemaUtils(TestCase):
         self.assertIn('title', jsonschema['fieldsets'][0]['fields'])
 
         jsonschema = get_jsonschema_for_portal_type(
-            'Document', portal, request, excluded_fields=['title'])
+            'Document',
+            portal,
+            request,
+            excluded_fields=['title']
+        )
         self.assertNotIn('title', jsonschema['properties'].keys())
 
 
@@ -363,6 +383,11 @@ class TestJsonSchemaProviders(TestCase):
                     'description': u'',
                     'type': 'string'
                 },
+                'secret': {
+                    'title': u'Secret',
+                    'description': u'',
+                    'type': 'string'
+                }
             }
         }
         self.assertEqual(jsonschema, expected)

--- a/src/plone/restapi/types/utils.py
+++ b/src/plone/restapi/types/utils.py
@@ -103,6 +103,8 @@ def get_fields_from_schema(schema, context, request, prefix='',
             fields_info[fieldname] = adapter.get_schema()
         if fieldname in hidden_fields.keys():
             fields_info[fieldname]['mode'] = hidden_fields[fieldname]
+        else:
+            fields_info[fieldname]['mode'] = u'input'
 
     return fields_info
 

--- a/src/plone/restapi/types/utils.py
+++ b/src/plone/restapi/types/utils.py
@@ -9,6 +9,7 @@ from zope.i18n import translate
 from zope.schema import getFieldsInOrder
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.autoform.interfaces import MODES_KEY
+from plone.autoform.utils import mergedTaggedValuesForForm
 from plone.behavior.interfaces import IBehavior
 from plone.supermodel.interfaces import FIELDSETS_KEY
 from Products.CMFCore.utils import getToolByName
@@ -76,9 +77,14 @@ def get_ordered_fields(fti):
     return (fields, ordered_fieldsets_fields)
 
 
-def get_hidden_fields_from_schema(schema):
+def get_hidden_fields_from_schema(schema, form):
     hidden_fields = {}
-    for (iface, title, display_mode) in schema.getTaggedValue(MODES_KEY):
+    merged_tagged_values = mergedTaggedValuesForForm(
+        schema,
+        MODES_KEY,
+        form
+    )
+    for (title, display_mode) in merged_tagged_values.items():
         hidden_fields[title] = display_mode
     return hidden_fields
 
@@ -89,7 +95,7 @@ def get_fields_from_schema(schema, context, request, prefix='',
     fields_info = OrderedDict()
     if excluded_fields is None:
         excluded_fields = []
-    hidden_fields = get_hidden_fields_from_schema(schema)
+    hidden_fields = get_hidden_fields_from_schema(schema, request.form)
     for fieldname, field in getFieldsInOrder(schema):
         if fieldname not in excluded_fields:
             adapter = getMultiAdapter(


### PR DESCRIPTION
This is just a proof-of-concept right now. Here is the problem: The "mode" is part of the schema, not of the field. Therefore we can not use the serialization adapters (at least not without passing the schema to each adapter). This somehow breaks the adapter pattern, because integrators will have to make a difference between the schema adapters and the form "properties". Before I continue to refactor my solution to improve it I would like to hear some feedback. @davisagli @lukasgraf @buchi?