### PR TITLE
Expandable translations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,20 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+Breaking Changes:
+
+- Make `@translations` endpoint expandable
+  [erral]
+
+- Rename the results attribute in `@translations` endpoint to be 'items'
+  [erral]
+
+- Remove 'language' attribute in `@translations` endpoint from the 
+  top-level response entry
+  [erral]
+
+
+
 New Features:
 
 - Allow users to get their own user information.

--- a/docs/source/_json/translations_get.resp
+++ b/docs/source/_json/translations_get.resp
@@ -2,9 +2,8 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "@id": "http://localhost:55001/plone/en/test-document", 
-  "language": "en", 
-  "translations": [
+  "@id": "http://localhost:55001/plone/en/test-document/@translations", 
+  "items": [
     {
       "@id": "http://localhost:55001/plone/es/test-document", 
       "language": "es"

--- a/docs/source/expansion.rst
+++ b/docs/source/expansion.rst
@@ -1,3 +1,5 @@
+.. _`expansion name`: 
+
 Expansion
 =========
 

--- a/docs/source/translations.rst
+++ b/docs/source/translations.rst
@@ -1,3 +1,5 @@
+.. _`translations`: 
+
 Translations
 ============
 
@@ -63,6 +65,17 @@ endpoint of the content item and provide the language code you want to unlink.:
 
 .. literalinclude:: _json/translations_delete.resp
    :language: http
+
+
+Expansion
+---------
+
+This endpoint can be used with the :ref:`expansion name` mechanism which allows to get additional
+information about a content item in one query, avoiding unnecesary requests.
+
+If a simple ``GET`` request is done on the content item, a new entry will be shown on the `@components`
+entry with the URL of the `@translations` endpoint:
+
 
 
 .. _`plone.app.multilingual`: https://pypi.python.org/pypi/plone.app.multilingual

--- a/docs/source/upgrade-guide.rst
+++ b/docs/source/upgrade-guide.rst
@@ -4,6 +4,20 @@ Upgrade Guide
 This upgrade guide lists all breaking changes in plone.restapi and explains the necessary steps that are needed to upgrade to the lastest version.
 
 
+Upgrading from plone.restapi 1.x
+--------------------------------
+
+The JSON response to a GET request to the :ref:`translations` endpoint does not include
+anymore the language of the actual content item.
+
+The JSON response to a GET request to the :ref:`translations` endpoint includes the actual
+translations in an attribute called `items` instead of `translations`.
+
+These changes were done to behave like the other existing endpoints that are also expandable, which as
+top level information only include the name of the endpoint on the `id` attribute and the actual
+information in an attribute called `items`.
+
+
 Upgrading to plone.restapi 1.0b1
 --------------------------------
 

--- a/docs/source/upgrade-guide.rst
+++ b/docs/source/upgrade-guide.rst
@@ -7,15 +7,47 @@ This upgrade guide lists all breaking changes in plone.restapi and explains the 
 Upgrading from plone.restapi 1.x
 --------------------------------
 
-The JSON response to a GET request to the :ref:`translations` endpoint does not include
-anymore the language of the actual content item.
+When using the `@translations` endpoint in plone.restapi 1.x, the endpoint returned a `language` key
+with the content object's language and a `translations` key with all its translations.
 
-The JSON response to a GET request to the :ref:`translations` endpoint includes the actual
-translations in an attribute called `items` instead of `translations`.
+Now, as the endpoint is expandable we want the endpoint to behave like the other expandable endpoints.
+As top level information we only include the name of the endpoint on the `@id` attribute and the actual
+translations of the content object in an attribute called `items`.
 
-These changes were done to behave like the other existing endpoints that are also expandable, which as
-top level information only include the name of the endpoint on the `id` attribute and the actual
-information in an attribute called `items`.
+This means that now the JSON response to a GET request to the :ref:`translations` endpoint does not
+include anymore the language of the actual content item and the translations in an attribute called
+`items` instead of `translations`.
+
+Old response::
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+    "@id": "http://localhost:55001/plone/en/test-document",
+    "language": "en",
+    "translations": [
+      {
+        "@id": "http://localhost:55001/plone/es/test-document",
+        "language": "es"
+      }
+    ]
+  }
+
+New response::
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+    "@id": "http://localhost:55001/plone/en/test-document/@translations",
+    "items": [
+      {
+        "@id": "http://localhost:55001/plone/es/test-document",
+        "language": "es"
+      }
+    ]
+  }
 
 
 Upgrading to plone.restapi 1.0b1

--- a/src/plone/restapi/services/multilingual/configure.zcml
+++ b/src/plone/restapi/services/multilingual/configure.zcml
@@ -3,6 +3,8 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:zcml="http://namespaces.zope.org/zcml">
 
+    <adapter factory=".pam.Translations" name="translations"/>
+
     <plone:service
       method="GET"
       name="@translations"

--- a/src/plone/restapi/services/multilingual/pam.py
+++ b/src/plone/restapi/services/multilingual/pam.py
@@ -16,12 +16,11 @@ class TranslationInfo(Service):
     def reply(self):
         manager = ITranslationManager(self.context)
         info = {
-            '@id': self.context.absolute_url(),
-            'language': ILanguage(self.context).get_language(),
-            'translations': []}
+            '@id': '{}/@translations'.format(self.context.absolute_url()),
+            'items': []}
         for language, translation in manager.get_translations().items():
             if language != ILanguage(self.context).get_language():
-                info['translations'].append({
+                info['items'].append({
                     '@id': translation.absolute_url(),
                     'language': language,
                 })

--- a/src/plone/restapi/tests/test_translations.py
+++ b/src/plone/restapi/tests/test_translations.py
@@ -43,8 +43,8 @@ class TestTranslationInfo(unittest.TestCase):
             name=u'GET_application_json_@translations')
 
         info = tinfo.reply()
-        self.assertIn('translations', info)
-        self.assertEqual(1, len(info['translations']))
+        self.assertIn('items', info)
+        self.assertEqual(1, len(info['items']))
 
     def test_correct_translation_information(self):
         tinfo = getMultiAdapter(
@@ -52,7 +52,7 @@ class TestTranslationInfo(unittest.TestCase):
             name=u'GET_application_json_@translations')
 
         info = tinfo.reply()
-        tinfo_es = info['translations'][0]
+        tinfo_es = info['items'][0]
         self.assertEqual(
             self.es_content.absolute_url(),
             tinfo_es['@id'])


### PR DESCRIPTION
- Make `@translations` endpoint expandable
- Modify `@translations` endpoint to return results in an attribute called `items` instead of `translations` as previously to behave like the other expandable endpoints.
- Document the upgrade path from the previous version
