### PR TITLE
Fix ZCML load order issue by explicitly loading permissions.zcml from CMFCore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ New Features:
 - Add endpoints for locking/unlocking.
   [buchi]
 
+Bugfixes:
+
+- Fix ZCML load order issue by explicitly loading permissions.zcml from CMFCore.
+  [lgraf]
+
 
 1.0a20 (2017-07-24)
 -------------------

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -1,6 +1,9 @@
 <configure
     xmlns="http://namespaces.zope.org/zope">
 
+  <!-- Service registrations below need permissions from CMFCore -->
+  <include package="Products.CMFCore" file="permissions.zcml" />
+
   <include package=".auth" />
   <include package=".breadcrumbs"/>
   <include package=".components"/>


### PR DESCRIPTION
The service registrations in [`plone/restapi/services`](https://github.com/plone/plone.restapi/tree/master/src/plone/restapi/services) use permissions that are defined in `Products.CMFCore`'s `permissions.zcml`.

In many cases, `permissions.zcml` has already been loaded by another package, but depending on the exact ZCML load order that happens to play out it may not, causing a `ComponentLookupError`.

The top level ZCML in the `service` package should therefore **explicitly load** `permissions.zcml`. 

Fixes #395 