### PR TITLE
Add Products.PasswortResetTool to dependencies.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 Bugfixes:
 
+- Add Products.PasswortResetTool to dependencies. This dependency is gone in
+  Plone 5.1.
+  [timo]
+
 - Make import of LocalrolesModifiedEvent conditional, so plone.restapi
   doesn't prevent Plone 4.3 deployments < 4.3.4 from booting.
   [lgraf]

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name='plone.restapi',
       install_requires=[
           'setuptools',
           'plone.rest >= 1.0a6',  # json renderer moved to plone.restapi
+          'Products.PasswordResetTool',  # gone in Plone 5.1
           'PyJWT',
       ],
       extras_require={'test': [


### PR DESCRIPTION
This dependency is gone in Plone 5.1.