### PR TITLE
Fix object creation events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@ Bugfixes:
 - Plone 5.2 compatible tests.
   [sunew]
 
+- Fix object creation events. Before this fix, creation events were fired on
+  on empty not yet deserialized objects. Also a modified event was fired after
+  deserializing e newly created object.
+  [buchi]
+
 
 2.1.0 (2018-06-23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ Changelog
 
 Breaking Changes:
 
+- Fix object creation events. Before this fix, creation events were fired on
+  empty not yet deserialized objects. Also a modified event was fired after
+  deserializing e newly created object.
+  Custom content deserializers now must handle the `create` keyword argument,
+  which determines if deserialization is performed during object creation or
+  while updating an object.
+  [buchi]
+
 - Include translated role titles in `@sharing` GET.
   [lgraf]
 
@@ -52,11 +60,6 @@ Bugfixes:
 
 - Plone 5.2 compatible tests.
   [sunew]
-
-- Fix object creation events. Before this fix, creation events were fired on
-  on empty not yet deserialized objects. Also a modified event was fired after
-  deserializing e newly created object.
-  [buchi]
 
 
 2.1.0 (2018-06-23)

--- a/docs/source/upgrade-guide.rst
+++ b/docs/source/upgrade-guide.rst
@@ -64,6 +64,19 @@ New Response::
   }
 
 
+Custom Content Deserializers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have implemented custom content deserializers, you have to handle the
+new ``create`` keyword in the ``__call__`` method, which determines if deserialization
+is performed during object creation or while updating an object.
+
+Deserializers should only fire an ``IObjectModifiedEvent`` event if an object
+has been updated. They should not fire it, when a new object has been created.
+
+See `Dexterity content deserializer <https://github.com/plone/plone.restapi/blob/master/src/plone/restapi/deserializer/dxcontent.py>`_ for an example.
+
+
 Upgrading to plone.restapi 2.x
 ------------------------------
 

--- a/src/plone/restapi/deserializer/atcontent.py
+++ b/src/plone/restapi/deserializer/atcontent.py
@@ -28,7 +28,7 @@ class DeserializeFromJson(OrderingMixin, object):
         self.context = context
         self.request = request
 
-    def __call__(self, validate_all=False, data=None):
+    def __call__(self, validate_all=False, data=None, create=False):
         if data is None:
             data = json_body(self.request)
 
@@ -62,8 +62,9 @@ class DeserializeFromJson(OrderingMixin, object):
                     'error': 'ValidationError'} for f, e in errors.items()]
                 raise BadRequest(errors)
 
-            if obj.checkCreationFlag():
-                obj.unmarkCreationFlag()
+            if create:
+                if obj.checkCreationFlag():
+                    obj.unmarkCreationFlag()
                 notify(ObjectInitializedEvent(obj))
                 obj.at_post_create_script()
             else:

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -35,7 +35,7 @@ class DeserializeFromJson(OrderingMixin, object):
         self.sm = getSecurityManager()
         self.permission_cache = {}
 
-    def __call__(self, validate_all=False, data=None):  # noqa: ignore=C901
+    def __call__(self, validate_all=False, data=None, create=False):  # noqa: ignore=C901
         if data is None:
             data = json_body(self.request)
 
@@ -137,7 +137,7 @@ class DeserializeFromJson(OrderingMixin, object):
         # OrderingMixin
         self.handle_ordering(data)
 
-        if modified:
+        if modified and not create:
             descriptions = []
             for interface, names in modified.items():
                 descriptions.append(Attributes(interface, *names))

--- a/src/plone/restapi/services/content/tus.py
+++ b/src/plone/restapi/services/content/tus.py
@@ -11,6 +11,7 @@ from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.services import Service
 from plone.restapi.services.content.utils import create
 from plone.restapi.services.content.utils import rename
+from plone.restapi.services.content.utils import add
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from uuid import uuid4
 from zExceptions import Unauthorized
@@ -18,6 +19,8 @@ from zope.component import queryMultiAdapter
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
+from zope.lifecycleevent import ObjectCreatedEvent
+from zope.event import notify
 
 import json
 import os
@@ -228,6 +231,8 @@ class UploadPatch(UploadFileBase):
                         filename.lower(), content_type, '') or 'File'
 
                 obj = create(self.context, type_)
+                notify(ObjectCreatedEvent(obj))
+                obj = add(self.context, obj)
             else:
                 obj = self.context
 

--- a/src/plone/restapi/services/content/utils.py
+++ b/src/plone/restapi/services/content/utils.py
@@ -1,11 +1,18 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_base
 from Acquisition import aq_parent
 from DateTime import DateTime
-from Products.CMFPlone.utils import base_hasattr
 from plone.app.content.interfaces import INameFromTitle
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import base_hasattr
 from random import randint
-from zExceptions import BadRequest
+from zExceptions import Unauthorized
+from zope.component import getUtility
+from zope.component.interfaces import IFactory
+from zope.container.contained import notifyContainerModified
+from zope.container.contained import ObjectAddedEvent
 from zope.container.interfaces import INameChooser
+from zope.event import notify
 
 import transaction
 
@@ -22,17 +29,56 @@ def create(container, type_, id_=None, title=None):
             str(now.millis())[7:],
             randint(0, 9999))
     else:
-        new_id = id_
+        if isinstance(id_, unicode):
+            new_id = id_.encode('utf8')
+        else:
+            new_id = id_
 
-    try:
-        new_id = container.invokeFactory(type_, new_id, title=title)
-    except (BadRequest, ValueError) as exc:
-        return {'error': {
-            'type': exc.__class__.__name__,
-            'message': exc.message,
-        }}
+    portal_types = getToolByName(container, 'portal_types')
+    type_info = portal_types.getTypeInfo(type_)
 
-    return container[new_id]
+    # Check for add permission
+    if not type_info.isConstructionAllowed(container):
+        raise Unauthorized('Cannot create %s' % type_info.getId())
+
+    # Check if allowed subobject type
+    container_type_info = portal_types.getTypeInfo(container)
+    if not container_type_info.allowType(type_):
+        raise Unauthorized('Disallowed subobject type: %s' % type_)
+
+    # Check for type constraints
+    if type_ not in [fti.getId() for fti in container.allowedContentTypes()]:
+        raise Unauthorized('Disallowed subobject type: %s' % type_)
+
+    if type_info.product:
+        # Oldstyle factory
+        factory = type_info._getFactoryMethod(container, check_security=0)
+        new_id = factory(new_id, title=title)
+        obj = container._getOb(new_id)
+
+    else:
+        factory = getUtility(IFactory, type_info.factory)
+        obj = factory(new_id, title=title)
+
+    if base_hasattr(obj, '_setPortalTypeName'):
+        obj._setPortalTypeName(type_info.getId())
+
+    return obj
+
+
+def add(container, obj):
+    """Add an object to a container."""
+    id_ = obj.getId()
+    # Archetypes objects are already created in a container thus we just fire
+    # the notification events.
+    if aq_base(container) is aq_base(aq_parent(obj)):
+        notify(ObjectAddedEvent(obj, container, id_))
+        notifyContainerModified(container)
+        return obj
+    else:
+        rval = container._setObject(id_, obj)
+        new_id = isinstance(rval, basestring) and rval or id_
+        return container._getOb(new_id)
 
 
 def rename(obj):

--- a/src/plone/restapi/tests/test_atcontent_deserializer.py
+++ b/src/plone/restapi/tests/test_atcontent_deserializer.py
@@ -45,12 +45,13 @@ class TestATContentDeserializer(unittest.TestCase, OrderingMixin):
                 title='Test doc ' + str(x)
             )
 
-    def deserialize(self, body='{}', validate_all=False, context=None):
+    def deserialize(self, body='{}', validate_all=False, create=False,
+                    context=None):
         context = context or self.doc1
         self.request['BODY'] = body
         deserializer = getMultiAdapter((context, self.request),
                                        IDeserializeFromJson)
-        return deserializer(validate_all=validate_all)
+        return deserializer(validate_all=validate_all, create=create)
 
     def test_deserializer_ignores_readonly_fields(self):
         self.doc1.getField('testReadonlyField').set(self.doc1, 'Readonly')
@@ -70,7 +71,7 @@ class TestATContentDeserializer(unittest.TestCase, OrderingMixin):
 
     def test_deserializer_clears_creation_flag(self):
         self.doc1.markCreationFlag()
-        self.deserialize(body='{"testStringField": "Updated"}')
+        self.deserialize(body='{"testStringField": "Updated"}', create=True)
         self.assertFalse(self.doc1.checkCreationFlag(),
                          'Creation flag not cleared')
 

--- a/src/plone/restapi/tests/test_content_patch.py
+++ b/src/plone/restapi/tests/test_content_patch.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.PortalContent import PortalContent
-from Products.CMFCore.utils import getToolByName
+from OFS.interfaces import IObjectWillBeAddedEvent
+from plone.app.testing import login
+from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import login
-from plone.app.testing import setRoles
 from plone.restapi.testing import PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from Products.CMFCore.PortalContent import PortalContent
+from Products.CMFCore.utils import getToolByName
+from zope.component import getGlobalSiteManager
+from zope.lifecycleevent.interfaces import IObjectAddedEvent
+from zope.lifecycleevent.interfaces import IObjectCreatedEvent
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 import requests
 import transaction
@@ -164,6 +169,38 @@ class TestContentPatch(unittest.TestCase):
         self.assertIn('content-type', response.json()['image'])
         self.assertIn('download', response.json()['image'])
 
+    def test_patch_document_fires_proper_events(self):
+        sm = getGlobalSiteManager()
+        fired_events = []
+
+        def record_event(event):
+            fired_events.append(event.__class__.__name__)
+
+        sm.registerHandler(record_event, (IObjectCreatedEvent,))
+        sm.registerHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.registerHandler(record_event, (IObjectAddedEvent,))
+        sm.registerHandler(record_event, (IObjectModifiedEvent,))
+
+        requests.patch(
+            self.portal.doc1.absolute_url(),
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            json={
+                "description": "123",
+            },
+        )
+
+        self.assertEqual(
+            fired_events,
+            [
+                'ObjectModifiedEvent',
+            ])
+
+        sm.unregisterHandler(record_event, (IObjectCreatedEvent,))
+        sm.unregisterHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectModifiedEvent,))
+
 
 class TestATContentPatch(unittest.TestCase):
 
@@ -196,3 +233,35 @@ class TestATContentPatch(unittest.TestCase):
         transaction.begin()
         brain = self.portal.portal_catalog(UID=self.portal.doc1.UID())[0]
         self.assertEqual(brain.Description, 'Foo Bar')
+
+    def test_patch_document_fires_proper_events(self):
+        sm = getGlobalSiteManager()
+        fired_events = []
+
+        def record_event(event):
+            fired_events.append(event.__class__.__name__)
+
+        sm.registerHandler(record_event, (IObjectCreatedEvent,))
+        sm.registerHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.registerHandler(record_event, (IObjectAddedEvent,))
+        sm.registerHandler(record_event, (IObjectModifiedEvent,))
+
+        requests.patch(
+            self.portal.doc1.absolute_url(),
+            headers={'Accept': 'application/json'},
+            auth=(TEST_USER_NAME, TEST_USER_PASSWORD),
+            json={
+                "description": "123",
+            },
+        )
+
+        self.assertEqual(
+            fired_events,
+            [
+                'ObjectEditedEvent',
+            ])
+
+        sm.unregisterHandler(record_event, (IObjectCreatedEvent,))
+        sm.unregisterHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectModifiedEvent,))

--- a/src/plone/restapi/tests/test_content_post.py
+++ b/src/plone/restapi/tests/test_content_post.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.utils import getToolByName
+from OFS.interfaces import IObjectWillBeAddedEvent
+from plone.app.testing import login
+from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import login
-from plone.app.testing import setRoles
-from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from Products.CMFCore.utils import getToolByName
+from zope.component import getGlobalSiteManager
+from zope.lifecycleevent.interfaces import IObjectAddedEvent
+from zope.lifecycleevent.interfaces import IObjectCreatedEvent
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 import requests
 import transaction
@@ -149,8 +154,62 @@ class TestFolderCreate(unittest.TestCase):
         )
         self.assertEqual(401, response.status_code)
 
+    def test_post_to_folder_without_add_permission_returns_403_forbidden(self):
+        self.portal.folder1.manage_permission(
+            'plone.app.contenttypes: Add Document', [], acquire=False)
+        transaction.commit()
+        response = requests.post(
+            self.portal.folder1.absolute_url(),
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            json={
+                "@type": "Document",
+                "id": "mydocument",
+                "title": "My Document",
+            },
+        )
+        self.assertEqual(403, response.status_code)
 
-class TestFolderCreateAT(unittest.TestCase):
+    def test_post_to_folder_fires_proper_events(self):
+        sm = getGlobalSiteManager()
+        fired_events = []
+
+        def record_event(event):
+            fired_events.append(event.__class__.__name__)
+
+        sm.registerHandler(record_event, (IObjectCreatedEvent,))
+        sm.registerHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.registerHandler(record_event, (IObjectAddedEvent,))
+        sm.registerHandler(record_event, (IObjectModifiedEvent,))
+
+        requests.post(
+            self.portal.folder1.absolute_url(),
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            json={
+                "@type": "Document",
+                "id": "mydocument",
+                "title": "My Document",
+                "description": "123",
+            },
+        )
+
+        self.assertEqual(
+            fired_events,
+            [
+                'ObjectCreatedEvent',
+                'ObjectWillBeAddedEvent',
+                'ObjectAddedEvent',
+                'ContainerModifiedEvent',
+            ])
+
+        sm.unregisterHandler(record_event, (IObjectCreatedEvent,))
+        sm.unregisterHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectModifiedEvent,))
+
+
+class TestATFolderCreate(unittest.TestCase):
 
     layer = PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
 
@@ -196,3 +255,55 @@ class TestFolderCreateAT(unittest.TestCase):
         self.assertEqual(201, response.status_code)
         transaction.begin()
         self.assertIn('test.txt', self.portal.folder1)
+
+    def test_post_with_id_already_in_use_returns_400(self):
+        self.portal.folder1.invokeFactory('Document', 'mydocument')
+        transaction.commit()
+        response = requests.post(
+            self.portal.folder1.absolute_url(),
+            headers={'Accept': 'application/json'},
+            auth=(TEST_USER_NAME, TEST_USER_PASSWORD),
+            json={
+                "@type": "Document",
+                "id": "mydocument",
+                "title": "My Document",
+            },
+        )
+        self.assertEqual(400, response.status_code)
+
+    def test_post_to_folder_fires_proper_events(self):
+        sm = getGlobalSiteManager()
+        fired_events = []
+
+        def record_event(event):
+            fired_events.append(event.__class__.__name__)
+
+        sm.registerHandler(record_event, (IObjectCreatedEvent,))
+        sm.registerHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.registerHandler(record_event, (IObjectAddedEvent,))
+        sm.registerHandler(record_event, (IObjectModifiedEvent,))
+
+        requests.post(
+            self.portal.folder1.absolute_url(),
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            json={
+                "@type": "Document",
+                "id": "mydocument",
+                "title": "My Document",
+                "description": "123",
+            },
+        )
+
+        self.assertEqual(
+            fired_events,
+            [
+                'ObjectInitializedEvent',
+                'ObjectAddedEvent',
+                'ContainerModifiedEvent',
+            ])
+
+        sm.unregisterHandler(record_event, (IObjectCreatedEvent,))
+        sm.unregisterHandler(record_event, (IObjectWillBeAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectAddedEvent,))
+        sm.unregisterHandler(record_event, (IObjectModifiedEvent,))

--- a/src/plone/restapi/tests/test_content_utils.py
+++ b/src/plone/restapi/tests/test_content_utils.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+from Acquisition import aq_parent
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.restapi.services.content.utils import add
+from plone.restapi.services.content.utils import create
+from plone.restapi.services.content.utils import rename
+from plone.restapi.testing import PLONE_RESTAPI_AT_INTEGRATION_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
+from Products.CMFPlone.interfaces import ISelectableConstrainTypes
+from zExceptions import Unauthorized
+
+import unittest
+
+
+class TestCreateContent(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        self.folder = self.portal[self.portal.invokeFactory(
+            'Folder', id='folder', title='My Folder'
+        )]
+
+    def test_create_content_with_provided_id(self):
+        obj = create(self.folder, 'Document', 'my-document')
+        self.assertEqual(obj.portal_type, 'Document')
+        self.assertEqual(obj.getId(), 'my-document')
+
+    def test_create_content_without_provided_id(self):
+        obj = create(self.folder, 'Document')
+        self.assertEqual(obj.portal_type, 'Document')
+        self.assertTrue(obj.getId().startswith('document.'))
+
+    def test_create_content_without_add_permission_raises_unauthorized(self):
+        self.folder.manage_permission(
+            'plone.app.contenttypes: Add Document', [], acquire=False)
+        with self.assertRaises(Unauthorized):
+            create(self.folder, 'Document', 'my-document')
+
+    def test_create_of_disallowed_content_type_raises_unauthorized(self):
+        self.portal.portal_types.Folder.filter_content_types = True
+        self.portal.portal_types.Folder.allowed_content_types = ()
+        with self.assertRaises(Unauthorized):
+            create(self.folder, 'Document', 'my-document')
+
+    def test_create_of_constrained_content_type_raises_unauthorized(self):
+        constrains = ISelectableConstrainTypes(self.folder)
+        constrains.setConstrainTypesMode(1)
+        constrains.setLocallyAllowedTypes(['File'])
+        with self.assertRaises(Unauthorized):
+            create(self.folder, 'Document', 'my-document')
+
+
+class TestATCreateContent(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_AT_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+
+        self.folder = self.portal[self.portal.invokeFactory(
+            'Folder', id='folder', title='My Folder'
+        )]
+
+    def test_create_content_with_provided_id(self):
+        obj = create(self.folder, 'Document', 'my-document')
+        self.assertEqual(obj.portal_type, 'Document')
+        self.assertEqual(obj.getId(), 'my-document')
+
+    def test_create_content_without_provided_id(self):
+        obj = create(self.folder, 'Document')
+        self.assertEqual(obj.portal_type, 'Document')
+        self.assertTrue(obj.getId().startswith('document.'))
+
+    def test_create_content_without_add_permission_raises_unauthorized(self):
+        self.folder.manage_permission(
+            'ATContentTypes: Add Document', [], acquire=False)
+        with self.assertRaises(Unauthorized):
+            create(self.folder, 'Document', 'my-document')
+
+    def test_create_of_disallowed_content_type_raises_unauthorized(self):
+        self.portal.portal_types.Folder.filter_content_types = True
+        self.portal.portal_types.Folder.allowed_content_types = ()
+        with self.assertRaises(Unauthorized):
+            create(self.folder, 'Document', 'my-document')
+
+    def test_create_of_constrained_content_type_raises_unauthorized(self):
+        constrains = ISelectableConstrainTypes(self.folder)
+        constrains.setConstrainTypesMode(1)
+        constrains.setLocallyAllowedTypes(['File'])
+        with self.assertRaises(Unauthorized):
+            create(self.folder, 'Document', 'my-document')
+
+
+class TestAddContent(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        self.folder = self.portal[self.portal.invokeFactory(
+            'Folder', id='folder', title='My Folder'
+        )]
+        self.obj = create(self.folder, 'Document', 'my-document')
+
+    def test_add_content_to_container(self):
+        obj = add(self.folder, self.obj)
+        self.assertEqual(aq_parent(obj), self.folder)
+
+
+class TestATAddContent(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_AT_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+
+        self.folder = self.portal[self.portal.invokeFactory(
+            'Folder', id='folder', title='My Folder'
+        )]
+        self.obj = create(self.folder, 'Document', 'my-document')
+
+    def test_add_content_to_container(self):
+        obj = add(self.folder, self.obj)
+        self.assertEqual(aq_parent(obj), self.folder)
+
+
+class TestRenameContent(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        self.folder = self.portal[self.portal.invokeFactory(
+            'Folder', id='folder', title='My Folder'
+        )]
+        self.obj = add(
+            self.folder, create(self.folder, 'Document', title='My Document'))
+
+    def test_rename_content(self):
+        rename(self.obj)
+        self.assertEqual(self.obj.getId(), 'my-document')
+
+
+class TestATRenameContent(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_AT_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+
+        self.folder = self.portal[self.portal.invokeFactory(
+            'Folder', id='folder', title='My Folder'
+        )]
+        self.obj = add(
+            self.folder, create(self.folder, 'Document', title='My Document'))
+
+    def test_rename_content(self):
+        rename(self.obj)
+        self.assertEqual(self.obj.getId(), 'my-document')


### PR DESCRIPTION
This makes object creation in plone.restapi behave more like TTW object creation.

New objects are now created in the following way:
1. Create an empty object
2. Deserialize it
3. Fire object created event
4. Add object to container
5. Fire object added and container modified events

Before that change new objects were created in the this way:
1. Create an empty object
2. Fire object created event
3. Add object to container
4. Fire object added and container modified events
5. Deserialize object
6. Fire modified event
