### PR TITLE
New permission for accessing user information in the GET @user endpoint...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,11 @@ New Features:
 - Render subject vocabulary as items for subjects field.
   [jaroel]
 
+- New permission for accessing user information in the GET @user endpoint
+  `plone.restapi: Access Plone user information` mapped by default to Manager
+  role (as it was before).
+  [sneridagh]
+
 Bugfixes:
 
 - Add VHM support to @search

--- a/src/plone/restapi/permissions.zcml
+++ b/src/plone/restapi/permissions.zcml
@@ -12,4 +12,9 @@
       title="plone.restapi: Access Plone vocabularies"
       />
 
+  <permission
+      id="plone.restapi.getusers"
+      title="plone.restapi: Access Plone user information"
+      />
+
 </configure>

--- a/src/plone/restapi/profiles/default/metadata.xml
+++ b/src/plone/restapi/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>0003</version>
+  <version>0004</version>
 </metadata>

--- a/src/plone/restapi/profiles/default/rolemap.xml
+++ b/src/plone/restapi/profiles/default/rolemap.xml
@@ -7,5 +7,8 @@
       <role name="Manager"/>
       <role name="Site Administrator"/>
     </permission>
+    <permission name="plone.restapi: Access Plone user information" acquire="True">
+      <role name="Manager"/>
+    </permission>
   </permissions>
 </rolemap>

--- a/src/plone/restapi/services/users/get.py
+++ b/src/plone/restapi/services/users/get.py
@@ -94,8 +94,9 @@ class UsersGet(Service):
         mt = getToolByName(self.context, 'portal_membership')
         current_user_id = mt.getAuthenticatedMember().getId()
 
-        if sm.checkPermission('Manage portal', self.context) or \
-                (current_user_id and current_user_id == self._get_user_id):
+        if sm.checkPermission(
+            'plone.restapi: Access Plone user information', self.context) or \
+           (current_user_id and current_user_id == self._get_user_id):
 
             # we retrieve the user on the user id not the username
             user = self._get_user(self._get_user_id)

--- a/src/plone/restapi/tests/test_upgrades.py
+++ b/src/plone/restapi/tests/test_upgrades.py
@@ -25,3 +25,16 @@ class TestUpgrades(TestCase):
         portal_setup = getToolByName(self.portal, 'portal_setup')
         assign_use_api_permission(portal_setup)
         self.assertTrue(True)
+
+    def test_migration_profile_to_0004_can_be_loaded(self):
+        loadMigrationProfile(
+            self.portal,
+            'profile-plone.restapi.upgrades:0004'
+        )
+        self.assertTrue(True)
+
+    def test_run_migration_profile_to_0004(self):
+        from plone.restapi.upgrades.to0004 import assign_get_users_permission
+        portal_setup = getToolByName(self.portal, 'portal_setup')
+        assign_get_users_permission(portal_setup)
+        self.assertTrue(True)

--- a/src/plone/restapi/upgrades/configure.zcml
+++ b/src/plone/restapi/upgrades/configure.zcml
@@ -32,5 +32,13 @@
         profile="plone.restapi:default"
         />
 
+    <genericsetup:registerProfile
+        name="0004"
+        title="plone.restapi.upgrades.0004"
+        description=""
+        directory="profiles/0004"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
 
 </configure>

--- a/src/plone/restapi/upgrades/profiles/0004/rolemap.xml
+++ b/src/plone/restapi/upgrades/profiles/0004/rolemap.xml
@@ -1,0 +1,7 @@
+<rolemap>
+  <permissions>
+    <permission name="plone.restapi: Access Plone user information" acquire="True">
+      <role name="Manager"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/src/plone/restapi/upgrades/to0004.py
+++ b/src/plone/restapi/upgrades/to0004.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+
+def assign_get_users_permission(setup_context):
+    """Assign the 'plone.restapi: Access Plone user information' permission
+       to Managers by default.
+    """
+    setup_context.runImportStepFromProfile(
+        'profile-plone.restapi.upgrades:0004',
+        'rolemap',
+        run_dependencies=False,
+        purge_old=False)


### PR DESCRIPTION
`plone.restapi: Access Plone user information` mapped by default to Manager role (as it was before).