### PR TITLE
Fix test_documentation (ReadConflictError)

### DIFF
--- a/src/plone/restapi/tests/test_atcontent_serializer.py
+++ b/src/plone/restapi/tests/test_atcontent_serializer.py
@@ -6,6 +6,7 @@ from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.testing import PLONE_RESTAPI_AT_INTEGRATION_TESTING
 from plone.restapi.tests.test_expansion import ExpandableElementFoo
+from zope.component import getGlobalSiteManager
 from zope.component import getMultiAdapter
 from zope.component import provideAdapter
 from zope.interface import Interface
@@ -165,6 +166,12 @@ class TestATContentSerializer(unittest.TestCase):
         obj = self.serialize(self.doc1)
         self.assertIn('foo', obj['@components'])
         self.assertEqual('collapsed', obj['@components']['foo'])
+        gsm = getGlobalSiteManager()
+        gsm.unregisterAdapter(
+            ExpandableElementFoo,
+            (Interface, IBrowserRequest),
+            IExpandableElement,
+            'foo')
 
     def test_get_is_folderish_in_folder(self):
         self.portal.invokeFactory('Folder', id=u'folder')

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -23,8 +23,8 @@ from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from plone.registry.interfaces import IRegistry
 from plone.restapi.testing import PAM_INSTALLED
-from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
-from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING_FREEZETIME  # noqa
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME  # noqa
 from plone.restapi.testing import register_static_uuid_utility
 from plone.restapi.testing import RelativeSession
 from plone.testing.z2 import Browser
@@ -142,11 +142,9 @@ def save_request_and_response_for_docs(name, response):
 
 class TestDocumentation(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME
 
     def setUp(self):
-        if PLONE_VERSION.base_version >= '5.1':
-            self.skipTest('Do not run documentation tests for Plone 5')
         self.app = self.layer['app']
         self.request = self.layer['request']
         self.portal = self.layer['portal']
@@ -1232,11 +1230,9 @@ class TestDocumentation(unittest.TestCase):
 
 class TestCommenting(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME
 
     def setUp(self):
-        if PLONE_VERSION.base_version >= '5.1':
-            self.skipTest('Do not run documentation tests for Plone 5')
         self.app = self.layer['app']
         self.request = self.layer['request']
         self.portal = self.layer['portal']
@@ -1410,11 +1406,9 @@ class TestCommenting(unittest.TestCase):
 @unittest.skipUnless(PAM_INSTALLED, 'plone.app.multilingual is installed by default only in Plone 5')  # NOQA
 class TestPAMDocumentation(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
+    layer = PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING_FREEZETIME
 
     def setUp(self):
-        if PLONE_VERSION.base_version >= '5.1':
-            self.skipTest('Do not run documentation tests for Plone 5')
         self.app = self.layer['app']
         self.request = self.layer['request']
         self.portal = self.layer['portal']

--- a/src/plone/restapi/tests/test_dxcontent_serializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_serializer.py
@@ -168,6 +168,12 @@ class TestDXContentSerializer(unittest.TestCase):
         obj = self.serialize()
         self.assertIn('foo', obj['@components'])
         self.assertEqual('collapsed', obj['@components']['foo'])
+        gsm = getGlobalSiteManager()
+        gsm.unregisterAdapter(
+            ExpandableElementFoo,
+            (Interface, IBrowserRequest),
+            IExpandableElement,
+            'foo')
 
     def test_get_is_folderish(self):
         obj = self.serialize()

--- a/src/plone/restapi/tests/test_expansion.py
+++ b/src/plone/restapi/tests/test_expansion.py
@@ -11,6 +11,7 @@ from plone.restapi.testing import PAM_INSTALLED
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
+from zope.component import getGlobalSiteManager
 from zope.component import provideAdapter
 from zope.interface import alsoProvides
 from zope.interface import Interface
@@ -84,6 +85,19 @@ class TestExpansion(unittest.TestCase):
         self.assertEqual(
             {'@components': {'bar': 'expanded', 'foo': 'expanded'}},
             expandable_elements(None, request))
+
+    def tearDown(self):
+        gsm = getGlobalSiteManager()
+        gsm.unregisterAdapter(
+            ExpandableElementFoo,
+            (Interface, IBrowserRequest),
+            IExpandableElement,
+            'foo')
+        gsm.unregisterAdapter(
+            ExpandableElementBar,
+            (Interface, IBrowserRequest),
+            IExpandableElement,
+            'bar')
 
 
 class TestExpansionFunctional(unittest.TestCase):

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -6,6 +6,7 @@ from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
+from zope.component import getGlobalSiteManager
 from zope.component import provideUtility
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleVocabulary
@@ -120,6 +121,9 @@ class TestVocabularyEndpoint(unittest.TestCase):
         response = self.api_session.get(
             'testdoc/@vocabularies/{}'.format(context_vocab_name))
 
+        gsm = getGlobalSiteManager()
+        gsm.unregisterUtility(provided=IVocabularyFactory,
+                              name=context_vocab_name)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
@@ -133,3 +137,8 @@ class TestVocabularyEndpoint(unittest.TestCase):
                      u'title': u'Document 1',
                      u'token': u'title'}]
             })
+
+    def tearDown(self):
+        gsm = getGlobalSiteManager()
+        gsm.unregisterUtility(provided=IVocabularyFactory,
+                              name='plone.restapi.tests.test_vocabulary')


### PR DESCRIPTION
Fixes https://github.com/plone/plone.restapi/issues/470

The issue was the generation of new transaction ids in ZODB.utils.newTid.
For the documentation test only we patch the newTid to use the unpatched time and gmtime methods, in a new testing layer.
