### PR TITLE
Re-enable documentation-generating tests on Plone 5.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0b2 (unreleased)
 ------------------
 
+- Re-enable documentation-generating tests on Plone 5.
+  [lgraf]
+
 - Build documentation on Plone 5.0.x (before: Plone 4.3.x).
   [timo]
 

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -144,8 +144,6 @@ class TestDocumentation(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
-        if PLONE_VERSION.base_version >= '5.1':
-            self.skipTest('Do not run documentation tests for Plone 5')
         self.app = self.layer['app']
         self.request = self.layer['request']
         self.portal = self.layer['portal']
@@ -1071,8 +1069,6 @@ class TestCommenting(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
-        if PLONE_VERSION.base_version >= '5.1':
-            self.skipTest('Do not run documentation tests for Plone 5')
         self.app = self.layer['app']
         self.request = self.layer['request']
         self.portal = self.layer['portal']
@@ -1249,8 +1245,6 @@ class TestPAMDocumentation(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 
     def setUp(self):
-        if PLONE_VERSION.base_version >= '5.1':
-            self.skipTest('Do not run documentation tests for Plone 5')
         self.app = self.layer['app']
         self.request = self.layer['request']
         self.portal = self.layer['portal']


### PR DESCRIPTION
Re-enable documentation-generating tests on Plone 5.

These passed for me locally without any failures.

xref: https://github.com/plone/plone.restapi/pull/471#issuecomment-356292865
  