### PR TITLE
Update testing environment to latest Plone 4 and 5 releases

### DIFF
--- a/docs/source/_json/vocabularies.resp
+++ b/docs/source/_json/vocabularies.resp
@@ -31,8 +31,8 @@ Content-Type: application/json
     "title": "plone.app.vocabularies.Actions"
   }, 
   {
-    "@id": "http://localhost:55001/plone/@vocabularies/plone.app.contenttypes.migration.changed_base_classes", 
-    "title": "plone.app.contenttypes.migration.changed_base_classes"
+    "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.ImagesScales", 
+    "title": "plone.app.vocabularies.ImagesScales"
   }, 
   {
     "@id": "http://localhost:55001/plone/@vocabularies/wicked.vocabularies.BaseConfigurationsOptions", 
@@ -189,6 +189,10 @@ Content-Type: application/json
   {
     "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Workflows", 
     "title": "plone.app.vocabularies.Workflows"
+  }, 
+  {
+    "@id": "http://localhost:55001/plone/@vocabularies/plone.app.contenttypes.migration.changed_base_classes", 
+    "title": "plone.app.contenttypes.migration.changed_base_classes"
   }, 
   {
     "@id": "http://localhost:55001/plone/@vocabularies/Group Ids", 

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/4.3.9/versions.cfg
+    http://dist.plone.org/release/4.3.11/versions.cfg
     versions.cfg

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.0.6/versions.cfg
+    http://dist.plone.org/release/5.0.7/versions.cfg
     versions.cfg


### PR DESCRIPTION
Plone 4.3.x setup can't be updated to 4.3.12 because some errors on the generated KGS, so I updated it to Plone 4.3.11 (see https://community.plone.org/t/plone-4-3-12-soft-released/3529/14)