### PR TITLE
Group membership add/remove

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.0a16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+New Features:
+
+- Manipulate group membership in the @groups endpoint.
+  [jaroel]
 
 
 1.0a15 (2017-05-15)

--- a/docs/source/_json/groups_created.req
+++ b/docs/source/_json/groups_created.req
@@ -13,5 +13,9 @@ Content-Type: application/json
     "roles": [
         "Manager"
     ],
+    "users": [
+        "admin",
+        "test_user_1_"
+    ],
     "title": "Framework Team"
 }

--- a/docs/source/_json/groups_created.req
+++ b/docs/source/_json/groups_created.req
@@ -13,9 +13,9 @@ Content-Type: application/json
     "roles": [
         "Manager"
     ],
+    "title": "Framework Team",
     "users": [
         "admin",
         "test_user_1_"
-    ],
-    "title": "Framework Team"
+    ]
 }

--- a/docs/source/_json/groups_created.resp
+++ b/docs/source/_json/groups_created.resp
@@ -8,18 +8,14 @@ Location: http://localhost:55001/plone/@groups/fwt
   "email": "fwt@plone.org", 
   "groupname": "fwt", 
   "id": "fwt", 
-  "title": "Framework Team",
+  "title": "Framework Team", 
   "users": {
-    "batching": {
-      "@id": "http://localhost:55001/plone/@groups/ploneteam?b_size=1", 
-      "first": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=0", 
-      "last": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=19", 
-      "next": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=1"
-    }, 
+    "@id": "http://localhost:55001/plone/@groups", 
     "items": [
+      "Administrators", 
       "admin", 
       "test_user_1_"
     ], 
-    "items_total": 20
+    "items_total": 3
   }
 }

--- a/docs/source/_json/groups_created.resp
+++ b/docs/source/_json/groups_created.resp
@@ -9,8 +9,17 @@ Location: http://localhost:55001/plone/@groups/fwt
   "groupname": "fwt", 
   "id": "fwt", 
   "title": "Framework Team",
-  "users": [
-    "admin",
-    "test_user_1_"
-  ]
+  "users": {
+    "batching": {
+      "@id": "http://localhost:55001/plone/@groups/ploneteam?b_size=1", 
+      "first": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=0", 
+      "last": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=19", 
+      "next": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=1"
+    }, 
+    "items": [
+      "admin", 
+      "test_user_1_"
+    ], 
+    "items_total": 20
+  }
 }

--- a/docs/source/_json/groups_created.resp
+++ b/docs/source/_json/groups_created.resp
@@ -8,5 +8,9 @@ Location: http://localhost:55001/plone/@groups/fwt
   "email": "fwt@plone.org", 
   "groupname": "fwt", 
   "id": "fwt", 
-  "title": "Framework Team"
+  "title": "Framework Team",
+  "users": [
+    "admin",
+    "test_user_1_"
+  ]
 }

--- a/docs/source/_json/groups_get.resp
+++ b/docs/source/_json/groups_get.resp
@@ -7,18 +7,10 @@ Content-Type: application/json
   "email": "ploneteam@plone.org", 
   "groupname": "ploneteam", 
   "id": "ploneteam", 
-  "title": "Plone Team",
+  "title": "Plone Team", 
   "users": {
-    "batching": {
-      "@id": "http://localhost:55001/plone/@groups/ploneteam?b_size=1", 
-      "first": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=0", 
-      "last": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=19", 
-      "next": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=1"
-    }, 
-    "items": [
-      "admin",
-      "test_user_1_"
-    ], 
-    "items_total": 20
+    "@id": "http://localhost:55001/plone/@groups/ploneteam", 
+    "items": [], 
+    "items_total": 0
   }
 }

--- a/docs/source/_json/groups_get.resp
+++ b/docs/source/_json/groups_get.resp
@@ -7,5 +7,9 @@ Content-Type: application/json
   "email": "ploneteam@plone.org", 
   "groupname": "ploneteam", 
   "id": "ploneteam", 
-  "title": "Plone Team"
+  "title": "Plone Team",
+  "users": [
+    "admin",
+    "test_user_1_"
+  ]
 }

--- a/docs/source/_json/groups_get.resp
+++ b/docs/source/_json/groups_get.resp
@@ -8,8 +8,17 @@ Content-Type: application/json
   "groupname": "ploneteam", 
   "id": "ploneteam", 
   "title": "Plone Team",
-  "users": [
-    "admin",
-    "test_user_1_"
-  ]
+  "users": {
+    "batching": {
+      "@id": "http://localhost:55001/plone/@groups/ploneteam?b_size=1", 
+      "first": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=0", 
+      "last": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=19", 
+      "next": "http://localhost:55001/plone/@groups/ploneteam?b_size=1&b_start=1"
+    }, 
+    "items": [
+      "admin",
+      "test_user_1_"
+    ], 
+    "items_total": 20
+  }
 }

--- a/docs/source/_json/groups_update.req
+++ b/docs/source/_json/groups_update.req
@@ -4,5 +4,10 @@ Authorization: Basic YWRtaW46c2VjcmV0
 Content-Type: application/json
 
 {
-    "email": "ploneteam2@plone.org"
+    "email": "ploneteam2@plone.org",
+    "users": [
+        {
+            "test_user_1_": false
+        }
+    ]
 }

--- a/docs/source/_json/groups_update.req
+++ b/docs/source/_json/groups_update.req
@@ -5,9 +5,7 @@ Content-Type: application/json
 
 {
     "email": "ploneteam2@plone.org",
-    "users": [
-        {
-            "test_user_1_": false
-        }
-    ]
+    "users": {
+        "test_user_1_": false
+    }
 }

--- a/docs/source/groups.rst
+++ b/docs/source/groups.rst
@@ -68,6 +68,9 @@ To update the settings of a group, send a ``PATCH`` request with the group detai
 ..  http:example:: curl httpie python-requests
     :request: _json/groups_update.req
 
+.. note::
+        The 'users' object is a mapping of a user_id and a boolean indirect adding or removing from the group.
+
 A successful response to a PATCH request will be indicated by a :term:`204 No Content` response:
 
 .. literalinclude:: _json/groups_update.resp

--- a/docs/source/groups.rst
+++ b/docs/source/groups.rst
@@ -59,6 +59,7 @@ The server will respond with a ``200 OK`` status code and the JSON representatio
 .. literalinclude:: _json/groups_get.resp
    :language: http
 
+Batching is supported for the 'users' object.
 
 Update Group
 ------------

--- a/docs/source/groups.rst
+++ b/docs/source/groups.rst
@@ -69,7 +69,7 @@ To update the settings of a group, send a ``PATCH`` request with the group detai
     :request: _json/groups_update.req
 
 .. note::
-        The 'users' object is a mapping of a user_id and a boolean indirect adding or removing from the group.
+        The 'users' object is a mapping of a user_id and a boolean indicating adding or removing from the group.
 
 A successful response to a PATCH request will be indicated by a :term:`204 No Content` response:
 

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -58,6 +58,7 @@
     <adapter factory=".catalog.LazyCatalogResultSerializer" />
 
     <adapter factory=".user.SerializeUserToJson" />
+    <adapter factory=".user.SerializeUserToJsonSummary" />
     <adapter factory=".group.SerializeGroupToJson" />
     <adapter factory=".group.SerializeGroupToJsonSummary" />
 

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -59,6 +59,7 @@
 
     <adapter factory=".user.SerializeUserToJson" />
     <adapter factory=".group.SerializeGroupToJson" />
+    <adapter factory=".group.SerializeGroupToJsonSummary" />
 
     <adapter factory=".local_roles.SerializeLocalRolesToJson"
              name="local_roles"

--- a/src/plone/restapi/serializer/group.py
+++ b/src/plone/restapi/serializer/group.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+from plone.restapi.batching import HypermediaBatch
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from Products.PlonePAS.interfaces.group import IGroupData
 from zope.component import adapter
 from zope.component.hooks import getSite
@@ -7,10 +9,7 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 
-@implementer(ISerializeToJson)
-@adapter(IGroupData, Interface)
-class SerializeGroupToJson(object):
-
+class BaseSerializer(object):
     def __init__(self, context, request):
         self.context = context
         self.request = request
@@ -18,6 +17,7 @@ class SerializeGroupToJson(object):
     def __call__(self):
         group = self.context
         portal = getSite()
+
         return {
             '@id': '{}/@groups/{}'.format(
                 portal.absolute_url(),
@@ -27,5 +27,33 @@ class SerializeGroupToJson(object):
             'groupname': group.getGroupName(),
             'email': group.getProperty('email'),
             'title': group.getProperty('title'),
-            'description': group.getProperty('description')
+            'description': group.getProperty('description'),
         }
+
+
+@implementer(ISerializeToJsonSummary)
+@adapter(IGroupData, Interface)
+class SerializeGroupToJsonSummary(BaseSerializer):
+    pass
+
+
+@implementer(ISerializeToJson)
+@adapter(IGroupData, Interface)
+class SerializeGroupToJson(BaseSerializer):
+
+    def __call__(self):
+        data = super(SerializeGroupToJson, self).__call__()
+        group = self.context
+        members = group.getGroupMemberIds()
+        batch = HypermediaBatch(self.request, members)
+
+        users_data = {
+            '@id': batch.canonical_url,
+            'items_total': batch.items_total,
+            'items': list(batch),
+        }
+        if batch.links:
+            users_data['batching'] = batch.links
+
+        data['users'] = users_data
+        return data

--- a/src/plone/restapi/serializer/user.py
+++ b/src/plone/restapi/serializer/user.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from Products.CMFCore.interfaces._tools import IMemberData
 from zope.component import adapter
 from zope.component.hooks import getSite
 from zope.interface import implementer
-from zope.interface import Interface
+from zope.publisher.interfaces import IRequest
 
 
-@implementer(ISerializeToJson)
-@adapter(IMemberData, Interface)
-class SerializeUserToJson(object):
+class BaseSerializer(object):
 
     def __init__(self, context, request):
         self.context = context
@@ -39,3 +38,15 @@ class SerializeUserToJson(object):
             'location': user.getProperty('location'),
             'roles': roles,
         }
+
+
+@implementer(ISerializeToJson)
+@adapter(IMemberData, IRequest)
+class SerializeUserToJson(BaseSerializer):
+    pass
+
+
+@implementer(ISerializeToJsonSummary)
+@adapter(IMemberData, IRequest)
+class SerializeUserToJsonSummary(BaseSerializer):
+    pass

--- a/src/plone/restapi/services/groups/add.py
+++ b/src/plone/restapi/services/groups/add.py
@@ -29,6 +29,7 @@ class GroupsPost(Service):
         description = data.get('description', None)
         roles = data.get('roles', None)
         groups = data.get('groups', None)
+        users = data.get('users', [])
 
         properties = {
             'title': title,
@@ -59,7 +60,10 @@ class GroupsPost(Service):
             raise BadRequest(
                 "Error occurred, could not add group {}.".format(groupname))
 
+        # Add members
         group = gtool.getGroupById(groupname)
+        for userid in users:
+            group.addMember(userid)
 
         self.request.response.setStatus(201)
         self.request.response.setHeader(

--- a/src/plone/restapi/services/groups/get.py
+++ b/src/plone/restapi/services/groups/get.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
@@ -59,7 +60,7 @@ class GroupsGet(Service):
                 for group in groups:
                     serializer = queryMultiAdapter(
                         (group, self.request),
-                        ISerializeToJson
+                        ISerializeToJsonSummary
                     )
                     result.append(serializer())
                 return result
@@ -71,7 +72,7 @@ class GroupsGet(Service):
             for group in self._get_groups():
                 serializer = queryMultiAdapter(
                     (group, self.request),
-                    ISerializeToJson
+                    ISerializeToJsonSummary
                 )
                 result.append(serializer())
             return result

--- a/src/plone/restapi/services/groups/update.py
+++ b/src/plone/restapi/services/groups/update.py
@@ -48,6 +48,7 @@ class GroupsPatch(Service):
         description = data.get('description', None)
         roles = data.get('roles', None)
         groups = data.get('groups', None)
+        users = data.get('users', {})
 
         # Disable CSRF protection
         if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
@@ -65,6 +66,16 @@ class GroupsPatch(Service):
                 properties[id] = data[id]
 
         group.setGroupProperties(properties)
+
+        # Add/remove members
+        memberids = group.getGroupMemberIds()
+        for userid, allow in users.items():
+            if allow:
+                if userid not in memberids:
+                    group.addMember(userid)
+            else:
+                if userid in memberids:
+                    group.removeMember(userid)
 
         self.request.response.setStatus(204)
         return None

--- a/src/plone/restapi/services/principals/get.py
+++ b/src/plone/restapi/services/principals/get.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from itertools import chain
 from plone.app.workflow.browser.sharing import merge_search_results
-from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
 from zope.component import getMultiAdapter
-from zope.component import queryMultiAdapter
 
 
 class PrincipalsGet(Service):
@@ -27,9 +26,9 @@ class PrincipalsGet(Service):
     def serialize_principals(self, principals):
         result = []
         for principal in principals:
-            serializer = queryMultiAdapter(
+            serializer = getMultiAdapter(
                 (principal, self.request),
-                ISerializeToJson
+                ISerializeToJsonSummary
             )
             result.append(serializer())
         return result

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -630,7 +630,8 @@ class TestTraversal(unittest.TestCase):
                 'title': 'Framework Team',
                 'description': 'The Plone Framework Team',
                 'roles': ['Manager'],
-                'groups': ['Administrators']
+                'groups': ['Administrators'],
+                'users': [SITE_OWNER_NAME, TEST_USER_ID]
             },
         )
         save_request_and_response_for_docs('groups_created', response)
@@ -652,6 +653,7 @@ class TestTraversal(unittest.TestCase):
             '/@groups/ploneteam',
             json={
                 'email': 'ploneteam2@plone.org',
+                'users': {TEST_USER_ID: False}
             },
         )
         save_request_and_response_for_docs('groups_update', response)

--- a/src/plone/restapi/tests/test_serializer_group.py
+++ b/src/plone/restapi/tests/test_serializer_group.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from plone import api
+from plone.app.testing import TEST_USER_ID
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from zope.component import getMultiAdapter
 
 import unittest
 
 
-class TestSerializeUserToJsonAdapter(unittest.TestCase):
+class TestSerializeUserToJsonAdapters(unittest.TestCase):
 
     layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
 
@@ -27,10 +29,16 @@ class TestSerializeUserToJsonAdapter(unittest.TestCase):
             title=properties['title'],
             description=properties['description'])
         self.group = self.gtool.getGroupById('ploneteam')
+        self.group.addMember(TEST_USER_ID)
 
     def serialize(self, user):
         serializer = getMultiAdapter((user, self.request),
                                      ISerializeToJson)
+        return serializer()
+
+    def serialize_summary(self, user):
+        serializer = getMultiAdapter((user, self.request),
+                                     ISerializeToJsonSummary)
         return serializer()
 
     def test_serialize_returns_id(self):
@@ -40,3 +48,16 @@ class TestSerializeUserToJsonAdapter(unittest.TestCase):
         self.assertEqual('ploneteam@plone.org', group.get('email'))
         self.assertEqual('Plone Team', group.get('title'))
         self.assertEqual('We are Plone', group.get('description'))
+        self.assertEqual(
+            set(group['users'].keys()),
+            set(['@id', 'items_total', 'items'])
+        )
+
+    def test_summary(self):
+        group = self.serialize_summary(self.group)
+        self.assertTrue(group)
+        self.assertEqual('ploneteam', group.get('id'))
+        self.assertEqual('ploneteam@plone.org', group.get('email'))
+        self.assertEqual('Plone Team', group.get('title'))
+        self.assertEqual('We are Plone', group.get('description'))
+        self.assertNotIn('users', group)


### PR DESCRIPTION
Support adding and removing group members in the add and patch of the `@groups` endpoint.
Group membership is retrievable in the get of a group on the `@groups/[group id]` endpoint as the subobject 'users'.