### PR TITLE
Remove the disabled flag from @sharing entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 1.0a14 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+Bugfixes:
+- Remove 'disabled' from @sharing entries, as it is a Plone template hint.
+  It doesn't actually mean that the entry is disabled.
+  [jaroel]
 
 1.0a13 (2017-04-18)
 -------------------

--- a/docs/source/_json/sharing_folder_get.resp
+++ b/docs/source/_json/sharing_folder_get.resp
@@ -3,25 +3,24 @@ Content-Type: application/json
 
 {
   "available_roles": [
-    "Contributor", 
-    "Editor", 
-    "Reviewer", 
+    "Contributor",
+    "Editor",
+    "Reviewer",
     "Reader"
-  ], 
+  ],
   "entries": [
     {
-      "disabled": false, 
-      "id": "AuthenticatedUsers", 
-      "login": null, 
+      "id": "AuthenticatedUsers",
+      "login": null,
       "roles": {
-        "Contributor": false, 
-        "Editor": false, 
-        "Reader": false, 
+        "Contributor": false,
+        "Editor": false,
+        "Reader": false,
         "Reviewer": false
-      }, 
-      "title": "Logged-in users", 
+      },
+      "title": "Logged-in users",
       "type": "group"
     }
-  ], 
+  ],
   "inherit": false
 }

--- a/src/plone/restapi/serializer/local_roles.py
+++ b/src/plone/restapi/serializer/local_roles.py
@@ -21,9 +21,19 @@ class SerializeLocalRolesToJson(object):
         sharing_view = getMultiAdapter((self.context, self.request),
                                        name='sharing')
         local_roles = sharing_view.existing_role_settings()
+
+        # We remove the disabled flag. The entry isn't disabled, but just used
+        # as a flag for the Plone template to prevent removing a users own
+        # entry.
+        entries = []
+        for role in local_roles:
+            if 'disabled' in role:
+                del role['disabled']
+            entries.append(role)
+
         available_roles = [r['id'] for r in sharing_view.roles()]
         return {'inherit': getattr(aq_base(self.context),
                                    '__ac_local_roles_block__',
                                    False),
-                'entries': local_roles,
+                'entries': entries,
                 'available_roles': available_roles}

--- a/src/plone/restapi/tests/test_content_local_roles.py
+++ b/src/plone/restapi/tests/test_content_local_roles.py
@@ -40,6 +40,18 @@ class TestFolderCreate(unittest.TestCase):
                     '__ac_local_roles_block__',
                     False))
 
+    def test_sharing_no_disabled(self):
+        '''A sharing response should not contain a disabled flag.
+        '''
+        response = requests.get(
+            self.portal.folder1.absolute_url() + '/@sharing?search=' + SITE_OWNER_NAME,  # noqa
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        self.assertGreater(len(response.json()['entries']), 0)
+        for entry in response.json()['entries']:
+            self.assertNotIn('disabled', entry)
+
     def test_sharing_requires_delegate_roles_permission(self):
         '''A response for an object without any roles assigned'''
         response = requests.get(
@@ -62,7 +74,6 @@ class TestFolderCreate(unittest.TestCase):
             response.json(),
             {u'available_roles': [u'Contributor', u'Editor', u'Reviewer', u'Reader'],  # noqa
              u'entries': [{
-                 u'disabled': False,
                  u'id': u'AuthenticatedUsers',
                  u'login': None,
                  u'roles': {u'Contributor': False,
@@ -92,7 +103,6 @@ class TestFolderCreate(unittest.TestCase):
             {u'available_roles': [u'Contributor', u'Editor', u'Reviewer', u'Reader'],  # noqa
              u'entries': [
                 {
-                    u'disabled': False,
                     u'id': u'AuthenticatedUsers',
                     u'login': None,
                     u'roles': {u'Contributor': False,
@@ -102,7 +112,6 @@ class TestFolderCreate(unittest.TestCase):
                     u'title': u'Logged-in users',
                     u'type': u'group'},
                 {
-                    u'disabled': False,
                     u'id': u'test_user_1_',
                     u'roles': {u'Contributor': False,
                                u'Editor': False,


### PR DESCRIPTION
This is a UI flag for Plone templates and does not actually specify that the entry is disabled.