### PR TITLE
Add `include_items` option to `SerializeFolderToJson`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ New Features:
 - Add uninstall profile
   [davilima6]
 
+- Add `include_items` option to `SerializeFolderToJson`.
+  [Gagaro]
+
 Bug Fixes:
 
 - Fix error messages for password reset (wrong user and wrong password).

--- a/docs/source/content.rst
+++ b/docs/source/content.rst
@@ -112,7 +112,7 @@ After a successful POST, we can access the resource by sending a GET request to 
 ..  http:example:: curl httpie python-requests
     :request: _json/content_get.req
 
-You can also set the `include_items` GET parameter to an empty string if you don't want to include children.
+You can also set the `include_items` GET parameter to false if you don't want to include children.
 
 
 Successful Response (200 OK)

--- a/docs/source/content.rst
+++ b/docs/source/content.rst
@@ -112,6 +112,8 @@ After a successful POST, we can access the resource by sending a GET request to 
 ..  http:example:: curl httpie python-requests
     :request: _json/content_get.req
 
+You can also set the `include_items` GET parameter to an empty string if you don't want to include children.
+
 
 Successful Response (200 OK)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/plone/restapi/deserializer/__init__.py
+++ b/src/plone/restapi/deserializer/__init__.py
@@ -12,3 +12,16 @@ def json_body(request):
     if not isinstance(data, dict):
         raise DeserializationError('Malformed body')
     return data
+
+
+def boolean_value(value):
+    """
+
+    Args:
+        value: a value representing a boolean which can be
+               a string, a boolean or an integer (usually a string from a GET parameter).
+
+    Returns: a boolean
+
+    """
+    return not value in {False, 'false', 'False', '0', 0}

--- a/src/plone/restapi/deserializer/__init__.py
+++ b/src/plone/restapi/deserializer/__init__.py
@@ -19,9 +19,10 @@ def boolean_value(value):
 
     Args:
         value: a value representing a boolean which can be
-               a string, a boolean or an integer (usually a string from a GET parameter).
+               a string, a boolean or an integer
+                   (usually a string from a GET parameter).
 
     Returns: a boolean
 
     """
-    return not value in {False, 'false', 'False', '0', 0}
+    return value not in {False, 'false', 'False', '0', 0}

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -5,6 +5,7 @@ from Products.Archetypes.interfaces import IBaseFolder
 from Products.Archetypes.interfaces import IBaseObject
 from Products.CMFCore.utils import getToolByName
 from plone.restapi.batching import HypermediaBatch
+from plone.restapi.deserializer import boolean_value
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
@@ -93,7 +94,7 @@ class SerializeFolderToJson(SerializeToJson):
         folder_metadata.update({'is_folderish': True})
         result = folder_metadata
 
-        include_items = self.request.form.get('include_items', True)
+        include_items = boolean_value(self.request.form.get('include_items', True))
         if include_items:
             query = self._build_query()
 

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -91,23 +91,25 @@ class SerializeFolderToJson(SerializeToJson):
         )
 
         folder_metadata.update({'is_folderish': True})
-
-        query = self._build_query()
-
-        catalog = getToolByName(self.context, 'portal_catalog')
-        brains = catalog(query)
-
-        batch = HypermediaBatch(self.request, brains)
-
         result = folder_metadata
-        if not self.request.form.get('fullobjects'):
-            result['@id'] = batch.canonical_url
-        result['items_total'] = batch.items_total
-        if batch.links:
-            result['batching'] = batch.links
 
-        result['items'] = [
-            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
-            for brain in batch
-        ]
+        include_items = self.request.form.get('include_items', True)
+        if include_items:
+            query = self._build_query()
+
+            catalog = getToolByName(self.context, 'portal_catalog')
+            brains = catalog(query)
+
+            batch = HypermediaBatch(self.request, brains)
+
+            if not self.request.form.get('fullobjects'):
+                result['@id'] = batch.canonical_url
+            result['items_total'] = batch.items_total
+            if batch.links:
+                result['batching'] = batch.links
+
+            result['items'] = [
+                getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+                for brain in batch
+            ]
         return result

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -94,7 +94,8 @@ class SerializeFolderToJson(SerializeToJson):
         folder_metadata.update({'is_folderish': True})
         result = folder_metadata
 
-        include_items = boolean_value(self.request.form.get('include_items', include_items))
+        include_items = self.request.form.get('include_items', include_items)
+        include_items = boolean_value(include_items)
         if include_items:
             query = self._build_query()
 
@@ -110,7 +111,9 @@ class SerializeFolderToJson(SerializeToJson):
                 result['batching'] = batch.links
 
             result['items'] = [
-                getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+                getMultiAdapter(
+                    (brain, self.request), ISerializeToJsonSummary
+                )()
                 for brain in batch
             ]
         return result

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -86,7 +86,7 @@ class SerializeFolderToJson(SerializeToJson):
                  'sort_on': 'getObjPositionInParent'}
         return query
 
-    def __call__(self, version=None):
+    def __call__(self, version=None, include_items=True):
         folder_metadata = super(SerializeFolderToJson, self).__call__(
             version=version
         )
@@ -94,7 +94,7 @@ class SerializeFolderToJson(SerializeToJson):
         folder_metadata.update({'is_folderish': True})
         result = folder_metadata
 
-        include_items = boolean_value(self.request.form.get('include_items', True))
+        include_items = boolean_value(self.request.form.get('include_items', include_items))
         if include_items:
             query = self._build_query()
 

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -126,7 +126,8 @@ class SerializeFolderToJson(SerializeToJson):
         folder_metadata.update({'is_folderish': True})
         result = folder_metadata
 
-        include_items = boolean_value(self.request.form.get('include_items', include_items))
+        include_items = self.request.form.get('include_items', include_items)
+        include_items = boolean_value(include_items)
         if include_items:
             query = self._build_query()
 

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -8,6 +8,7 @@ from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import iterSchemata
 from plone.restapi.batching import HypermediaBatch
+from plone.restapi.deserializer import boolean_value
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
@@ -125,7 +126,7 @@ class SerializeFolderToJson(SerializeToJson):
         folder_metadata.update({'is_folderish': True})
         result = folder_metadata
 
-        include_items = self.request.form.get('include_items', include_items)
+        include_items = boolean_value(self.request.form.get('include_items', include_items))
         if include_items:
             query = self._build_query()
 

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -125,6 +125,7 @@ class SerializeFolderToJson(SerializeToJson):
         folder_metadata.update({'is_folderish': True})
         result = folder_metadata
 
+        include_items = self.request.form.get('include_items', include_items)
         if include_items:
             query = self._build_query()
 
@@ -152,5 +153,4 @@ class SerializeFolderToJson(SerializeToJson):
                     )()
                     for brain in batch
                 ]
-
         return result

--- a/src/plone/restapi/tests/test_boolean_value.py
+++ b/src/plone/restapi/tests/test_boolean_value.py
@@ -1,0 +1,42 @@
+import unittest
+
+from plone.restapi.deserializer import boolean_value
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+
+class TestBooleanValue(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def test_true_bool(self):
+        self.assertTrue(boolean_value(True))
+        
+    def test_true_string(self):
+        self.assertTrue(boolean_value('true'))
+        
+    def test_true_string_uppercase(self):
+        self.assertTrue(boolean_value('True'))
+        
+    def test_true_int(self):
+        self.assertTrue(boolean_value(1))
+        
+    def test_true_int_string(self):
+        self.assertTrue(boolean_value('1'))
+   
+    def test_false_bool(self):
+        self.assertFalse(boolean_value(False))
+        
+    def test_false_string(self):
+        self.assertFalse(boolean_value('false'))
+        
+    def test_false_string_uppercase(self):
+        self.assertFalse(boolean_value('False'))
+        
+    def test_false_int(self):
+        self.assertFalse(boolean_value(0))
+        
+    def test_false_int_string(self):
+        self.assertFalse(boolean_value('0'))
+
+    def test_true_other_value(self):
+        self.assertTrue(boolean_value('foobar'))

--- a/src/plone/restapi/tests/test_boolean_value.py
+++ b/src/plone/restapi/tests/test_boolean_value.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 
 from plone.restapi.deserializer import boolean_value
@@ -10,31 +11,31 @@ class TestBooleanValue(unittest.TestCase):
 
     def test_true_bool(self):
         self.assertTrue(boolean_value(True))
-        
+
     def test_true_string(self):
         self.assertTrue(boolean_value('true'))
-        
+
     def test_true_string_uppercase(self):
         self.assertTrue(boolean_value('True'))
-        
+
     def test_true_int(self):
         self.assertTrue(boolean_value(1))
-        
+
     def test_true_int_string(self):
         self.assertTrue(boolean_value('1'))
-   
+
     def test_false_bool(self):
         self.assertFalse(boolean_value(False))
-        
+
     def test_false_string(self):
         self.assertFalse(boolean_value('false'))
-        
+
     def test_false_string_uppercase(self):
         self.assertFalse(boolean_value('False'))
-        
+
     def test_false_int(self):
         self.assertFalse(boolean_value(0))
-        
+
     def test_false_int_string(self):
         self.assertFalse(boolean_value('0'))
 

--- a/src/plone/restapi/tests/test_content_get.py
+++ b/src/plone/restapi/tests/test_content_get.py
@@ -92,6 +92,16 @@ class TestContentGet(unittest.TestCase):
             response_doc.json()
         )
 
+    def test_get_content_include_items(self):
+        response = requests.get(
+            self.portal.folder1.absolute_url() + '?include_items=false',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('items', response.json())
+
     def test_get_content_returns_fullobjects_correct_id(self):
         response = requests.get(
             self.portal.folder1.absolute_url() + '?fullobjects',


### PR DESCRIPTION
This allow to get only the content without its children. It avoids a catalog query when not needed.

I didn't find test for testing the content GET, did I miss them?