### PR TITLE
Make sure DX DefaultFieldDeserializer validates field values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bugfixes:
+
+- Make sure DX DefaultFieldDeserializer validates field values.
+  [lgraf]
 
 
 2.1.0 (2018-06-23)

--- a/src/plone/restapi/deserializer/dxfields.py
+++ b/src/plone/restapi/deserializer/dxfields.py
@@ -39,8 +39,12 @@ class DefaultFieldDeserializer(object):
 
     def __call__(self, value):
         if not isinstance(value, unicode):
+            self.field.validate(value)
             return value
-        return IFromUnicode(self.field).fromUnicode(value)
+
+        value = IFromUnicode(self.field).fromUnicode(value)
+        # IFromUnicode.fromUnicode() will validate, no need to do it twice
+        return value
 
 
 @implementer(IFieldDeserializer)

--- a/src/plone/restapi/tests/test_dxfield_deserializer.py
+++ b/src/plone/restapi/tests/test_dxfield_deserializer.py
@@ -378,12 +378,22 @@ class TestDXFieldDeserializer(unittest.TestCase):
     def test_collection_deserializer_validates_value(self):
         with self.assertRaises(ValidationError) as cm:
             self.deserialize('test_list_value_type_field', [1, '2', 3])
-        self.assertEqual(u'Wrong contained type', cm.exception.doc())
+
+        # This validation error is actually produced by the
+        # DefaultFieldDeserializer that the CollectionFieldDeserializer will
+        # delegate to for deserializing collection items.
+        self.assertEqual(u'Object is of wrong type.', cm.exception.doc())
+        self.assertEqual(('2', (int, long), ''), cm.exception.args)
 
     def test_dict_deserializer_validates_value(self):
         with self.assertRaises(ValidationError) as cm:
             self.deserialize('test_dict_key_type_field', {'k': 'v'})
-        self.assertEqual(u'Wrong contained type', cm.exception.doc())
+
+        # This validation error is actually produced by the
+        # DefaultFieldDeserializer that the DictFieldSerializer will delegate
+        # to for deserializing keys and values.
+        self.assertEqual(u'Object is of wrong type.', cm.exception.doc())
+        self.assertEqual(('k', (int, long), ''), cm.exception.args)
 
     def test_time_deserializer_handles_invalid_value(self):
         with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
Make sure DX `DefaultFieldDeserializer` validates field values.