### PR TITLE
convert date/times to UTC when exporting, use python-datetime for parsing date strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,7 +84,7 @@ Bugfixes:
 - Fix workflow translations with unicode characters.
   [Gagaro]
 
-- Fix workflow encoding in transition endpoint
+- Fix workflow encoding in transition endpoint.
   [Gagaro]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,12 @@ New Features:
 
 New Features:
 
+- Convert all datetime, DateTime and time instances to UTC before serializing.
+  [thet]
+
+- Use python-dateutil instead of DateTime to parse date strings when de-serializing.
+  [thet]
+
 - Allow users to get their own user information.
   [erral]
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name='plone.restapi',
       zip_safe=False,
       install_requires=[
           'setuptools',
+          'python-dateutil',
           'plone.rest >= 1.0a6',  # json renderer moved to plone.restapi
           'PyJWT',
           'pytz',

--- a/src/plone/restapi/serializer/converters.py
+++ b/src/plone/restapi/serializer/converters.py
@@ -32,9 +32,9 @@ def datetimelike_to_iso(value):
         # timezone aware date/time objects are converted to UTC first.
         utc = pytz.timezone('UTC')
         value = value.astimezone(utc)
-    # if getattr(value, 'microsecond', False):
-    #     # Microseconds are normally not used in Plone
-    #     value.replace(microsecond=0)
+    if getattr(value, 'microsecond', False):
+        # Microseconds are normally not used in Plone
+        value = value.replace(microsecond=0)
     iso = value.isoformat()
     # if value.tzinfo:
     #     # Use "Z" instead of a timezone offset of "+00:00" to indicate UTC.

--- a/src/plone/restapi/serializer/converters.py
+++ b/src/plone/restapi/serializer/converters.py
@@ -32,7 +32,9 @@ def datetimelike_to_iso(value):
         # timezone aware date/time objects are converted to UTC first.
         utc = pytz.timezone('UTC')
         value = value.astimezone(utc)
-    value.replace(microsecond=0)  # Remove microsecond part, we don't need it.
+    # if getattr(value, 'microsecond', False):
+    #     # Microseconds are normally not used in Plone
+    #     value.replace(microsecond=0)
     iso = value.isoformat()
     # if value.tzinfo:
     #     # Use "Z" instead of a timezone offset of "+00:00" to indicate UTC.

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -145,16 +145,16 @@ class TestJsonCompatibleConverters(TestCase):
 
     def test_python_datetime(self):
         value = DateTime('2015/11/23 19:45:55.649027 GMT+3').asdatetime()
-        self.assertEquals(u'2015-11-23T19:45:55+03:00',
+        self.assertEquals(u'2015-11-23T16:45:55+00:00',
                           json_compatible(value))
-        self.assertEquals('"2015-11-23T19:45:55+03:00"',
+        self.assertEquals('"2015-11-23T16:45:55+00:00"',
                           json.dumps(json_compatible(value)))
 
     def test_zope_DateTime(self):
         value = DateTime('2015/11/23 19:45:55.649027 GMT+3')
-        self.assertEquals(u'2015-11-23T19:45:55+03:00',
+        self.assertEquals(u'2015-11-23T16:45:55+00:00',
                           json_compatible(value))
-        self.assertEquals('"2015-11-23T19:45:55+03:00"',
+        self.assertEquals('"2015-11-23T16:45:55+00:00"',
                           json.dumps(json_compatible(value)))
 
     def test_date(self):


### PR DESCRIPTION
Most of the test failures for Plone 5.2 were related to missing initialization of ZServer, which is fixed but not yet merged here: https://github.com/plone/plone.testing/pull/45

Other Plone 5.2 failures were related to date/timezone related offsets which did not match (I do not yet understand why this failures only were apparent for Plone 5.2).

Investigating this, I found out that the date/times were not consistently converted to UTC when exporting. I recall some discussions about this including some contradictory statements including from myself in https://github.com/plone/plone.restapi/issues/253

However, I think since ISO8601 lacks of a concept of timezone names which are necessary to do date math when daylight saving time boundaries are included (timezone offsets do not allow to conclude to DST dates), the most practical thing would be to convert all date/times to UTC when exporting.

This PR addresses this:

- Convert all datetime, DateTime and time instances to UTC before serializing.
- Use python-dateutil instead of DateTime to parse date strings when de-serializing.

please comment, if this approach is going in the right direction!