### PR TITLE
Add verbose message to avoid confusion for creating document under a folder docs

### DIFF
--- a/docs/source/content.rst
+++ b/docs/source/content.rst
@@ -5,6 +5,9 @@ plone.restapi does not only expose content objects via a RESTful API. The API co
 
 Manipulating resources across the network by using HTTP as an application protocol is one of core principles of the REST architectural pattern. This allows us to interact with a specific resource in a standardized way:
 
+.. note::
+        Here folder implies to name of the `folder name` in which you want to create the new document.
+
 ======= ======================= ==============================================
 Verb    URL                     Action
 ======= ======================= ==============================================

--- a/docs/source/content.rst
+++ b/docs/source/content.rst
@@ -5,17 +5,14 @@ plone.restapi does not only expose content objects via a RESTful API. The API co
 
 Manipulating resources across the network by using HTTP as an application protocol is one of core principles of the REST architectural pattern. This allows us to interact with a specific resource in a standardized way:
 
-.. note::
-        Here folder implies to name of the `folder name` in which you want to create the new document.
-
-======= ======================= ==============================================
-Verb    URL                     Action
-======= ======================= ==============================================
-POST    /folder                 Creates a new document within the folder
-GET     /folder/{document-id}   Request the current state of the document
-PATCH   /folder/{document-id}   Update the document details
-DELETE  /folder/{document-id}   Remove the document
-======= ======================= ==============================================
+======= =============================    ==============================================
+Verb    URL                              Action
+======= =============================    ==============================================
+POST    /{{folder_name}}                 Creates a new document within the folder
+GET     /{{folder_name}}/{document-id}   Request the current state of the document
+PATCH   /{{folder_name}}/{document-id}   Update the document details
+DELETE  /{{folder_name}}/{document-id}   Remove the document
+======= ==============================   ==============================================
 
 
 Creating a Resource with POST
@@ -28,7 +25,7 @@ If we want to create a new document within an existing folder, we send a POST re
 
   .. code-block:: http-request
 
-    POST /folder HTTP/1.1
+    POST /{{folder_name}} HTTP/1.1
     Host: localhost:8080
     Accept: application/json
     Content-Type: application/json
@@ -40,15 +37,15 @@ If we want to create a new document within an existing folder, we send a POST re
 
   .. code-block:: curl
 
-    curl -i -H "Accept: application/json" -H "Content-type: application/json" --data-raw '{"@type":"Document", "title": "My Document"}' --user admin:admin -X POST http://localhost:8080/Plone/folder
+    curl -i -H "Accept: application/json" -H "Content-type: application/json" --data-raw '{"@type":"Document", "title": "My Document"}' --user admin:admin -X POST http://localhost:8080/Plone/{{folder_name}}
 
   .. code-block:: httpie
 
-    http -a admin:admin POST http://localhost:8080/Plone/folder \\@type=Document title=My Document Accept:application/json
+    http -a admin:admin POST http://localhost:8080/Plone/{{folder_name}} \\@type=Document title=My Document Accept:application/json
 
   .. code-block:: python-requests
 
-    requests.post('http://localhost:8080/Plone/folder', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'@type': 'Document', 'title': 'My Document'})
+    requests.post('http://localhost:8080/Plone/{{folder_name}}', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'@type': 'Document', 'title': 'My Document'})
 
 By setting the 'Accept' header, we tell the server that we would like to receive the response in the 'application/json' representation format.
 
@@ -66,7 +63,7 @@ The 'Location' header contains the URL of the newly created resource and the res
 
   HTTP/1.1 201 Created
   Content-Type: application/json
-  Location: http://localhost:8080/folder/my-document
+  Location: http://localhost:8080/{{folder_name}}/my-document
 
   {
       '@type': 'Document',
@@ -210,7 +207,7 @@ PATCH allows to provide just a subset of the resource (the values you actually w
 
   .. code-block:: http-request
 
-    PATCH /folder/my-document HTTP/1.1
+    PATCH /{{folder_name}}/my-document HTTP/1.1
     Host: localhost:8080/Plone
     Content-Type: application/json
 
@@ -220,15 +217,15 @@ PATCH allows to provide just a subset of the resource (the values you actually w
 
   .. code-block:: curl
 
-    curl -i -H "Accept: application/json" -H "Content-type: application/json" --data-raw '{title": "My New Document Title"}' --user admin:admin -X PATCH http://localhost:8080/Plone/folder/my-document
+    curl -i -H "Accept: application/json" -H "Content-type: application/json" --data-raw '{title": "My New Document Title"}' --user admin:admin -X PATCH http://localhost:8080/Plone/{{folder_name}}/my-document
 
   .. code-block:: httpie
 
-    http -a admin:admin PATCH http://localhost:8080/Plone/folder/my-document title="My New Document Title" Accept:application/json
+    http -a admin:admin PATCH http://localhost:8080/Plone/{{folder_name}}/my-document title="My New Document Title" Accept:application/json
 
   .. code-block:: python-requests
 
-    requests.patch('http://localhost:8080/Plone/folder/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'title': 'My New Document Title'})
+    requests.patch('http://localhost:8080/Plone/{{folder_name}}/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'title': 'My New Document Title'})
 
 
 Successful Response (204 No Content)
@@ -256,7 +253,7 @@ To replace an existing resource we send a PUT request to the server:
 
   .. code-block:: http-request
 
-    PUT /folder/my-document HTTP/1.1
+    PUT /{{folder_name}}/my-document HTTP/1.1
     Host: localhost:8080
     Content-Type: application/json
 
@@ -267,15 +264,15 @@ To replace an existing resource we send a PUT request to the server:
 
   .. code-block:: curl
 
-    curl -i -H "Accept: application/json" -X PUT http://localhost:8080/Plone/folder
+    curl -i -H "Accept: application/json" -X PUT http://localhost:8080/Plone/{{folder_name}}
 
   .. code-block:: httpie
 
-    http -a admin:admin PUT http://localhost:8080/Plone/folder title="My New Document Title" Accept:application/json
+    http -a admin:admin PUT http://localhost:8080/Plone/{{folder_name}} title="My New Document Title" Accept:application/json
 
   .. code-block:: python-requests
 
-    requests.put('http://localhost:8080/Plone/folder/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'title': 'My New Document Title', ...})
+    requests.put('http://localhost:8080/Plone/{{folder_name}}/my-document', auth=('admin', 'admin'), headers={'Accept': 'application/json'}, json={'title': 'My New Document Title', ...})
 
 In accordance with the HTTP specification, a successful PUT will not create a new resource or produce a new URL.
 
@@ -359,20 +356,20 @@ We can delete an existing resource by sending a DELETE request:
 
   .. code-block:: http-request
 
-    DELETE /folder/my-document HTTP/1.1
+    DELETE /{{folder_name}}/my-document HTTP/1.1
     Host: localhost:8080
 
   .. code-block:: curl
 
-      curl -i -H "Accept: application/json" -X DELETE --user admin:admin http://localhost:8080/Plone/folder/my-document
+      curl -i -H "Accept: application/json" -X DELETE --user admin:admin http://localhost:8080/Plone/{{folder_name}}/my-document
 
   .. code-block:: httpie
 
-      http -a admin:admin DELETE http://localhost:8080/Plone/folder/my-document Accept:application/json
+      http -a admin:admin DELETE http://localhost:8080/Plone/{{folder_name}}/my-document Accept:application/json
 
   .. code-block:: python-requests
 
-    requests.delete('http://localhost:8080/Plone/folder', auth=('admin', 'admin'), headers={'Accept': 'application/json'})
+    requests.delete('http://localhost:8080/Plone/{{folder_name}}', auth=('admin', 'admin'), headers={'Accept': 'application/json'})
 
 A successful response will be indicated by a :term:`204 No Content` response::
 


### PR DESCRIPTION
Here are few confusion that I faced while trying out APIs.

1) When I see the url `/folder	Creates a new document within the folder` this looks like a url something like `http://localhost/Plone/folder` but here folder means the name of the folder in which we want to create a document. 

Also if we show APIs like `/folder` it signifies that this is the endpoint but the reality is it is something like this `/{{folder_name`.

So the quick fix that pop up to me is to add a note before declaring these endpoints that it means the folder in which you want to create a document. Later may be we can update the endpoints and their responses in generic way, something like this `/{{folder_name}}`