### PR TITLE
Ensure the userid returned by `authenticateCredentials` is a byte string.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ npm-debug.log
 .DS_Store
 jmeter.log
 pip-selfcheck.json
+/.idea

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,9 @@ Bug Fixes:
   including all items recursively.
   [sneridagh]
 
+- Fix #443, Ensure the userid returned by `authenticateCredentials` is a byte string and not unicode.
+  [Gagaro]
+
 
 1.0a24 (2017-11-13)
 -------------------

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -117,10 +117,7 @@ class JWTAuthenticationPlugin(BasePlugin):
         if 'sub' not in payload:
             return None
 
-        userid = payload['sub']
-
-        if isinstance(userid, unicode):
-            userid = userid.encode('utf8')
+        userid = payload['sub'].encode('utf8')
 
         if self.store_tokens:
             if userid not in self._tokens:

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -119,6 +119,9 @@ class JWTAuthenticationPlugin(BasePlugin):
 
         userid = payload['sub']
 
+        if isinstance(userid, unicode):
+            userid = userid.encode('utf8')
+
         if self.store_tokens:
             if userid not in self._tokens:
                 return None

--- a/src/plone/restapi/tests/test_pas.py
+++ b/src/plone/restapi/tests/test_pas.py
@@ -72,6 +72,12 @@ class TestJWTAuthenticationPlugin(unittest.TestCase):
             ('admin', 'admin'),
             self.plugin.authenticateCredentials(creds))
 
+    def test_authenticate_credentials_returns_byte_string(self):
+        creds = {}
+        creds['extractor'] = 'jwt_auth'
+        creds['token'] = self.plugin.create_token('admin')
+        self.assertIsInstance(self.plugin.authenticateCredentials(creds)[0], str)
+
     def test_decode_token_after_key_rotation(self):
         token = self.plugin.create_token('admin', timeout=0)
         key_manager = getUtility(IKeyManager)


### PR DESCRIPTION
fix #443