### PR TITLE
Include descriptions of modified fields in object-modified event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.0a25 (unreleased)
 -------------------
 
-- Nothing changed yet.
+New Features:
+
+- Include descriptions of modified fields in object-modified event.
+  [buchi]
 
 
 1.0a24 (2017-11-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,18 @@ Changelog
 1.0a25 (unreleased)
 -------------------
 
-New Features:
+- Add fullobjects parameter to content GET request.
+  [timo]
+
+- Remove "sharing" attributes from GET response.
+  [timo,jaroel]
 
 - Include descriptions of modified fields in object-modified event.
   [buchi]
+
+- Convert richtext using .output_relative_to. Direct conversion from RichText
+  if no longer supported as we *always* need a context for the ITransformer.
+  [jaroel]
 
 - Add uninstall profile [davilima6]
 

--- a/src/plone/restapi/tests/test_dxcontent_deserializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_deserializer.py
@@ -74,6 +74,16 @@ class TestDXContentDeserializer(unittest.TestCase, OrderingMixin):
         self.assertTrue(getattr(self.portal.doc1, '_handler_called', False),
                         'IObjectEditedEvent not notified')
 
+    def test_deserializer_modified_event_contains_descriptions(self):
+        def handler(obj, event):
+            self.event = event
+        provideHandler(handler, (IDexterityItem, IObjectModifiedEvent,))
+        self.deserialize(body='{"test_textline_field": "My Item"}')
+        self.assertEquals(1, len(self.event.descriptions))
+        self.assertEquals(
+            ('IDXTestDocumentSchema.test_textline_field',),
+            self.event.descriptions[0].attributes)
+
     def test_deserializer_does_not_update_field_without_write_permission(self):
         self.portal.doc1.test_write_permission_field = u'Test Write Permission'
         setRoles(self.portal,


### PR DESCRIPTION
With this event handlers can lookup which fields were modified. It mimics the same behavior as in z3c.form.