### PR TITLE
Fix handling of Zope root users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 1.0a23 (unreleased)
 -------------------
 
-- Nothing changed yet.
+Bugfixes:
+
+- Fix JWT authentication for users defined in the Zope root user folder.
+  This fixes https://github.com/plone/plone.restapi/issues/168 and
+  https://github.com/plone/plone.restapi/issues/127.
 
 
 1.0a22 (2017-11-04)
@@ -20,6 +24,7 @@ New Features:
 
 - Include is_folderish property on GET request responses. Fixes #327.
   [sneridagh]
+
 
 Bugfixes:
 

--- a/docs/source/_json/jwt_logged_in.req
+++ b/docs/source/_json/jwt_logged_in.req
@@ -1,3 +1,3 @@
 GET /plone/ HTTP/1.1
 Accept: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.SZDnl_baH5M_StJJrzfbj7o-5My30NmSFbMrhpSX5I4
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.RVl8ZFJWIaA-8ujyulJvw0j3F3qFjIHDIJFK0GF6j_0

--- a/docs/source/_json/jwt_login.resp
+++ b/docs/source/_json/jwt_login.resp
@@ -2,5 +2,5 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.SZDnl_baH5M_StJJrzfbj7o-5My30NmSFbMrhpSX5I4"
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.RVl8ZFJWIaA-8ujyulJvw0j3F3qFjIHDIJFK0GF6j_0"
 }

--- a/docs/source/_json/jwt_login_renew.req
+++ b/docs/source/_json/jwt_login_renew.req
@@ -1,3 +1,3 @@
 POST /plone/@login-renew HTTP/1.1
 Accept: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.SZDnl_baH5M_StJJrzfbj7o-5My30NmSFbMrhpSX5I4
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.RVl8ZFJWIaA-8ujyulJvw0j3F3qFjIHDIJFK0GF6j_0

--- a/docs/source/_json/jwt_login_renew.resp
+++ b/docs/source/_json/jwt_login_renew.resp
@@ -2,5 +2,5 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.SZDnl_baH5M_StJJrzfbj7o-5My30NmSFbMrhpSX5I4"
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.RVl8ZFJWIaA-8ujyulJvw0j3F3qFjIHDIJFK0GF6j_0"
 }

--- a/docs/source/_json/jwt_logout.req
+++ b/docs/source/_json/jwt_logout.req
@@ -1,3 +1,3 @@
 POST /plone/@logout HTTP/1.1
 Accept: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.SZDnl_baH5M_StJJrzfbj7o-5My30NmSFbMrhpSX5I4
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIn0.RVl8ZFJWIaA-8ujyulJvw0j3F3qFjIHDIJFK0GF6j_0

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -153,7 +153,7 @@ class JWTAuthenticationPlugin(BasePlugin):
                 if secret is None:
                     continue
                 try:
-                    payload = jwt.decode(token, secret)
+                    payload = jwt.decode(token, secret + self._path())
                 except jwt.DecodeError:
                     pass
                 except jwt.ExpiredSignatureError:
@@ -162,7 +162,7 @@ class JWTAuthenticationPlugin(BasePlugin):
                     break
         else:
             try:
-                payload = jwt.decode(token, self._secret, verify=verify)
+                payload = jwt.decode(token, self._secret + self._path(), verify=verify)
             except jwt.DecodeError:
                 pass
         return payload
@@ -170,10 +170,13 @@ class JWTAuthenticationPlugin(BasePlugin):
     def _signing_secret(self):
         if self.use_keyring:
             manager = getUtility(IKeyManager)
-            return manager.secret()
+            return manager.secret() + self._path()
         if not self._secret:
             self._secret = GenerateSecret()
-        return self._secret
+        return self._secret + self._path()
+
+    def _path(self):
+        return '/'.join(self.getPhysicalPath())
 
     def delete_token(self, token):
         payload = self._decode_token(token, verify=False)

--- a/src/plone/restapi/profiles/default/metadata.xml
+++ b/src/plone/restapi/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>0002</version>
+  <version>0003</version>
 </metadata>

--- a/src/plone/restapi/setuphandlers.py
+++ b/src/plone/restapi/setuphandlers.py
@@ -1,19 +1,25 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from Products.CMFCore.utils import getToolByName
 from plone.restapi.pas.plugin import JWTAuthenticationPlugin
 
 
 def install_pas_plugin(context):
-    uf = getToolByName(context, 'acl_users')
-    if 'jwt_auth' in uf:
-        return
-    plugin = JWTAuthenticationPlugin('jwt_auth')
-    uf._setObject(plugin.getId(), plugin)
-    plugin = uf['jwt_auth']
-    plugin.manage_activateInterfaces([
-        'IAuthenticationPlugin',
-        'IExtractionPlugin',
-    ])
+    uf_parent = aq_inner(context)
+    while True:
+        uf = getToolByName(uf_parent, 'acl_users')
+        if 'jwt_auth' not in uf:
+            plugin = JWTAuthenticationPlugin('jwt_auth')
+            uf._setObject(plugin.getId(), plugin)
+            plugin = uf['jwt_auth']
+            plugin.manage_activateInterfaces([
+                'IAuthenticationPlugin',
+                'IExtractionPlugin',
+            ])
+        if uf_parent is uf_parent.getPhysicalRoot():
+            break
+        uf_parent = aq_parent(uf_parent)
 
 
 def import_various(context):

--- a/src/plone/restapi/tests/test_auth.py
+++ b/src/plone/restapi/tests/test_auth.py
@@ -92,6 +92,15 @@ class TestLogin(TestCase):
                          res['error']['message'])
         self.assertNotIn('token', res)
 
+    def test_login_with_zope_user(self):
+        self.layer['app'].acl_users.plugins.users.addUser(
+            'zopeuser', 'zopeuser', 'secret')
+        self.request['BODY'] = '{"login": "zopeuser", "password": "secret"}'
+        service = self.traverse()
+        res = service.reply()
+        self.assertEqual(200, self.request.response.getStatus())
+        self.assertIn('token', res)
+
 
 class TestLogout(TestCase):
 

--- a/src/plone/restapi/tests/test_auth.py
+++ b/src/plone/restapi/tests/test_auth.py
@@ -79,6 +79,19 @@ class TestLogin(TestCase):
         res = service.render()
         self.assertIn('token', res)
 
+    def test_login_with_zope_user_fails_without_pas_plugin(self):
+        uf = self.layer['app'].acl_users
+        uf.plugins.users.addUser('zopeuser', 'zopeuser', 'secret')
+        if 'jwt_auth' in uf:
+            uf['jwt_auth'].manage_activateInterfaces([])
+        self.request['BODY'] = '{"login": "zopeuser", "password": "secret"}'
+        service = self.traverse()
+        res = service.reply()
+        self.assertIn('error', res)
+        self.assertEqual('JWT authentication plugin not installed.',
+                         res['error']['message'])
+        self.assertNotIn('token', res)
+
 
 class TestLogout(TestCase):
 

--- a/src/plone/restapi/upgrades/configure.zcml
+++ b/src/plone/restapi/upgrades/configure.zcml
@@ -22,4 +22,15 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 0002 -> 0003 -->
+    <genericsetup:upgradeStep
+        title="Install PAS plugin in Zope root"
+        description=""
+        source="0002"
+        destination="0003"
+        handler="plone.restapi.upgrades.to0003.install_pas_plugin_in_zope_root"
+        profile="plone.restapi:default"
+        />
+
+
 </configure>

--- a/src/plone/restapi/upgrades/to0003.py
+++ b/src/plone/restapi/upgrades/to0003.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.setuphandlers import install_pas_plugin
+from Products.CMFCore.utils import getToolByName
+
+
+def install_pas_plugin_in_zope_root(setup_context):
+    """Install PAS plugin in Zope root
+    """
+    portal = getToolByName(setup_context, 'portal_url').getPortalObject()
+    install_pas_plugin(portal)


### PR DESCRIPTION
Another approach to fix #178, #127, #168 
Obsoletes #378 

- The `@login` endpoints now checks for an installed JWT plugin in the acl_users folder where the logging in user has been found.
- The JWT plugin is also installed in the Zope root acl_users folder.
- Each JWT plugin uses a unique signing secret to prevent authenticating tokens issued by other JWT plugins.