### PR TITLE
Docs: Fix batching example request/response.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New Features:
 - Automatically publish docker images on hub.docker.com.
   [timo]
 
+Bugfixes:
+
+- Docs: Fix batching example request/response.
+  [lgraf]
+
 
 1.0a16 (2017-05-23)
 -------------------

--- a/docs/source/batching.rst
+++ b/docs/source/batching.rst
@@ -79,8 +79,8 @@ Parameter        Description
 Full example of a batched request and response:
 
 ..  http:example:: curl httpie python-requests
-    :request: _json/types.req
+    :request: _json/batching.req
 
-.. literalinclude:: _json/types.resp
+.. literalinclude:: _json/batching.resp
    :language: http
 


### PR DESCRIPTION
Fixes the example response / request in the [batching docs](http://plonerestapi.readthedocs.io/en/latest/batching.html#parameters).

I broke those in 32227e74 by accidentally replacing the request/response included in the docs with the one from the `@types` endpoint.

Fixes #349