### PR TITLE
Pass context to richtext.output_relative_to

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0b1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- convert richtext using .output_relative_to.
+  Finds the context by walking the frame stack.
+  [jaroel]
 
 
 1.0a23 (2017-11-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.0b1 (unreleased)
 ------------------
 
-- convert richtext using .output_relative_to.
-  Finds the context by walking the frame stack.
+- Convert richtext using .output_relative_to. Direct conversion from RichText
+  if no longer supported as we *always* need a context for the ITransformer.
   [jaroel]
 
 

--- a/src/plone/restapi/interfaces.py
+++ b/src/plone/restapi/interfaces.py
@@ -34,6 +34,15 @@ class IJsonCompatible(Interface):
     """
 
 
+class IContextawareJsonCompatible(IJsonCompatible):
+    """Convert a value to a JSON compatible data structure, using a context.
+    """
+
+    def __init__(value, context,):
+        """Adapts value and a context
+        """
+
+
 class IFieldSerializer(Interface):
     """The field serializer multi adapter serializes the field value into
     JSON compatible python data.

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -17,6 +17,7 @@
     <adapter factory=".dxfields.DefaultFieldSerializer" />
     <adapter factory=".dxfields.FileFieldSerializer" />
     <adapter factory=".dxfields.ImageFieldSerializer" />
+    <adapter factory=".dxfields.RichttextFieldSerializer" />
 
     <configure zcml:condition="installed Products.Archetypes">
         <adapter factory=".atcontent.SerializeToJson" />
@@ -42,7 +43,7 @@
     <adapter factory=".converters.persistent_list_converter" />
     <adapter factory=".converters.persistent_mapping_converter" />
     <adapter factory=".converters.python_datetime_converter" />
-    <adapter factory=".converters.richtext_converter" />
+    <adapter factory=".converters.RichtextDXContextConverter" />
     <adapter factory=".converters.set_converter" />
     <adapter factory=".converters.string_converter" />
     <adapter factory=".converters.time_converter" />

--- a/src/plone/restapi/serializer/dxfields.py
+++ b/src/plone/restapi/serializer/dxfields.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone.app.textfield.interfaces import IRichText
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.interfaces import INamedFileField
 from plone.namedfile.interfaces import INamedImageField
@@ -73,3 +74,10 @@ class FileFieldSerializer(DefaultFieldSerializer):
             'download': url
         }
         return json_compatible(result)
+
+
+@adapter(IRichText, IDexterityContent, Interface)
+class RichttextFieldSerializer(DefaultFieldSerializer):
+    def __call__(self):
+        value = self.get_value()
+        return json_compatible(value, self.context)

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -171,15 +171,6 @@ class TestJsonCompatibleConverters(TestCase):
     def test_timedelta(self):
         self.assertEquals(9.58, json_compatible(timedelta(seconds=9.58)))
 
-    def test_richtext(self):
-        value = RichTextValue(u'<p>Hallöchen</p>',
-                              mimeType='text/html',
-                              outputMimeType='text/html')
-        self.assertEquals({
-            u'content-type': u'text/html',
-            u'data': u'<p>Hallöchen</p>',
-            u'encoding': u'utf-8'}, json_compatible(value))
-
     def test_broken_relation_value(self):
         self.assertEquals(None, json_compatible(RelationValue(12345)))
 


### PR DESCRIPTION
Fixes #424
This changes the serialisers to pass in the correct context.