### PR TITLE
Hide upgrade profile from add-ons control panel in 5.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hide upgrades from the add-ons control panel.
+  Fixes `issue 532 <https://github.com/plone/plone.restapi/issues/532>`_.
+  [maurits]
 
 
 2.0.0 (2018-04-27)

--- a/src/plone/restapi/setuphandlers.py
+++ b/src/plone/restapi/setuphandlers.py
@@ -16,6 +16,15 @@ class HiddenProfiles(object):
             u'plone.restapi:uninstall',
         ]
 
+    def getNonInstallableProducts(self):  # pragma: no cover
+        """Do not show on Plone's list of installable products.
+
+        This method is only used in Plone 5.1+.
+        """
+        return [
+            u'plone.restapi.upgrades',
+        ]
+
 
 def install_pas_plugin(context):
     uf_parent = aq_inner(context)

--- a/versions.cfg
+++ b/versions.cfg
@@ -35,6 +35,7 @@ requests = 2.18.4
 collective.xmltestreport = 1.3.4
 
 # Misc
+plone.recipe.zope2instance = 4.4.0
 plone.testing = 4.3.0
 pytz = 2017.3
 zope.interface = 4.1.0


### PR DESCRIPTION
Fixes issue #532.

I had to pin plone.recipe.zope2instance to newer 4.4.0, so buildout would finish locally.
