### PR TITLE
Add support for named IJsonSchemaProvider adapter to target a single field in a schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ New Features:
   Refs https://github.com/plone/plone.restapi/issues/173
   [jaroel]
 
+- Added support for named IJsonSchemaProvider adapter to target a single field in a schema.
+  This allows us to prevent rendering all choices in relatedItems.
+  Refs https://github.com/plone/plone.restapi/issues/199
+  [jaroel]
+
 Bugfixes:
 
 - Fix timezone-related failures when running tests through `coverage`.

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """JsonSchema providers."""
 from plone.app.textfield.interfaces import IRichText
+from z3c.relationfield.interfaces import IRelationList
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -205,9 +206,9 @@ class ListJsonSchemaProvider(CollectionJsonSchemaProvider):
         return info
 
 
-@adapter(IList, Interface, Interface)
+@adapter(IRelationList, Interface, Interface)
 @implementer(IJsonSchemaProvider)
-class ChoiceslessSchemaProvider(ListJsonSchemaProvider):
+class ChoiceslessRelationListSchemaProvider(ListJsonSchemaProvider):
 
     def get_items(self):
         """Get items properties."""

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -207,7 +207,7 @@ class ListJsonSchemaProvider(CollectionJsonSchemaProvider):
 
 @adapter(IList, Interface, Interface)
 @implementer(IJsonSchemaProvider)
-class RelatedItemsSchemaProvider(ListJsonSchemaProvider):
+class ChoiceslessSchemaProvider(ListJsonSchemaProvider):
 
     def get_items(self):
         """Get items properties."""
@@ -216,8 +216,7 @@ class RelatedItemsSchemaProvider(ListJsonSchemaProvider):
             IJsonSchemaProvider)
 
         # Prevent rendering all choices.
-        should_render_choices = self.field.__name__ != 'relatedItems'
-        value_type_adapter.should_render_choices = should_render_choices
+        value_type_adapter.should_render_choices = False
 
         return value_type_adapter.get_schema()
 

--- a/src/plone/restapi/types/configure.zcml
+++ b/src/plone/restapi/types/configure.zcml
@@ -14,7 +14,7 @@
     <adapter factory=".adapters.BoolJsonSchemaProvider" />
     <adapter factory=".adapters.CollectionJsonSchemaProvider" />
     <adapter factory=".adapters.ListJsonSchemaProvider" />
-    <adapter factory=".adapters.ChoiceslessSchemaProvider" name="IRelatedItems.relatedItems" />
+    <adapter factory=".adapters.ChoiceslessRelationListSchemaProvider" name="IRelatedItems.relatedItems" />
     <adapter factory=".adapters.SetJsonSchemaProvider" />
     <adapter factory=".adapters.TupleJsonSchemaProvider" />
     <adapter factory=".adapters.ChoiceJsonSchemaProvider" />

--- a/src/plone/restapi/types/configure.zcml
+++ b/src/plone/restapi/types/configure.zcml
@@ -14,6 +14,7 @@
     <adapter factory=".adapters.BoolJsonSchemaProvider" />
     <adapter factory=".adapters.CollectionJsonSchemaProvider" />
     <adapter factory=".adapters.ListJsonSchemaProvider" />
+    <adapter factory=".adapters.RelatedItemsSchemaProvider" name="IRelatedItems.relatedItems" />
     <adapter factory=".adapters.SetJsonSchemaProvider" />
     <adapter factory=".adapters.TupleJsonSchemaProvider" />
     <adapter factory=".adapters.ChoiceJsonSchemaProvider" />

--- a/src/plone/restapi/types/configure.zcml
+++ b/src/plone/restapi/types/configure.zcml
@@ -14,7 +14,7 @@
     <adapter factory=".adapters.BoolJsonSchemaProvider" />
     <adapter factory=".adapters.CollectionJsonSchemaProvider" />
     <adapter factory=".adapters.ListJsonSchemaProvider" />
-    <adapter factory=".adapters.RelatedItemsSchemaProvider" name="IRelatedItems.relatedItems" />
+    <adapter factory=".adapters.ChoiceslessSchemaProvider" name="IRelatedItems.relatedItems" />
     <adapter factory=".adapters.SetJsonSchemaProvider" />
     <adapter factory=".adapters.TupleJsonSchemaProvider" />
     <adapter factory=".adapters.ChoiceJsonSchemaProvider" />

--- a/src/plone/restapi/types/utils.py
+++ b/src/plone/restapi/types/utils.py
@@ -21,6 +21,7 @@ from plone.restapi.types.interfaces import IJsonSchemaProvider
 from Products.CMFCore.utils import getToolByName
 from z3c.form import form as z3c_form
 from zope.component import getMultiAdapter
+from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 
@@ -101,7 +102,15 @@ def get_jsonschema_properties(context, request, fieldsets, prefix='',
     for field in iter_fields(fieldsets):
         fieldname = field.field.getName()
         if fieldname not in excluded_fields:
-            adapter = getMultiAdapter(
+
+            # We need to special case relatedItems not to render choices
+            # so we try a named adapter first and fallback to unnamed ones.
+            adapter = queryMultiAdapter(
+                (field.field, context, request),
+                interface=IJsonSchemaProvider,
+                name=field.__name__)
+
+            adapter = adapter or getMultiAdapter(
                 (field.field, context, request),
                 interface=IJsonSchemaProvider)
 


### PR DESCRIPTION
This allows us to prevent rending choices for relatedItems, which would dump the whole DB.

Fixes #199 by not rendering relatedItems' choices.