### PR TITLE
@search endpoint: Also prefill path query dict with context path.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changelog
 
 Bugfixes:
 
+- @search endpoint: Also prefill path query dict with context path.
+  This will allow users to supply an argument like path.depth=1, and still
+  have path.query be prefilled server-side to the context's path.
+  [lgraf]
+
 - Overhaul JSON schema generation for @types endpoint. It now returns
   fields in correct order and in their appropriate fieldsets.
   [lgraf]

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -90,11 +90,17 @@ class TestSearchFunctional(unittest.TestCase):
 
     def test_search_on_context_constrains_query_by_path(self):
         response = self.api_session.get('/folder/@search')
-
         self.assertSetEqual(
             {u'/plone/folder',
              u'/plone/folder/doc',
              u'/plone/folder/other-document'},
+            set(result_paths(response.json())))
+
+    def test_path_gets_prefilled_if_missing_from_path_query_dict(self):
+        response = self.api_session.get('/@search?path.depth=1')
+        self.assertSetEqual(
+            {u'/plone/folder',
+             u'/plone/doc-outside-folder'},
             set(result_paths(response.json())))
 
     def test_partial_metadata_retrieval(self):


### PR DESCRIPTION
`@search` endpoint: Also prefill `path` query dict with context path.

This will allow users to supply an argument like `path.depth=1`, and still have `path.query` be prefilled server-side to the context's path.

@sneridagh 