### PR TITLE
Add review_state on summary serializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Bugfixes:
 - Add missing id to the Plone site serialization, related to issue #186
   [sneridagh]
 
+New Features:
+
+- Add review_state to the folderish summary serializer.
+  [sneridagh]
+
 1.0a9 (2017-03-03)
 ------------------
 

--- a/docs/source/_json/batching.json
+++ b/docs/source/_json/batching.json
@@ -17,35 +17,35 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/folder", 
       "@type": "Folder", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Folder"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-1", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Document 1"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-2", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Document 2"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-3", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Document 3"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-4", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Document 4"
     }
   ], 

--- a/docs/source/_json/batching.json
+++ b/docs/source/_json/batching.json
@@ -17,30 +17,35 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/folder", 
       "@type": "Folder", 
       "description": "", 
+      "review_state": "private",
       "title": "Folder"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-1", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "Document 1"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-2", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "Document 2"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-3", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "Document 3"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc-4", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "Document 4"
     }
   ], 

--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -27,18 +27,21 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
+      "review_state": "private",
       "title": "Welcome to Plone"
     }, 
     {
       "@id": "http://localhost:55001/plone/doc1", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "Document 1"
     }, 
     {
       "@id": "http://localhost:55001/plone/doc2", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "Document 2"
     }
   ], 

--- a/docs/source/_json/collection.json
+++ b/docs/source/_json/collection.json
@@ -27,21 +27,21 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Welcome to Plone"
     }, 
     {
       "@id": "http://localhost:55001/plone/doc1", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Document 1"
     }, 
     {
       "@id": "http://localhost:55001/plone/doc2", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Document 2"
     }
   ], 

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -25,14 +25,14 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/folder/doc1", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "A document within a folder"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc2", 
       "@type": "Document", 
       "description": "", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "A document within a folder"
     }
   ], 

--- a/docs/source/_json/folder.json
+++ b/docs/source/_json/folder.json
@@ -25,12 +25,14 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/folder/doc1", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "A document within a folder"
     }, 
     {
       "@id": "http://localhost:55001/plone/folder/doc2", 
       "@type": "Document", 
       "description": "", 
+      "review_state": "private",
       "title": "A document within a folder"
     }
   ], 

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -11,7 +11,7 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Welcome to Plone"
     }
   ], 

--- a/docs/source/_json/search.json
+++ b/docs/source/_json/search.json
@@ -11,6 +11,7 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
+      "review_state": "private",
       "title": "Welcome to Plone"
     }
   ], 

--- a/docs/source/_json/siteroot.json
+++ b/docs/source/_json/siteroot.json
@@ -13,6 +13,7 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
+      "review_state": "private",
       "title": "Welcome to Plone"
     }
   ], 

--- a/docs/source/_json/siteroot.json
+++ b/docs/source/_json/siteroot.json
@@ -13,7 +13,7 @@ content-type: application/json
       "@id": "http://localhost:55001/plone/front-page", 
       "@type": "Document", 
       "description": "Congratulations! You have successfully installed Plone.", 
-      "review_state": "private",
+      "review_state": "private", 
       "title": "Welcome to Plone"
     }
   ], 

--- a/src/plone/restapi/serializer/summary.py
+++ b/src/plone/restapi/serializer/summary.py
@@ -27,7 +27,8 @@ class DefaultJSONSummarySerializer(object):
             '@id': obj.getURL(),
             '@type': obj.PortalType(),
             'title': obj.Title(),
-            'description': obj.Description()
+            'description': obj.Description(),
+            'review_state': obj.review_state()
         })
         return summary
 

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -114,6 +114,8 @@ class PloneRestApiATLayer(PloneSandboxLayer):
         applyProfile(portal, 'plone.restapi:default')
         applyProfile(portal, 'plone.restapi:testing')
         set_available_languages()
+        portal.portal_workflow.setDefaultChain("simple_publication_workflow")
+
 
 PLONE_RESTAPI_AT_FIXTURE = PloneRestApiATLayer()
 PLONE_RESTAPI_AT_INTEGRATION_TESTING = IntegrationTesting(

--- a/src/plone/restapi/tests/test_atcollection.py
+++ b/src/plone/restapi/tests/test_atcollection.py
@@ -59,17 +59,20 @@ class TestATContentSerializer(unittest.TestCase):
             u'@id': u'http://nohost/plone/folder',
             u'@type': u'ATTestFolder',
             u'description': u'',
-            u'title': u'Test Folder'},
+            u'title': u'Test Folder',
+            'review_state': 'private'},
             obj['items'][0])
         self.assertDictEqual({
             u'@id': u'http://nohost/plone/folder/subfolder-1',
             u'@type': u'ATTestFolder',
             u'description': u'',
-            u'title': u'Subfolder 1'},
+            u'title': u'Subfolder 1',
+            'review_state': 'private'},
             obj['items'][1])
         self.assertDictEqual({
             u'@id': u'http://nohost/plone/folder/subfolder-2',
             u'@type': u'ATTestFolder',
             u'description': u'',
-            u'title': u'Subfolder 2'},
+            u'title': u'Subfolder 2',
+            'review_state': 'private'},
             obj['items'][2])

--- a/src/plone/restapi/tests/test_atcontent_serializer.py
+++ b/src/plone/restapi/tests/test_atcontent_serializer.py
@@ -102,13 +102,15 @@ class TestATContentSerializer(unittest.TestCase):
             '@id': 'http://nohost/plone/folder/subfolder',
             '@type': 'ATTestFolder',
             'description': '',
-            'title': u'Subfolder'},
+            'title': u'Subfolder',
+            'review_state': 'private'},
             obj['items'][0])
         self.assertDictEqual({
             '@id': 'http://nohost/plone/folder/doc',
             '@type': 'ATTestDocument',
             'description': '',
-            'title': u'A Document'},
+            'title': u'A Document',
+            'review_state': 'private'},
             obj['items'][1])
 
     def test_serializer_orders_folder_items_by_get_object_position_in_parent(self):  # noqa
@@ -131,11 +133,13 @@ class TestATContentSerializer(unittest.TestCase):
                     '@type': 'ATTestDocument',
                     'description': '',
                     'title': u'Second doc',
+                    'review_state': 'private'
                 },
                 {
                     '@id': 'http://nohost/plone/folder/doc1',
                     '@type': 'ATTestDocument',
                     'description': '',
                     'title': u'A Document',
+                    'review_state': 'private'
                 },
             ])

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -302,6 +302,7 @@ class TestDexterityFieldSerializing(TestCase):
              '@type': 'DXTestDocument',
              'title': 'Referenceable Document',
              'description': 'Description 2',
+             'review_state': 'private'
              },
             value)
 
@@ -323,11 +324,14 @@ class TestDexterityFieldSerializing(TestCase):
              '@type': 'DXTestDocument',
              'title': 'Referenceable Document',
              'description': 'Description 2',
+             'review_state': 'private'
+
              },
             {'@id': 'http://nohost/plone/doc3',
              '@type': 'DXTestDocument',
              'title': 'Referenceable Document',
              'description': 'Description 3',
+             'review_state': 'private'
              }],
             value)
 

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -130,7 +130,8 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
                     u'@id': u'http://nohost/plone/folder1/doc1',
                     u'@type': u'Document',
                     u'description': u'This is a document',
-                    u'title': u'Document 1'
+                    u'title': u'Document 1',
+                    u'review_state': u'private'
                 }
             ]
         )
@@ -157,13 +158,15 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
                     u'@id': u'http://nohost/plone/folder1/doc2',
                     u'@type': u'Document',
                     u'description': u'Second doc',
-                    u'title': u'Document 2'
+                    u'title': u'Document 2',
+                    u'review_state': u'private'
                 },
                 {
                     u'@id': u'http://nohost/plone/folder1/doc1',
                     u'@type': u'Document',
                     u'description': u'This is a document',
-                    u'title': u'Document 1'
+                    u'title': u'Document 1',
+                    u'review_state': u'private'
                 }
             ]
         )
@@ -221,13 +224,15 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
                     u'@id': u'http://nohost/plone/dxdoc',
                     u'@type': u'DXTestDocument',
                     u'description': u'',
-                    u'title': u'DX Test Document'
+                    u'title': u'DX Test Document',
+                    u'review_state': u'private'
                 },
                 {
                     u'@id': u'http://nohost/plone/doc1',
                     u'@type': u'Document',
                     u'description': u'',
-                    u'title': u'Document 1'
+                    u'title': u'Document 1',
+                    u'review_state': u'private'
                 },
             ]
         )
@@ -349,13 +354,15 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
                     u'@id': self.portal.doc1.absolute_url(),
                     u'@type': u'Document',
                     u'description': u'',
-                    u'title': u'Document 1'
+                    u'title': u'Document 1',
+                    u'review_state': u'private'
                 },
                 {
                     u'@id': self.portal.doc2.absolute_url(),
                     u'@type': u'Document',
                     u'description': u'',
-                    u'title': u'Document 2'
+                    u'title': u'Document 2',
+                    u'review_state': u'private'
                 }
             ],
             self.serialize(self.portal.collection1).get('items')

--- a/src/plone/restapi/tests/test_serializer_catalog.py
+++ b/src/plone/restapi/tests/test_serializer_catalog.py
@@ -62,7 +62,8 @@ class TestCatalogSerializers(unittest.TestCase):
             {'@id': 'http://nohost/plone/my-folder/my-document',
              '@type': 'Document',
              'title': 'My Document',
-             'description': ''},
+             'description': '',
+             'review_state': 'private'},
             result)
 
     def test_brain_partial_metadata_representation(self):

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -195,7 +195,8 @@ class TestJsonCompatibleConverters(TestCase):
             {'@id': 'http://nohost/plone/doc1',
              '@type': 'DXTestDocument',
              'title': 'Document 1',
-             'description': 'Description'},
+             'description': 'Description',
+             'review_state': 'private'},
             json_compatible(RelationValue(intids.getId(doc1))))
 
     def test_i18n_message(self):

--- a/src/plone/restapi/tests/test_serializer_summary.py
+++ b/src/plone/restapi/tests/test_serializer_summary.py
@@ -48,7 +48,8 @@ class TestSummarySerializers(unittest.TestCase):
             {'@id': 'http://nohost/plone/doc1',
              '@type': 'DXTestDocument',
              'title': 'Lorem Ipsum',
-             'description': 'Description'},
+             'description': 'Description',
+             'review_state': 'private'},
             summary)
 
         # Must also work if we're dealing with a CatalogContentListingObject
@@ -62,7 +63,8 @@ class TestSummarySerializers(unittest.TestCase):
             {'@id': 'http://nohost/plone/doc1',
              '@type': 'DXTestDocument',
              'title': 'Lorem Ipsum',
-             'description': 'Description'},
+             'description': 'Description',
+             'review_state': 'private'},
             summary)
 
     def test_brain_summary_with_missing_value(self):
@@ -76,7 +78,8 @@ class TestSummarySerializers(unittest.TestCase):
             {'@id': 'http://nohost/plone/doc1',
              '@type': 'DXTestDocument',
              'title': 'Lorem Ipsum',
-             'description': None},
+             'description': None,
+             'review_state': 'private'},
             summary)
 
     def test_dx_type_summary(self):
@@ -87,7 +90,8 @@ class TestSummarySerializers(unittest.TestCase):
             {'@id': 'http://nohost/plone/doc1',
              '@type': 'DXTestDocument',
              'title': 'Lorem Ipsum',
-             'description': 'Description'},
+             'description': 'Description',
+             'review_state': 'private'},
             summary)
 
 
@@ -114,5 +118,6 @@ class TestSummarySerializersATTypes(unittest.TestCase):
             {'@id': 'http://nohost/plone/doc1',
              '@type': 'ATTestDocument',
              'title': 'Lorem Ipsum',
-             'description': 'Description'},
+             'description': 'Description',
+             'review_state': 'private'},
             summary)


### PR DESCRIPTION
Since this is already provided by IContentListingObject, we can easily add it to the summary serializer at no cost. By doing this, it will be easier to build basic listings from the summary of a folder.

Maybe there's still some other IContentListingObject information that we could include...
https://github.com/plone/plone.app.contentlisting/blob/master/plone/app/contentlisting/interfaces.py#L10

Bottom line is that I had to amend 17 tests failures! ;)

What do you think? /cc @lukasgraf @buchi @tisto @bloodbare 