### PR TITLE
Fix the @move endpoint fails to return 403 when the user don't have p…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ Bugfixes:
 - Don't fetch unnecessary PasswordResetTool in Plone 5.1
   [tomgross]
 
+- Fix the @move endpoint fails to return 403 when the user don't have proper
+  delete permissions over the parent folder
+  [sneridagh]
+
 
 1.0a12 (2017-04-03)
 -------------------

--- a/src/plone/restapi/services/copymove/copymove.py
+++ b/src/plone/restapi/services/copymove/copymove.py
@@ -67,11 +67,15 @@ class BaseCopyMove(Service):
         parents_ids = {}
         for item in source:
             obj = self.get_object(item)
-            if self.is_moving:
-                if not checkPermission('zope2.DeleteObjects', obj):
-                    self.request.response.setStatus(403)
-                    return
             if obj is not None:
+                if self.is_moving:
+                    # To be able to safely move the object, the user requires
+                    # permissions on the parent
+                    if not checkPermission('zope2.DeleteObjects', obj) and \
+                       not checkPermission(
+                            'zope2.DeleteObjects', aq_parent(obj)):
+                        self.request.response.setStatus(403)
+                        return
                 parent = aq_parent(obj)
                 if parent in parents_ids:
                     parents_ids[parent].append(obj.getId())

--- a/src/plone/restapi/tests/test_copymove.py
+++ b/src/plone/restapi/tests/test_copymove.py
@@ -201,6 +201,7 @@ class TestCopyMoveFunctional(unittest.TestCase):
     def test_move_single_object_no_permission_delete_source_raises_403(self):
         api.user.grant_roles(
             username='memberuser', obj=self.folder1, roles=['Manager', ])
+        api.content.transition(obj=self.doc1, transition='publish')
         transaction.commit()
 
         self.api_session.auth = ('memberuser', 'secret')


### PR DESCRIPTION
…roper delete permissions over the parent folder