### PR TITLE
Batching: Preserve list-like query string params when canonicalizing URLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0b1 (unreleased)
 ------------------
 
+- Batching: Preserve list-like query string params when canonicalizing URLs.
+  [lgraf]
+
 - Allow properties when adding a user.
   This allows setting the fullname by anonymous users.
   [jaroel]

--- a/docs/source/_json/batching.resp
+++ b/docs/source/_json/batching.resp
@@ -5,9 +5,9 @@ Content-Type: application/json
   "@id": "http://localhost:55001/plone/folder/@search", 
   "batching": {
     "@id": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path", 
-    "first": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path&b_start=0", 
-    "last": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path&b_start=5", 
-    "next": "http://localhost:55001/plone/folder/@search?b_size=5&sort_on=path&b_start=5"
+    "first": "http://localhost:55001/plone/folder/@search?b_start=0&b_size=5&sort_on=path", 
+    "last": "http://localhost:55001/plone/folder/@search?b_start=5&b_size=5&sort_on=path", 
+    "next": "http://localhost:55001/plone/folder/@search?b_start=5&b_size=5&sort_on=path"
   }, 
   "items": [
     {

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -92,10 +92,10 @@ class TestBatchingSearch(TestBatchingDXBase):
 
         self.assertDictEqual(
             {u'@id': self.portal_url + '/folder/@search?b_start=2&b_size=2',
-             u'first': self.portal_url + '/folder/@search?b_size=2&b_start=0',
-             u'next': self.portal_url + '/folder/@search?b_size=2&b_start=4',
-             u'prev': self.portal_url + '/folder/@search?b_size=2&b_start=0',
-             u'last': self.portal_url + '/folder/@search?b_size=2&b_start=4',
+             u'first': self.portal_url + '/folder/@search?b_start=0&b_size=2',
+             u'next': self.portal_url + '/folder/@search?b_start=4&b_size=2',
+             u'prev': self.portal_url + '/folder/@search?b_start=0&b_size=2',
+             u'last': self.portal_url + '/folder/@search?b_start=4&b_size=2',
              },
             batch_info)
 
@@ -159,10 +159,10 @@ class TestBatchingCollections(TestBatchingDXBase):
 
         self.assertDictEqual(
             {u'@id': self.portal_url + '/collection?b_start=2&b_size=2',
-             u'first': self.portal_url + '/collection?b_size=2&b_start=0',
-             u'next': self.portal_url + '/collection?b_size=2&b_start=4',
-             u'prev': self.portal_url + '/collection?b_size=2&b_start=0',
-             u'last': self.portal_url + '/collection?b_size=2&b_start=4',
+             u'first': self.portal_url + '/collection?b_start=0&b_size=2',
+             u'next': self.portal_url + '/collection?b_start=4&b_size=2',
+             u'prev': self.portal_url + '/collection?b_start=0&b_size=2',
+             u'last': self.portal_url + '/collection?b_start=4&b_size=2',
              },
             batch_info)
 
@@ -221,10 +221,10 @@ class TestBatchingDXFolders(TestBatchingDXBase):
 
         self.assertDictEqual(
             {u'@id': self.portal_url + '/folder?b_start=2&b_size=2',
-             u'first': self.portal_url + '/folder?b_size=2&b_start=0',
-             u'next': self.portal_url + '/folder?b_size=2&b_start=4',
-             u'prev': self.portal_url + '/folder?b_size=2&b_start=0',
-             u'last': self.portal_url + '/folder?b_size=2&b_start=4',
+             u'first': self.portal_url + '/folder?b_start=0&b_size=2',
+             u'next': self.portal_url + '/folder?b_start=4&b_size=2',
+             u'prev': self.portal_url + '/folder?b_start=0&b_size=2',
+             u'last': self.portal_url + '/folder?b_start=4&b_size=2',
              },
             batch_info)
 
@@ -279,10 +279,10 @@ class TestBatchingSiteRoot(TestBatchingDXBase):
 
         self.assertDictEqual(
             {u'@id': self.portal_url + '/?b_start=2&b_size=2',
-             u'first': self.portal_url + '/?b_size=2&b_start=0',
-             u'next': self.portal_url + '/?b_size=2&b_start=4',
-             u'prev': self.portal_url + '/?b_size=2&b_start=0',
-             u'last': self.portal_url + '/?b_size=2&b_start=4',
+             u'first': self.portal_url + '/?b_start=0&b_size=2',
+             u'next': self.portal_url + '/?b_start=4&b_size=2',
+             u'prev': self.portal_url + '/?b_start=0&b_size=2',
+             u'last': self.portal_url + '/?b_start=4&b_size=2',
              },
             batch_info)
 
@@ -359,10 +359,10 @@ class TestBatchingArchetypes(unittest.TestCase):
 
         self.assertDictEqual(
             {u'@id': self.portal_url + '/folder?b_start=2&b_size=2',
-             u'first': self.portal_url + '/folder?b_size=2&b_start=0',
-             u'next': self.portal_url + '/folder?b_size=2&b_start=4',
-             u'prev': self.portal_url + '/folder?b_size=2&b_start=0',
-             u'last': self.portal_url + '/folder?b_size=2&b_start=4',
+             u'first': self.portal_url + '/folder?b_start=0&b_size=2',
+             u'next': self.portal_url + '/folder?b_start=4&b_size=2',
+             u'prev': self.portal_url + '/folder?b_start=0&b_size=2',
+             u'last': self.portal_url + '/folder?b_start=4&b_size=2',
              },
             batch_info)
 

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -68,6 +68,21 @@ class TestBatchingSearch(TestBatchingDXBase):
             response.json()['@id'],
             self.portal_url + '/folder/@search')
 
+    def test_canonical_url_preserves_multiple_metadata_fields(self):
+        qs = 'b_start=2&b_size=2&metadata_fields=one&metadata_fields=two'
+        response = self.api_session.get('/folder/@search?%s' % qs)
+
+        # Response should contain canonical URL without batching params.
+        # Argument lists like metadata_fields (same query string parameter
+        # repeated multiple times) should be preserved.
+
+        original_qs = parse_qsl(qs)
+        canonicalized_qs = parse_qsl(urlparse(response.json()['@id']).query)
+
+        self.assertEqual(
+            set(original_qs) - set([('b_size', '2'), ('b_start', '2')]),
+            set(canonicalized_qs))
+
     def test_contains_batching_links(self):
         # Fetch the second page of the batch
         response = self.api_session.get('/folder/@search?b_start=2&b_size=2')
@@ -448,6 +463,21 @@ class TestHypermediaBatch(unittest.TestCase):
         self.assertEquals('nohost', parsed_url.netloc)
         self.assertEquals('', parsed_url.path)
 
+    def test_canonical_url_preserves_list_like_query_string_params(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        self.request['QUERY_STRING'] = 'foolist=1&foolist=2'
+        batch = HypermediaBatch(self.request, items)
+
+        # Argument lists (same query string parameter repeated multiple
+        # times) should be preserved.
+
+        self.assertEquals(
+            set([('foolist', '1'), ('foolist', '2')]),
+            set(parse_qsl(urlparse(batch.canonical_url).query))
+        )
+
     def test_canonical_url_strips_batching_params(self):
         items = range(1, 26)
 
@@ -499,6 +529,22 @@ class TestHypermediaBatch(unittest.TestCase):
         batch = HypermediaBatch(self.request, items)
         self.assertDictContainsSubset(
             {'first': 'http://nohost?b_start=0'}, batch.links)
+
+    def test_first_link_preserves_list_like_querystring_params(self):
+        items = range(1, 26)
+
+        self.request.form['b_size'] = 10
+        self.request['QUERY_STRING'] = 'foolist=1&foolist=2'
+        batch = HypermediaBatch(self.request, items)
+
+        # Argument lists (same query string parameter repeated multiple
+        # times) should be preserved.
+
+        batch_params = set([('b_start', '0'), ('b_size', '10')])
+        self.assertEquals(
+            set([('foolist', '1'), ('foolist', '2')]),
+            set(parse_qsl(urlparse(batch.links['first']).query)) - batch_params
+        )
 
     def test_last_link_contained(self):
         items = range(1, 26)


### PR DESCRIPTION
Query string parameters can be **repeated with the same key**, but different values, which is a de-facto standard for passing lists of values in query strings.

These got mangled when creating canonical batch URLs (and other URLs derived from the canonical batch URL, like `next` and `first` links) because we turned the result of `parse_qsl` into a dict.

This change makes sure these list-like query string parameters are preserved.

As a side effect, I also had to modify the order the batching parameters are added to the URLs slightly, but because they're now ordered that should make the URLs more stable overall and tests less brittle for the future.

Fixes #450 