### PR TITLE
Make @types endpoint include an 'omitted' attribute.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0a10 (unreleased)
 -------------------
 
+New Features:
+
+- Make @types endpoint include an 'omitted' attribute.
+  [lgraf]
+
 Bugfixes:
 
 - Add missing id to the Plone site serialization, related to issue #186

--- a/src/plone/restapi/tests/test_types.py
+++ b/src/plone/restapi/tests/test_types.py
@@ -57,6 +57,12 @@ class ITaggedValuesSchema(model.Schema):
         description=u"",
     )
 
+    form.omitted('field_omitted_true')
+    field_omitted_true = schema.TextLine(
+        title=u"OmittedTrue",
+        description=u"",
+    )
+
 
 class TestJsonSchemaUtils(TestCase):
 
@@ -161,6 +167,25 @@ class TestTaggedValuesJsonSchemaUtils(TestCase):
         # self.assertEqual(
         #     'input',
         #     jsonschema['properties']['field_mode_default']['mode']
+        # )
+
+    def test_get_jsonschema_with_omitted_field(self):
+        ttool = getToolByName(self.portal, 'portal_types')
+        jsonschema = get_jsonschema_for_fti(
+            ttool['TaggedDocument'],
+            self.portal,
+            self.request
+        )
+
+        self.assertEqual(
+            True,
+            jsonschema['properties']['field_omitted_true']['omitted']
+        )
+
+        # XXX: To be decided if we always return an omitted attribute
+        # self.assertEqual(
+        #     False,
+        #     jsonschema['properties']['field_omitted_false']['omitted']
         # )
 
 

--- a/src/plone/restapi/types/utils.py
+++ b/src/plone/restapi/types/utils.py
@@ -8,8 +8,11 @@ from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.schema import getFieldsInOrder
 
-from plone.autoform.interfaces import MODES_KEY
+from plone.autoform.directives import no_omit
+from plone.autoform.directives import omitted
 from plone.autoform.interfaces import IFormFieldProvider
+from plone.autoform.interfaces import MODES_KEY
+from plone.autoform.interfaces import OMITTED_KEY
 from plone.autoform.utils import mergedTaggedValuesForForm
 from plone.behavior.interfaces import IBehavior
 from plone.supermodel.interfaces import FIELDSETS_KEY
@@ -127,6 +130,19 @@ def get_jsonschema_for_fti(fti, context, request, excluded_fields=None):
     )
     for field_title, mode_value in hidden_fields.items():
         fields_info[field_title]['mode'] = mode_value
+
+    # look up omitted fields from plone.autoform tagged values
+    omitted_fields = mergedTaggedValuesForForm(
+        fti.lookupSchema(),
+        OMITTED_KEY,
+        []
+    )
+    for field_title, omitted_value in omitted_fields.items():
+        field = fields_info[field_title]
+        if omitted_value == omitted.value:
+            field['omitted'] = True
+        elif omitted_value == no_omit.value:
+            field['omitted'] = False
 
     return {
         'type': 'object',


### PR DESCRIPTION
This will serialize Tagged Values from the `omitted` and `no_omit` `plone.autoform` directives in the `@types` endpoint.

---

One case that isn't handled yet is the ability to omit fields only for a particular type of form:

```
    form.omitted('edit_only')
    form.no_omit(IEditForm, 'edit_only')
    edit_only = schema.TextLine(
        title = u'Only included on edit forms',
        )
```

This is not specific to omitted fields though, this applies to other directives as well, `mode()` for example also allows for this.