### PR TITLE
Make import of LocalrolesModifiedEvent conditional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 1.0a11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+Bugfixes:
+
+- Make import of LocalrolesModifiedEvent conditional, so plone.restapi
+  doesn't prevent Plone 4.3 deployments < 4.3.4 from booting.
+  [lgraf]
 
 
 1.0a10 (2017-03-22)

--- a/src/plone/restapi/deserializer/local_roles.py
+++ b/src/plone/restapi/deserializer/local_roles.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
 from AccessControl.interfaces import IRoleManager
-from Products.CMFCore.interfaces import ICatalogAware
-
-from plone.app.workflow.events import LocalrolesModifiedEvent
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IDeserializeFromJson
+from Products.CMFCore.interfaces import ICatalogAware
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.event import notify
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
+
+try:
+    from plone.app.workflow.events import LocalrolesModifiedEvent
+    LOCALROLES_MODIFIED_EVENT_AVAILABLE = True
+except ImportError:
+    # Plone < 4.3.4
+    LOCALROLES_MODIFIED_EVENT_AVAILABLE = False
 
 
 marker = object()
@@ -53,4 +58,5 @@ class DeserializeFromJson(object):
 
         if ICatalogAware(self.context) and (inherit_reindex or roles_reindex):
             self.context.reindexObjectSecurity()
-            notify(LocalrolesModifiedEvent(self.context, self.request))
+            if LOCALROLES_MODIFIED_EVENT_AVAILABLE:
+                notify(LocalrolesModifiedEvent(self.context, self.request))


### PR DESCRIPTION
I propose to make the import of `LocalrolesModifiedEvent` from `plone.app.workflow` conditional, so `plone.restapi` doesn't prevent Plone 4.3 deployments < 4.3.4 from booting.

---

A deployment with `plone.restapi == 1.0a10` and Plone < 4.3.4 will currently fail to boot because of the import of `LocalrolesModifiedEvent` from `plone.app.workflow`. This event has only been [added in `p.a.workflow` 2.2.1](https://github.com/plone/plone.app.workflow/pull/5), resp. backported to 2.1.8, which is available in Plone 4.3.4 or higher.

This currently bites us, preventing us from using the most recent `plone.restapi`, because we still have a few deployments that we can't yet bump to the most recent 4.3.x version.

I'm definitely not advocating here that we should officially claim support for older bugfix versions of Plone 4.3.x, and/or run 4.3 tests against anything else than a recent version. Or that actual *functionality* is supposed to be guaranteed to work on those versions.

But if we can make imports that get triggered during boot time a bit more defensive and through that achieve that `plone.restapi` doesn't completely prevent the instance from even *booting* on those older versions, we'd currently benefit from that.

So, @tisto @sneridagh @csenger would you object to this change?