### PR TITLE
Fix plone.api, z3c.relationfield and zope.intid dependencies.

### DIFF
--- a/src/plone/restapi/services/copymove/copymove.py
+++ b/src/plone/restapi/services/copymove/copymove.py
@@ -5,9 +5,7 @@ from plone.restapi.services import Service
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
 from zope.component import getMultiAdapter
-from zope.component import queryUtility
 from zope.interface import alsoProvides
-from zope.intid.interfaces import IIntIds
 from zope.security import checkPermission
 
 import plone
@@ -25,12 +23,8 @@ class BaseCopyMove(Service):
         self.catalog = getToolByName(self.context, 'portal_catalog')
 
     def get_object(self, key):
-        """Get an object by intid, url, path or UID."""
-        if isinstance(key, int):
-            # Resolve by intid
-            intids = queryUtility(IIntIds)
-            return intids.queryObject(key)
-        elif isinstance(key, basestring):
+        """Get an object by url, path or UID."""
+        if isinstance(key, basestring):
             if key.startswith(self.portal_url):
                 # Resolve by URL
                 return self.portal.restrictedTraverse(

--- a/src/plone/restapi/services/principals/get.py
+++ b/src/plone/restapi/services/principals/get.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from itertools import chain
-from plone import api
 from plone.app.workflow.browser.sharing import merge_search_results
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
@@ -42,7 +41,8 @@ class PrincipalsGet(Service):
                       for field in ['name', 'fullname', 'email']]), 'userid')
 
         def get_principal_by_id(user_id):
-            return api.user.get(user_id)
+            mtool = getToolByName(self.context, 'portal_membership')
+            return mtool.getMemberById(user_id)
 
         return self._principal_search_results(
             search_for_principal, get_principal_by_id, 'user', 'userid')

--- a/src/plone/restapi/tests/test_copymove.py
+++ b/src/plone/restapi/tests/test_copymove.py
@@ -9,9 +9,7 @@ from plone.app.testing import setRoles
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
-from zope.component import queryUtility
 from zope.event import notify
-from zope.intid.interfaces import IIntIds
 
 import unittest
 import transaction
@@ -40,13 +38,6 @@ class TestCopyMove(unittest.TestCase):
             '%s:%s' % (SITE_OWNER_NAME, SITE_OWNER_PASSWORD))
         notify(PubStart(request))
         return request.traverse(path)
-
-    def test_get_object_by_intid(self):
-        intids = queryUtility(IIntIds)
-        service = self.traverse('/plone/@copy', method='POST')
-        obj = service.get_object(intids.getId(self.doc1))
-
-        self.assertEqual(self.doc1, obj)
 
     def test_get_object_by_url(self):
         service = self.traverse('/plone/@copy', method='POST')

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -31,15 +31,6 @@ from plone.restapi.types.interfaces import IJsonSchemaProvider
 from plone.restapi.types.utils import get_fieldsets
 from plone.restapi.types.utils import get_jsonschema_properties
 
-import pkg_resources
-
-try:
-    pkg_resources.get_distribution('z3c.relationfield')
-    Z3CRELATIONS_INSTALLED = True
-    from z3c.relationfield.interfaces import IRelationList
-except pkg_resources.DistributionNotFound:
-    Z3CRELATIONS_INSTALLED = False
-
 
 @adapter(IField, Interface, Interface)
 @implementer(IJsonSchemaProvider)
@@ -221,23 +212,6 @@ class ListJsonSchemaProvider(CollectionJsonSchemaProvider):
             info['uniqueItems'] = False
 
         return info
-
-if Z3CRELATIONS_INSTALLED:
-
-    @adapter(IRelationList, Interface, Interface)
-    @implementer(IJsonSchemaProvider)
-    class ChoiceslessRelationListSchemaProvider(ListJsonSchemaProvider):
-
-        def get_items(self):
-            """Get items properties."""
-            value_type_adapter = getMultiAdapter(
-                (self.field.value_type, self.context, self.request),
-                IJsonSchemaProvider)
-
-            # Prevent rendering all choices.
-            value_type_adapter.should_render_choices = False
-
-            return value_type_adapter.get_schema()
 
 
 @adapter(ISet, Interface, Interface)

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """JsonSchema providers."""
 from plone.app.textfield.interfaces import IRichText
-from z3c.relationfield.interfaces import IRelationList
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -31,6 +30,15 @@ from zope.schema.interfaces import IVocabularyFactory
 from plone.restapi.types.interfaces import IJsonSchemaProvider
 from plone.restapi.types.utils import get_fieldsets
 from plone.restapi.types.utils import get_jsonschema_properties
+
+import pkg_resources
+
+try:
+    pkg_resources.get_distribution('z3c.relationfield')
+    Z3CRELATIONS_INSTALLED = True
+    from z3c.relationfield.interfaces import IRelationList
+except pkg_resources.DistributionNotFound:
+    Z3CRELATIONS_INSTALLED = False
 
 
 @adapter(IField, Interface, Interface)
@@ -214,21 +222,22 @@ class ListJsonSchemaProvider(CollectionJsonSchemaProvider):
 
         return info
 
+if Z3CRELATIONS_INSTALLED:
 
-@adapter(IRelationList, Interface, Interface)
-@implementer(IJsonSchemaProvider)
-class ChoiceslessRelationListSchemaProvider(ListJsonSchemaProvider):
+    @adapter(IRelationList, Interface, Interface)
+    @implementer(IJsonSchemaProvider)
+    class ChoiceslessRelationListSchemaProvider(ListJsonSchemaProvider):
 
-    def get_items(self):
-        """Get items properties."""
-        value_type_adapter = getMultiAdapter(
-            (self.field.value_type, self.context, self.request),
-            IJsonSchemaProvider)
+        def get_items(self):
+            """Get items properties."""
+            value_type_adapter = getMultiAdapter(
+                (self.field.value_type, self.context, self.request),
+                IJsonSchemaProvider)
 
-        # Prevent rendering all choices.
-        value_type_adapter.should_render_choices = False
+            # Prevent rendering all choices.
+            value_type_adapter.should_render_choices = False
 
-        return value_type_adapter.get_schema()
+            return value_type_adapter.get_schema()
 
 
 @adapter(ISet, Interface, Interface)

--- a/src/plone/restapi/types/configure.zcml
+++ b/src/plone/restapi/types/configure.zcml
@@ -15,7 +15,10 @@
     <adapter factory=".adapters.BoolJsonSchemaProvider" />
     <adapter factory=".adapters.CollectionJsonSchemaProvider" />
     <adapter factory=".adapters.ListJsonSchemaProvider" />
-    <adapter factory=".adapters.ChoiceslessRelationListSchemaProvider" name="IRelatedItems.relatedItems" />
+    <adapter
+        zcml:condition="installed z3c.relationfield"
+        factory=".adapters.ChoiceslessRelationListSchemaProvider"
+        name="IRelatedItems.relatedItems" />
     <adapter factory=".adapters.SetJsonSchemaProvider" />
     <adapter factory=".adapters.TupleJsonSchemaProvider" />
     <adapter factory=".adapters.ChoiceJsonSchemaProvider" />

--- a/src/plone/restapi/types/configure.zcml
+++ b/src/plone/restapi/types/configure.zcml
@@ -17,7 +17,7 @@
     <adapter factory=".adapters.ListJsonSchemaProvider" />
     <adapter
         zcml:condition="installed z3c.relationfield"
-        factory=".adapters.ChoiceslessRelationListSchemaProvider"
+        factory=".z3crelationadapter.ChoiceslessRelationListSchemaProvider"
         name="IRelatedItems.relatedItems" />
     <adapter factory=".adapters.SetJsonSchemaProvider" />
     <adapter factory=".adapters.TupleJsonSchemaProvider" />

--- a/src/plone/restapi/types/z3crelationadapter.py
+++ b/src/plone/restapi/types/z3crelationadapter.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.types.interfaces import IJsonSchemaProvider
+from z3c.relationfield.interfaces import IRelationList
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+from plone.restapi.types.adapters import ListJsonSchemaProvider
+
+
+@adapter(IRelationList, Interface, Interface)
+@implementer(IJsonSchemaProvider)
+class ChoiceslessRelationListSchemaProvider(ListJsonSchemaProvider):
+
+    def get_items(self):
+        """Get items properties."""
+        value_type_adapter = getMultiAdapter(
+            (self.field.value_type, self.context, self.request),
+            IJsonSchemaProvider)
+
+        # Prevent rendering all choices.
+        value_type_adapter.should_render_choices = False
+
+        return value_type_adapter.get_schema()


### PR DESCRIPTION
Fixes #288.

This PR removes the use of plone.api and zope.intid, and makes the use of z3c.relationfield conditional on the installation of it (present in Plone 5, not in Plone 4.3.x)

See #289 for further discussion.

Merge only this one or #289, but not both.