### PR TITLE
Have tests fail on Sphinx documentation errors / warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - bin/sphinxbuilder
   - bin/test
   - bin/test-no-uncommitted-doc-changes
+  - bin/test-no-sphinx-warnings
 after_success:
   - bin/test-coverage
   - pip install coverage==3.7.1 coveralls

--- a/base.cfg
+++ b/base.cfg
@@ -7,6 +7,7 @@ parts =
     coverage
     test-coverage
     test-no-uncommitted-doc-changes
+    test-no-sphinx-warnings
     code-analysis
     dependencychecker
     releaser
@@ -65,6 +66,11 @@ input = test-no-uncommitted-doc-changes.in
 output = bin/test-no-uncommitted-doc-changes
 mode = 755
 
+[test-no-sphinx-warnings]
+recipe = collective.recipe.template
+input = test-no-sphinx-warnings.in
+output = bin/test-no-sphinx-warnings
+mode = 755
 
 [code-analysis]
 recipe = plone.recipe.codeanalysis

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -46,11 +46,3 @@ Glossary
 
     Basic Auth
         A simple :term:`Authentication Method` referenced in the :term:`Authorization Header` that needs to be provided by the server.
-
-    Client
-
-    Server
-
-    Network
-
-    Socket

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Contents
    :maxdepth: 2
 
    authentication
+   exploring
    content
    history
    batching
@@ -31,8 +32,10 @@ Contents
    sharing
    registry
    types
+   types-schema
    users
    groups
+   principals
    roles
    components
    breadcrumbs
@@ -46,6 +49,7 @@ Contents
    conventions
    translations
    email-send
+   email-notification
    upgrade-guide
 
 .. include:: ../../README.rst

--- a/docs/source/roles.rst
+++ b/docs/source/roles.rst
@@ -9,9 +9,9 @@ List Roles
 To retrieve a list of all roles in the portal, call the ``/@roles`` endpoint with a ``GET`` request:
 
 ..  http:example:: curl httpie python-requests
-    :request: _json/groups.req
+    :request: _json/roles.req
 
-The server will respond with a list of all groups in the portal:
+The server will respond with a list of all roles in the portal:
 
 .. literalinclude:: _json/roles.resp
    :language: http

--- a/docs/source/sharing.rst
+++ b/docs/source/sharing.rst
@@ -11,10 +11,12 @@ Retrieve Local Roles
 
 In plone.restapi, the representation of any content object will include a hypermedia link to the local role / sharing information in the 'sharing' attribute:
 
-.. code:: json
+.. code-block:: http
 
-  GET /plone/folder
+  GET /plone/folder HTTP/1.1
   Accept: application/json
+
+.. code::
 
   HTTP 200 OK
   content-type: application/json

--- a/test-no-sphinx-warnings.in
+++ b/test-no-sphinx-warnings.in
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# CI test that should fail if there are warnings or even errors when building
+# the Sphinx docs.
+
+set -euo pipefail
+
+BUILD_LOG="sphinx_build.log"
+
+function red {
+    RED=$(tput setaf 1)
+    RESET=$(tput sgr0)
+    echo "$RED $1 $RESET"
+}
+
+bin/sphinxbuilder 2>&1 | tee $BUILD_LOG
+BUILD_RETCODE=$?
+
+! grep -q 'WARNING: ' $BUILD_LOG
+WARNINGS=$?
+
+# Fail the build if either
+# - exit code is 1
+# - or there are WARNINGs in Sphinx build output
+
+if [[ $WARNINGS = 1 || $BUILD_RETCODE = 1 ]]; then
+    red "ERROR: There have been warnings or errors when building Sphinx docs!"
+    red ""
+    red "This probably means these have been introduced by your changes."
+    red "Please take the time to check the output of the Sphinx build and"
+    red "address these warnings."
+    red ""
+    red "You should see the Sphinx build output just above, or you can run"
+    red "bin/sphinxbuilder"
+    red "locally to build the documentation (and then open docs/html/index.html"
+    red "to view it)."
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
Adds a **test that fails if Sphinx build has warnings or errors.**

*(Changelog entry omitted on purpose since it's not a user-visible bugfix/feature)* 

This is so we can keep documentation at a high quality level, and avoid piling up too many warnings. Especially frustrating is documentation that has been carefully written, but never got published because it wasn't included in a toctree.

The test is a simple bash script that checks the output and return code of `bin/sphinxbuild` and errors out to fail the build if either
- `bin/sphinxbuild` exited with return code 1 (hard errors)
- the output contains WARNINGs

In addition, I fixed all the existing Sphinx warnings.

The build failure is displayed in a way on travis where it should be immediately visible to developers / first time contributors why the build failed.

---

Example [travis build failure](https://travis-ci.org/plone/plone.restapi/jobs/395849798#L2700):

<img width="690" alt="sphinx_warnings" src="https://user-images.githubusercontent.com/405124/41812920-47bc1d6a-772c-11e8-8798-b833b5461229.png">
