### PR TITLE
Include translated role title in `@roles` GET

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+New Features:
+
+- Include translated role title in `@roles` GET.
+  [lgraf]
 
 
 2.0.1 (2018-06-22)

--- a/docs/source/_json/roles.resp
+++ b/docs/source/_json/roles.resp
@@ -5,36 +5,43 @@ Content-Type: application/json
   {
     "@id": "http://localhost:55001/plone/@roles/Contributor", 
     "@type": "role", 
-    "id": "Contributor"
+    "id": "Contributor", 
+    "title": "Contributor"
   }, 
   {
     "@id": "http://localhost:55001/plone/@roles/Editor", 
     "@type": "role", 
-    "id": "Editor"
+    "id": "Editor", 
+    "title": "Editor"
   }, 
   {
     "@id": "http://localhost:55001/plone/@roles/Member", 
     "@type": "role", 
-    "id": "Member"
+    "id": "Member", 
+    "title": "Member"
   }, 
   {
     "@id": "http://localhost:55001/plone/@roles/Reader", 
     "@type": "role", 
-    "id": "Reader"
+    "id": "Reader", 
+    "title": "Reader"
   }, 
   {
     "@id": "http://localhost:55001/plone/@roles/Reviewer", 
     "@type": "role", 
-    "id": "Reviewer"
+    "id": "Reviewer", 
+    "title": "Reviewer"
   }, 
   {
     "@id": "http://localhost:55001/plone/@roles/Site Administrator", 
     "@type": "role", 
-    "id": "Site Administrator"
+    "id": "Site Administrator", 
+    "title": "Site Administrator"
   }, 
   {
     "@id": "http://localhost:55001/plone/@roles/Manager", 
     "@type": "role", 
-    "id": "Manager"
+    "id": "Manager", 
+    "title": "Manager"
   }
 ]

--- a/docs/source/roles.rst
+++ b/docs/source/roles.rst
@@ -15,3 +15,6 @@ The server will respond with a list of all groups in the portal:
 
 .. literalinclude:: _json/roles.resp
    :language: http
+
+The role ``title`` is the translated role title as displayed in Plone's
+"Users and Groups" control panel.

--- a/src/plone/restapi/services/roles/get.py
+++ b/src/plone/restapi/services/roles/get.py
@@ -2,6 +2,7 @@
 from Acquisition import aq_inner
 from plone.restapi.services import Service
 from Products.CMFCore.utils import getToolByName
+from zope.i18n import translate
 
 
 class RolesGet(Service):
@@ -14,6 +15,7 @@ class RolesGet(Service):
                 '@type': 'role',
                 '@id': '{}/@roles/{}'.format(self.context.absolute_url(), r),
                 'id': r,
+                'title': translate(r, context=self.request, domain='plone'),
             }
             for r in roles
         ]

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -41,6 +41,9 @@ except pkg_resources.DistributionNotFound:
     PAM_INSTALLED = False
 
 
+ENABLED_LANGUAGES = ['de', 'en', 'es', 'fr']
+
+
 def set_available_languages():
     """Limit available languages to a small set.
 
@@ -48,9 +51,16 @@ def set_available_languages():
     for docs. Depends on our own ModifiableLanguages components
     (see plone.restapi:testing profile).
     """
-    enabled_languages = ['de', 'en', 'es', 'fr']
-    getUtility(IContentLanguages).setAvailableLanguages(enabled_languages)
-    getUtility(IMetadataLanguages).setAvailableLanguages(enabled_languages)
+    getUtility(IContentLanguages).setAvailableLanguages(ENABLED_LANGUAGES)
+    getUtility(IMetadataLanguages).setAvailableLanguages(ENABLED_LANGUAGES)
+
+
+def set_supported_languages(portal):
+    """Set supported languages to the same predictable set for all test layers.
+    """
+    language_tool = getToolByName(portal, 'portal_languages')
+    for lang in ENABLED_LANGUAGES:
+        language_tool.addSupportedLanguage(lang)
 
 
 class DateTimeFixture(Layer):
@@ -98,6 +108,9 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
             SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
         login(portal, SITE_OWNER_NAME)
         setRoles(portal, TEST_USER_ID, ['Manager'])
+
+        set_supported_languages(portal)
+
         applyProfile(portal, 'plone.restapi:default')
         applyProfile(portal, 'plone.restapi:testing')
         add_catalog_indexes(portal, DX_TYPES_INDEXES)
@@ -143,9 +156,8 @@ class PloneRestApiDXPAMLayer(PloneSandboxLayer):
             SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
         login(portal, SITE_OWNER_NAME)
         setRoles(portal, TEST_USER_ID, ['Manager'])
-        language_tool = getToolByName(portal, 'portal_languages')
-        language_tool.addSupportedLanguage('en')
-        language_tool.addSupportedLanguage('es')
+
+        set_supported_languages(portal)
         if portal.portal_setup.profileExists('plone.app.multilingual:default'):
             applyProfile(portal, 'plone.app.multilingual:default')
         applyProfile(portal, 'plone.restapi:default')
@@ -191,6 +203,8 @@ class PloneRestApiATLayer(PloneSandboxLayer):
         z2.installProduct(app, 'plone.restapi')
 
     def setUpPloneSite(self, portal):
+        set_supported_languages(portal)
+
         if portal.portal_setup.profileExists(
                 'Products.ATContentTypes:default'):
             applyProfile(portal, 'Products.ATContentTypes:default')

--- a/src/plone/restapi/tests/test_roles.py
+++ b/src/plone/restapi/tests/test_roles.py
@@ -25,23 +25,44 @@ class TestRolesGet(unittest.TestCase):
         self.assertEqual([
             {u'@id': u'http://localhost:55001/plone/@roles/Contributor',
              u'@type': u'role',
-             u'id': u'Contributor'},
+             u'id': u'Contributor',
+             u'title': u'Contributor'},
             {u'@id': u'http://localhost:55001/plone/@roles/Editor',
              u'@type': u'role',
-             u'id': u'Editor'},
+             u'id': u'Editor',
+             u'title': u'Editor'},
             {u'@id': u'http://localhost:55001/plone/@roles/Member',
              u'@type': u'role',
-             u'id': u'Member'},
+             u'id': u'Member',
+             u'title': u'Member'},
             {u'@id': u'http://localhost:55001/plone/@roles/Reader',
              u'@type': u'role',
-             u'id': u'Reader'},
+             u'id': u'Reader',
+             u'title': u'Reader'},
             {u'@id': u'http://localhost:55001/plone/@roles/Reviewer',
              u'@type': u'role',
-             u'id': u'Reviewer'},
+             u'id': u'Reviewer',
+             u'title': u'Reviewer'},
             {u'@id': u'http://localhost:55001/plone/@roles/Site Administrator',
              u'@type': u'role',
-             u'id': u'Site Administrator'},
+             u'id': u'Site Administrator',
+             u'title': u'Site Administrator'},
             {u'@id': u'http://localhost:55001/plone/@roles/Manager',
              u'@type': u'role',
-             u'id': u'Manager'}],
+             u'id': u'Manager',
+             u'title': u'Manager'}],
             response.json())
+
+    def test_roles_endpoint_translates_role_titles(self):
+        self.api_session.headers.update({'Accept-Language': 'de'})
+        response = self.api_session.get('/@roles')
+
+        self.assertItemsEqual([
+            u'Hinzuf\xfcgen',
+            u'Bearbeiten',
+            u'Benutzer',
+            u'Ansehen',
+            u'Ver\xf6ffentlichen',
+            u'Website-Administrator',
+            u'Verwalten'],
+            [item['title'] for item in response.json()])

--- a/src/plone/restapi/tests/test_roles.py
+++ b/src/plone/restapi/tests/test_roles.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from plone.restapi.testing import RelativeSession
+
+import unittest
+
+
+class TestRolesGet(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({'Accept': 'application/json'})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+    def test_roles_endpoint_lists_roles(self):
+        response = self.api_session.get('/@roles')
+
+        self.assertEqual([
+            {u'@id': u'http://localhost:55001/plone/@roles/Contributor',
+             u'@type': u'role',
+             u'id': u'Contributor'},
+            {u'@id': u'http://localhost:55001/plone/@roles/Editor',
+             u'@type': u'role',
+             u'id': u'Editor'},
+            {u'@id': u'http://localhost:55001/plone/@roles/Member',
+             u'@type': u'role',
+             u'id': u'Member'},
+            {u'@id': u'http://localhost:55001/plone/@roles/Reader',
+             u'@type': u'role',
+             u'id': u'Reader'},
+            {u'@id': u'http://localhost:55001/plone/@roles/Reviewer',
+             u'@type': u'role',
+             u'id': u'Reviewer'},
+            {u'@id': u'http://localhost:55001/plone/@roles/Site Administrator',
+             u'@type': u'role',
+             u'id': u'Site Administrator'},
+            {u'@id': u'http://localhost:55001/plone/@roles/Manager',
+             u'@type': u'role',
+             u'id': u'Manager'}],
+            response.json())


### PR DESCRIPTION
Include translated role title in `@roles` GET:

This returns the translated role name (**as displayed in the "Users and Groups" control panel**) as the title property in the output of the `@roles` endpoint.

Also includes some groundwork in setting up languages (available & supported, request negotiation) consistently during tests.

/cc @erral 

---

Note that the sharing view uses a different set of translations for the same role ID. At first, my intent was to use the same serialization of roles (plus their titles) for both the `@roles` endpoint as well as well as the available roles in the `@sharing` endpoint.

But since Plone itself uses different translations for roles in two places, I would suggest to just handle them seperately in these endpoints as well:

*Examples for how role titles are currently translated in Plone 5:*

### "Users and Groups" Control Panel

<img width="544" alt="roles_en" src="https://user-images.githubusercontent.com/405124/41807781-54518f90-76d4-11e8-8ad7-c6dd830d7403.png">

<img width="635" alt="roles_de" src="https://user-images.githubusercontent.com/405124/41807782-589aedf8-76d4-11e8-8f0c-6fd631481070.png">


---

### Sharing Page

<img width="1155" alt="sharing_roles_en" src="https://user-images.githubusercontent.com/405124/41807765-1e76f4fa-76d4-11e8-9455-2f76023e1549.png">

<img width="1158" alt="sharing_roles_de" src="https://user-images.githubusercontent.com/405124/41807767-2570d582-76d4-11e8-974e-1569cd093ba5.png">

