### PR TITLE
Add available_roles attribute to the GET @sharing endpoint.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ New Features:
   sharing UI widget or other user/groups search widgets.
   [sneridagh]
 
+- Add ``available_roles`` attribute to the GET @sharing endpoint.
+  [sneridagh]
+
 Bugfixes:
 
 - Return correct @id for folderish objects created via POST.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,9 +36,6 @@ New Features:
   sharing UI widget or other user/groups search widgets.
   [sneridagh]
 
-- Add ``available_roles`` attribute to the GET @sharing endpoint.
-  [sneridagh]
-
 Bugfixes:
 
 - Return correct @id for folderish objects created via POST.

--- a/docs/source/_json/sharing_folder_get.req
+++ b/docs/source/_json/sharing_folder_get.req
@@ -1,0 +1,3 @@
+GET /plone/folder/@sharing HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0

--- a/docs/source/_json/sharing_folder_get.resp
+++ b/docs/source/_json/sharing_folder_get.resp
@@ -1,0 +1,27 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "available_roles": [
+    "Contributor", 
+    "Editor", 
+    "Reviewer", 
+    "Reader"
+  ], 
+  "entries": [
+    {
+      "disabled": false, 
+      "id": "AuthenticatedUsers", 
+      "login": null, 
+      "roles": {
+        "Contributor": false, 
+        "Editor": false, 
+        "Reader": false, 
+        "Reviewer": false
+      }, 
+      "title": "Logged-in users", 
+      "type": "group"
+    }
+  ], 
+  "inherit": false
+}

--- a/docs/source/_json/sharing_folder_post.req
+++ b/docs/source/_json/sharing_folder_post.req
@@ -1,0 +1,6 @@
+POST /plone/folder/@sharing HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0
+Content-Type: application/json
+
+{"inherit": true, "entries": [{"type": "user", "id": "test_user_1_", "roles": {"Contributor": false, "Reviewer": true, "Editor": false, "Reader": true}}]}

--- a/docs/source/_json/sharing_folder_post.resp
+++ b/docs/source/_json/sharing_folder_post.resp
@@ -1,0 +1,2 @@
+HTTP/1.1 204 No Content
+

--- a/docs/source/sharing.rst
+++ b/docs/source/sharing.rst
@@ -27,51 +27,13 @@ In plone.restapi, the representation of any content object will include a hyperm
     }
   }
 
-RFC: Do we care about those hypermedia links on the top level for better discoverability?
-
 The sharing information of a content object can also be directly accessed by appending '/@sharing' to the GET request to the URL of a content object. E.g. to access the sharing information for a top-level folder, do:
 
-.. code:: json
+..  http:example:: curl httpie python-requests
+    :request: _json/sharing_folder_get.req
 
-  GET /plone/folder/@sharing
-  Accept: application/json
-
-  HTTP 200 OK
-  content-type: application/json
-
-  {
-     "inherit" : false,
-     "entries" : [
-        {
-           "disabled" : false,
-           "title" : "Logged-in users",
-           "id" : "AuthenticatedUsers",
-           "login" : null,
-           "type" : "group",
-           "roles" : {
-              "Reader" : false,
-              "Editor" : false,
-              "Contributor" : false,
-              "Reviewer" : false
-           }
-        },
-        {
-           "id" : "test_user_1_",
-           "title" : "test-user",
-           "disabled" : false,
-           "roles" : {
-              "Reviewer" : true,
-              "Contributor" : false,
-              "Editor" : false,
-              "Reader" : false
-           },
-           "type" : "user"
-        }
-     ]
-  }
-  
-
-RFC: We can not return a full list of all users and groups in the portal here. This would not scale for portals with lots of users. We could always list the local roles that are available. It is fair to assume that the number of local roles is somehow limited.
+.. literalinclude:: _json/sharing_folder_get.resp
+   :language: http
 
 
 Update Local Roles
@@ -79,28 +41,8 @@ Update Local Roles
 
 You can update the 'sharing' information by sending a POST request to the object URL and appending '/@sharing', e.g. '/plone/folder/@sharing'. E.g. say you want to give the AuthenticatedUsers group the 'reader' local role for a folder:
 
-.. code:: json
+..  http:example:: curl httpie python-requests
+    :request: _json/sharing_folder_post.req
 
-  POST /plone/folder/@sharing
-  Host: localhost:8080
-  Accept: application/json
-  Content-Type: application/json
-
-  {
-     "inherit" : true,
-     "entries" : [
-        {
-           "id" : "test_user_1_",
-           "roles" : {
-              "Reviewer" : true,
-              "Editor" : false,
-              "Reader" : true,
-              "Contributor" : false
-           },
-           "type" : "user"
-        }
-     ]
-  }
-  
-
-RFC: I'm wondering if a POST request is the correct HTTP verb. We are actually updating an object, which would make PATCH a more appropriate choice. Though, we are not embedding the sharing information in the standard view (something that could also be a possible option.)
+.. literalinclude:: _json/sharing_folder_post.resp
+   :language: http

--- a/src/plone/restapi/serializer/local_roles.py
+++ b/src/plone/restapi/serializer/local_roles.py
@@ -21,7 +21,9 @@ class SerializeLocalRolesToJson(object):
         sharing_view = getMultiAdapter((self.context, self.request),
                                        name='sharing')
         local_roles = sharing_view.existing_role_settings()
+        available_roles = [r['id'] for r in sharing_view.roles()]
         return {'inherit': getattr(aq_base(self.context),
                                    '__ac_local_roles_block__',
                                    False),
-                'entries': local_roles}
+                'entries': local_roles,
+                'available_roles': available_roles}

--- a/src/plone/restapi/tests/test_content_local_roles.py
+++ b/src/plone/restapi/tests/test_content_local_roles.py
@@ -58,16 +58,17 @@ class TestFolderCreate(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {u'entries': [{
-                u'disabled': False,
-                u'id': u'AuthenticatedUsers',
-                u'login': None,
-                u'roles': {u'Contributor': False,
-                           u'Editor': False,
-                           u'Reader': False,
-                           u'Reviewer': False},
-                u'title': u'Logged-in users',
-                u'type': u'group'}],
+            {u'available_roles': [u'Contributor', u'Editor', u'Reviewer', u'Reader'],  # noqa
+             u'entries': [{
+                 u'disabled': False,
+                 u'id': u'AuthenticatedUsers',
+                 u'login': None,
+                 u'roles': {u'Contributor': False,
+                            u'Editor': False,
+                            u'Reader': False,
+                            u'Reviewer': False},
+                 u'title': u'Logged-in users',
+                 u'type': u'group'}],
              u'inherit': False}
         )
 
@@ -86,7 +87,8 @@ class TestFolderCreate(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {u'entries': [
+            {u'available_roles': [u'Contributor', u'Editor', u'Reviewer', u'Reader'],  # noqa
+             u'entries': [
                 {
                     u'disabled': False,
                     u'id': u'AuthenticatedUsers',
@@ -224,3 +226,20 @@ class TestFolderCreate(unittest.TestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(self._get_ac_local_roles_block(self.portal.folder1),
                          False)
+
+    def test_get_available_roles(self):
+        api.user.grant_roles(username=TEST_USER_ID,
+                             obj=self.portal.folder1,
+                             roles=['Reviewer'])
+        transaction.commit()
+
+        response = requests.get(
+            self.portal.folder1.absolute_url() + '/@sharing',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        response = response.json()
+        self.assertIn('available_roles', response)
+        self.assertIn('Reader', response['available_roles'])

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -661,3 +661,35 @@ class TestTraversal(unittest.TestCase):
             '/@vocabularies/plone.app.vocabularies.ReallyUserFriendlyTypes'
         )
         save_request_and_response_for_docs('vocabularies_get', response)
+
+    def test_documentation_sharing_folder_get(self):
+        self.portal.invokeFactory('Folder', id='folder')
+        transaction.commit()
+        response = self.api_session.get(
+            '/folder/@sharing'
+        )
+        save_request_and_response_for_docs('sharing_folder_get', response)
+
+    def test_documentation_sharing_folder_post(self):
+        self.portal.invokeFactory('Folder', id='folder')
+        transaction.commit()
+        payload = {
+            "inherit": True,
+            "entries": [
+                {
+                    "id": "test_user_1_",
+                    "roles": {
+                        "Reviewer": True,
+                        "Editor": False,
+                        "Reader": True,
+                        "Contributor": False
+                    },
+                    "type": "user"
+                }
+            ]
+        }
+        response = self.api_session.post(
+            '/folder/@sharing',
+            json=payload
+        )
+        save_request_and_response_for_docs('sharing_folder_post', response)


### PR DESCRIPTION
It's required to build an UI on the top of the sharing feature.