### PR TITLE
Fix workflow translations with unicode characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Build documentation on Plone 5.0.x (before: Plone 4.3.x).
   [timo]
 
+- Fix workflow translations with unicode characters.
+  [Gagaro]
+
 
 1.0b1 (2018-01-05)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 - Fix workflow translations with unicode characters.
   [Gagaro]
 
+- Fix workflow encoding in transition endpoint
+  [Gagaro]
+
 
 1.0b1 (2018-01-05)
 ------------------

--- a/docs/source/_json/workflow_post.resp
+++ b/docs/source/_json/workflow_post.resp
@@ -7,5 +7,5 @@ Content-Type: application/json
   "comments": "", 
   "review_state": "published", 
   "time": "2016-10-21T19:05:00+00:00", 
-  "title": "Published"
+  "title": "Published with accent \u00e9"
 }

--- a/src/plone/restapi/services/workflow/info.py
+++ b/src/plone/restapi/services/workflow/info.py
@@ -42,7 +42,8 @@ class WorkflowInfo(object):
             transitions.append({
                 '@id': '{}/@workflow/{}'.format(
                     self.context.absolute_url(), action['id']),
-                'title': self.context.translate(action['title'].decode('utf8')),
+                'title': self.context.translate(
+                    action['title'].decode('utf8')),
             })
 
         for item, action in enumerate(history):

--- a/src/plone/restapi/services/workflow/info.py
+++ b/src/plone/restapi/services/workflow/info.py
@@ -42,14 +42,16 @@ class WorkflowInfo(object):
             transitions.append({
                 '@id': '{}/@workflow/{}'.format(
                     self.context.absolute_url(), action['id']),
-                'title': self.context.translate(action['title']),
+                'title': self.context.translate(action['title'].decode('utf8')),
             })
 
         for item, action in enumerate(history):
             history[item]['title'] = self.context.translate(
                 wftool.getTitleForStateOnType(
                     action['review_state'],
-                    self.context.portal_type))
+                    self.context.portal_type
+                ).decode('utf8')
+            )
 
         result['workflow'].update({
             'history': json_compatible(history),

--- a/src/plone/restapi/services/workflow/transition.py
+++ b/src/plone/restapi/services/workflow/transition.py
@@ -63,6 +63,6 @@ class WorkflowTransition(Service):
         action['title'] = self.context.translate(
             wftool.getTitleForStateOnType(
                 action['review_state'],
-                self.context.portal_type))
+                self.context.portal_type).decode('utf8'))
 
         return json_compatible(action)

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -85,6 +85,8 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
         set_available_languages()
         quickInstallProduct(portal, 'collective.MockMailHost')
         applyProfile(portal, 'collective.MockMailHost:default')
+        portal.portal_workflow['simple_publication_workflow'].states['published'].title = \
+            u'Published with accent é'.encode('utf8')
 
 
 PLONE_RESTAPI_DX_FIXTURE = PloneRestApiDXLayer()
@@ -130,6 +132,8 @@ class PloneRestApiDXPAMLayer(PloneSandboxLayer):
         applyProfile(portal, 'plone.restapi:testing')
         add_catalog_indexes(portal, DX_TYPES_INDEXES)
         set_available_languages()
+        portal.portal_workflow['simple_publication_workflow'].states['published'].title = \
+            u'Published with accent é'.encode('utf8')
 
 
 PLONE_RESTAPI_DX_PAM_FIXTURE = PloneRestApiDXPAMLayer()
@@ -179,6 +183,8 @@ class PloneRestApiATLayer(PloneSandboxLayer):
         applyProfile(portal, 'plone.restapi:testing')
         set_available_languages()
         portal.portal_workflow.setDefaultChain("simple_publication_workflow")
+        portal.portal_workflow['simple_publication_workflow'].states['published'].title = \
+            u'Published with accent é'.encode('utf8')
 
 
 PLONE_RESTAPI_AT_FIXTURE = PloneRestApiATLayer()

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -85,8 +85,8 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
         set_available_languages()
         quickInstallProduct(portal, 'collective.MockMailHost')
         applyProfile(portal, 'collective.MockMailHost:default')
-        portal.portal_workflow['simple_publication_workflow'].states['published'].title = \
-            u'Published with accent é'.encode('utf8')
+        states = portal.portal_workflow['simple_publication_workflow'].states
+        states['published'].title = u'Published with accent é'.encode('utf8')
 
 
 PLONE_RESTAPI_DX_FIXTURE = PloneRestApiDXLayer()
@@ -132,8 +132,8 @@ class PloneRestApiDXPAMLayer(PloneSandboxLayer):
         applyProfile(portal, 'plone.restapi:testing')
         add_catalog_indexes(portal, DX_TYPES_INDEXES)
         set_available_languages()
-        portal.portal_workflow['simple_publication_workflow'].states['published'].title = \
-            u'Published with accent é'.encode('utf8')
+        states = portal.portal_workflow['simple_publication_workflow'].states
+        states['published'].title = u'Published with accent é'.encode('utf8')
 
 
 PLONE_RESTAPI_DX_PAM_FIXTURE = PloneRestApiDXPAMLayer()
@@ -183,8 +183,8 @@ class PloneRestApiATLayer(PloneSandboxLayer):
         applyProfile(portal, 'plone.restapi:testing')
         set_available_languages()
         portal.portal_workflow.setDefaultChain("simple_publication_workflow")
-        portal.portal_workflow['simple_publication_workflow'].states['published'].title = \
-            u'Published with accent é'.encode('utf8')
+        states = portal.portal_workflow['simple_publication_workflow'].states
+        states['published'].title = u'Published with accent é'.encode('utf8')
 
 
 PLONE_RESTAPI_AT_FIXTURE = PloneRestApiATLayer()

--- a/src/plone/restapi/tests/test_workflow.py
+++ b/src/plone/restapi/tests/test_workflow.py
@@ -89,7 +89,7 @@ class TestWorkflowTransition(TestCase):
         self.request = self.layer['request']
         self.wftool = getToolByName(self.portal, 'portal_workflow')
         login(self.portal, SITE_OWNER_NAME)
-        self.portal.invokeFactory('Document', id='doc1')
+        self.portal.invokeFactory('DXTestDocument', id='doc1')
 
     def traverse(self, path='/plone', accept='application/json',
                  method='POST'):

--- a/src/plone/restapi/tests/test_workflow.py
+++ b/src/plone/restapi/tests/test_workflow.py
@@ -24,7 +24,7 @@ class TestWorkflowInfo(TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
         self.doc1 = self.portal[self.portal.invokeFactory(
-            'Document', id='doc1', title='Test Document')]
+            'DXTestDocument', id='doc1', title='Test Document')]
         wftool = getToolByName(self.portal, 'portal_workflow')
         wftool.doActionFor(self.portal.doc1, 'submit')
         wftool.doActionFor(self.portal.doc1, 'publish')
@@ -37,7 +37,7 @@ class TestWorkflowInfo(TestCase):
         history = info['history']
         self.assertEqual(3, len(history))
         self.assertEqual('published', history[-1][u'review_state'])
-        self.assertEqual('Published', history[-1][u'title'])
+        self.assertEqual(u'Published with accent é', history[-1][u'title'])
 
     def test_workflow_info_unauthorized_history(self):
         login(self.portal, SITE_OWNER_NAME)


### PR DESCRIPTION
I added a workflow in the testing profile (`test_workflow`) which is the `simple_publication_workflow` but with a unicode character in every title. I set it as the workflow for the custom testing types.