### PR TITLE
Include translated role titles in `@sharing` GET

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,15 @@
 Changelog
 =========
 
-2.1.1 (unreleased)
+3.0.0 (unreleased)
 ------------------
+
+Breaking Changes:
+
+- Include translated role titles in `@sharing` GET.
+  [lgraf]
+
+New Features:
 
 - Translate action name, workflow state and transition names in @history endpoint.
   [erral]

--- a/docs/source/_json/sharing_folder_get.resp
+++ b/docs/source/_json/sharing_folder_get.resp
@@ -3,10 +3,22 @@ Content-Type: application/json
 
 {
   "available_roles": [
-    "Contributor", 
-    "Editor", 
-    "Reviewer", 
-    "Reader"
+    {
+      "id": "Contributor", 
+      "title": "Can add"
+    }, 
+    {
+      "id": "Editor", 
+      "title": "Can edit"
+    }, 
+    {
+      "id": "Reader", 
+      "title": "Can view"
+    }, 
+    {
+      "id": "Reviewer", 
+      "title": "Can review"
+    }
   ], 
   "entries": [
     {

--- a/docs/source/_json/sharing_folder_get_include_titles.req
+++ b/docs/source/_json/sharing_folder_get_include_titles.req
@@ -1,0 +1,3 @@
+GET /plone/folder/@sharing?include_titles=1 HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0

--- a/docs/source/_json/sharing_folder_post.req
+++ b/docs/source/_json/sharing_folder_post.req
@@ -6,7 +6,7 @@ Content-Type: application/json
 {
     "entries": [
         {
-            "id": "test_user_1_",
+            "id": "AuthenticatedUsers",
             "roles": {
                 "Contributor": false,
                 "Editor": false,

--- a/docs/source/_json/sharing_search.resp
+++ b/docs/source/_json/sharing_search.resp
@@ -3,10 +3,22 @@ Content-Type: application/json
 
 {
   "available_roles": [
-    "Contributor", 
-    "Editor", 
-    "Reviewer", 
-    "Reader"
+    {
+      "id": "Contributor", 
+      "title": "Can add"
+    }, 
+    {
+      "id": "Editor", 
+      "title": "Can edit"
+    }, 
+    {
+      "id": "Reader", 
+      "title": "Can view"
+    }, 
+    {
+      "id": "Reviewer", 
+      "title": "Can review"
+    }
   ], 
   "entries": [
     {

--- a/docs/source/sharing.rst
+++ b/docs/source/sharing.rst
@@ -39,6 +39,10 @@ The sharing information of a content object can also be directly accessed by app
 .. literalinclude:: _json/sharing_folder_get.resp
    :language: http
 
+The ``available_roles`` property contains the list of roles that can be
+managed via the sharing page. It contains dictionaries with the role ID and
+its translated ``title`` (as it appears on the sharing page).
+
 
 Users and/or groups without a sharing entry can be found by appending the argument `search` to the query string. ie search=admin.
 Global roles are marked with the string "global". Inherited roles are marked with the string "acquired".

--- a/docs/source/sharing.rst
+++ b/docs/source/sharing.rst
@@ -6,10 +6,10 @@ Sharing
 Plone comes with a sophisticated user management system that allows to assign users and groups with global roles and permissions. Sometimes this in not enough though and you might want to give users the permission to access or edit a specific part of your website or a specific content object. This is where local roles (located in the Plone sharing tab) come in handy.
 
 
-Retrieve Local Roles
---------------------
+Retrieving Local Roles
+----------------------
 
-In plone.restapi, the representation of any content object will include a hypermedia link to the local role / sharing information in the 'sharing' attribute:
+In plone.restapi, the representation of any content object will include a hypermedia link to the local role / sharing information in the ``sharing`` attribute:
 
 .. code-block:: http
 
@@ -31,7 +31,7 @@ In plone.restapi, the representation of any content object will include a hyperm
     }
   }
 
-The sharing information of a content object can also be directly accessed by appending '/@sharing' to the GET request to the URL of a content object. E.g. to access the sharing information for a top-level folder, do:
+The sharing information of a content object can also be directly accessed by appending ``/@sharing`` to the GET request to the URL of a content object. E.g. to access the sharing information for a top-level folder, do:
 
 ..  http:example:: curl httpie python-requests
     :request: _json/sharing_folder_get.req
@@ -44,8 +44,11 @@ managed via the sharing page. It contains dictionaries with the role ID and
 its translated ``title`` (as it appears on the sharing page).
 
 
-Users and/or groups without a sharing entry can be found by appending the argument `search` to the query string. ie search=admin.
-Global roles are marked with the string "global". Inherited roles are marked with the string "acquired".
+Searching for principals
+------------------------
+
+Users and/or groups without a sharing entry can be found by appending the argument ``search`` to the query string. ie ``?search=admin``.
+Global roles are marked with the string ``"global"``. Inherited roles are marked with the string ``"acquired"``.
 
 ..  http:example:: curl httpie python-requests
     :request: _json/sharing_search.req
@@ -54,10 +57,10 @@ Global roles are marked with the string "global". Inherited roles are marked wit
    :language: http
 
 
-Update Local Roles
-------------------
+Updating Local Roles
+--------------------
 
-You can update the 'sharing' information by sending a POST request to the object URL and appending '/@sharing', e.g. '/plone/folder/@sharing'. E.g. say you want to give the AuthenticatedUsers group the 'reader' local role for a folder:
+You can update the 'sharing' information by sending a POST request to the object URL and appending ``/@sharing``, e.g. ``/plone/folder/@sharing``. E.g. say you want to give the ``AuthenticatedUsers`` group the ``Reader`` local role for a folder:
 
 ..  http:example:: curl httpie python-requests
     :request: _json/sharing_folder_post.req

--- a/docs/source/upgrade-guide.rst
+++ b/docs/source/upgrade-guide.rst
@@ -4,6 +4,66 @@ Upgrade Guide
 This upgrade guide lists all breaking changes in plone.restapi and explains the necessary steps that are needed to upgrade to the lastest version.
 
 
+Upgrading to plone.restapi 3.x
+------------------------------
+
+@sharing endpoint
+^^^^^^^^^^^^^^^^^
+
+The ``available_roles`` property in the response to a GET request to the
+``@sharing`` endpoint has changed: Instead of a flat list of strings, it now
+contains a list of dicts, with the role ID and their translated title:
+
+Old Response::
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  
+  {
+    "available_roles": [
+      "Contributor",
+      "Editor",
+      "Reviewer",
+      "Reader"
+    ],
+    "entries": [
+        "..."
+    ],
+    "inherit": true
+  }
+
+
+New Response::
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  
+  {
+    "available_roles": [
+      {
+        "id": "Contributor",
+        "title": "Can add"
+      },
+      {
+        "id": "Editor",
+        "title": "Can edit"
+      },
+      {
+        "id": "Reader",
+        "title": "Can view"
+      },
+      {
+        "id": "Reviewer",
+        "title": "Can review"
+      }
+    ],
+    "entries": [
+        "..."
+    ],
+    "inherit": true
+  }
+
+
 Upgrading to plone.restapi 2.x
 ------------------------------
 

--- a/src/plone/restapi/serializer/local_roles.py
+++ b/src/plone/restapi/serializer/local_roles.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from AccessControl.interfaces import IRoleManager
 from Acquisition import aq_base
-
+from operator import itemgetter
+from plone.app.workflow.interfaces import ISharingPageRole
 from plone.restapi.interfaces import ISerializeToJson
 from zope.component import adapter
 from zope.component import getMultiAdapter
-from zope.interface import Interface
+from zope.component import queryUtility
+from zope.i18n import translate
 from zope.interface import implementer
+from zope.interface import Interface
 
 
 @adapter(IRoleManager, Interface)
@@ -17,12 +20,25 @@ class SerializeLocalRolesToJson(object):
         self.context = context
         self.request = request
 
+    def _get_title(self, role_id):
+        util = queryUtility(ISharingPageRole, name=role_id)
+        if not util:
+            return role_id
+        return util.title
+
     def __call__(self, search=None):
         self.request.form['search_term'] = search
         sharing_view = getMultiAdapter((self.context, self.request),
                                        name='sharing')
         local_roles = sharing_view.role_settings()
-        available_roles = [r['id'] for r in sharing_view.roles()]
+
+        available_roles = []
+        for role in sorted(sharing_view.roles(), key=itemgetter('id')):
+            util = queryUtility(ISharingPageRole, name=role['id'])
+            title = util.title
+            available_roles.append({
+                'id': role['id'],
+                'title': translate(title, context=self.request)})
 
         blocked_roles = getattr(
             aq_base(self.context),

--- a/src/plone/restapi/services/content/sharing.py
+++ b/src/plone/restapi/services/content/sharing.py
@@ -26,7 +26,8 @@ class SharingGet(Service):
             self.request.response.setStatus(501)
             return dict(error=dict(message='No serializer available.'))
 
-        return serializer(search=self.request.form.get('search'))
+        search = self.request.form.get('search')
+        return serializer(search=search)
 
 
 class SharingPost(Service):

--- a/src/plone/restapi/tests/test_content_local_roles.py
+++ b/src/plone/restapi/tests/test_content_local_roles.py
@@ -114,6 +114,21 @@ class TestFolderCreate(unittest.TestCase):
         roles = roles[0]['roles']
         self.assertEqual(new_roles, roles)
 
+    def test_sharing_titles_are_translated(self):
+        response = requests.get(
+            self.portal.folder1.absolute_url() + '/@sharing',
+            headers={'Accept': 'application/json',
+                     'Accept-Language': 'de'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        available_roles = response.json()['available_roles']
+        self.assertEqual([
+            {u'id': u'Contributor', u'title': u'Kann hinzuf\xfcgen'},
+            {u'id': u'Editor', u'title': u'Kann bearbeiten'},
+            {u'id': u'Reader', u'title': u'Kann ansehen'},
+            {u'id': u'Reviewer', u'title': u'Kann ver\xf6ffentlichen'}],
+            available_roles)
+
     def test_sharing_requires_delegate_roles_permission(self):
         '''A response for an object without any roles assigned'''
         response = requests.get(
@@ -134,7 +149,11 @@ class TestFolderCreate(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {u'available_roles': [u'Contributor', u'Editor', u'Reviewer', u'Reader'],  # noqa
+            {u'available_roles': [
+                {u'id': u'Contributor', u'title': u'Can add'},
+                {u'id': u'Editor', u'title': u'Can edit'},
+                {u'id': u'Reader', u'title': u'Can view'},
+                {u'id': u'Reviewer', u'title': u'Can review'}],
              u'entries': [{
                  u'disabled': False,
                  u'id': u'AuthenticatedUsers',
@@ -163,7 +182,11 @@ class TestFolderCreate(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {u'available_roles': [u'Contributor', u'Editor', u'Reviewer', u'Reader'],  # noqa
+            {u'available_roles': [
+                {u'id': u'Contributor', u'title': u'Can add'},
+                {u'id': u'Editor', u'title': u'Can edit'},
+                {u'id': u'Reader', u'title': u'Can view'},
+                {u'id': u'Reviewer', u'title': u'Can review'}],
              u'entries': [
                 {
                     u'disabled': False,
@@ -320,7 +343,8 @@ class TestFolderCreate(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         response = response.json()
         self.assertIn('available_roles', response)
-        self.assertIn('Reader', response['available_roles'])
+        self.assertIn({'id': 'Reader', 'title': 'Can view'},
+                      response['available_roles'])
 
     def test_inherited_global(self):
         api.user.grant_roles(username=TEST_USER_ID, roles=['Reviewer'])

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -993,7 +993,7 @@ class TestDocumentation(unittest.TestCase):
             "inherit": True,
             "entries": [
                 {
-                    "id": "test_user_1_",
+                    "id": "AuthenticatedUsers",
                     "roles": {
                         "Reviewer": True,
                         "Editor": False,


### PR DESCRIPTION
⚠️ breaking change - planned for 3.0.0 ⚠️ 

---

This will include translated role titles in the `available_roles` property of a `@sharing` GET response.

This is a breaking change, since the `available_roles` property will now, instead of a flat list of strings, contain a list of dicts with role IDs and their translated titles.

---

For reference, this is how role titles are currently being displayed / translated in Plone 5:

### Sharing page

<img width="1155" alt="sharing_roles_en" src="https://user-images.githubusercontent.com/405124/41817916-a571ad9e-77a4-11e8-97fb-8a02c6a0a2c9.png">
<img width="1158" alt="sharing_roles_de" src="https://user-images.githubusercontent.com/405124/41817917-a877773a-77a4-11e8-9b5e-1e3072a1a7b9.png">
