### PR TITLE
Fix change password on Plone 5.2.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Bugfixes:
 - Reindex AT content on PATCH. This fixes `issue 531 <https://github.com/plone/plone.restapi/issues/531>`_.
   [buchi]
 
+- Fix change password on Plone 5.2
+  [sunew]
+
 
 2.1.0 (2018-06-23)
 ------------------

--- a/src/plone/restapi/services/users/update.py
+++ b/src/plone/restapi/services/users/update.py
@@ -46,6 +46,10 @@ class UsersPatch(Service):
         portal_membership = getToolByName(portal, 'portal_membership')
         return portal_membership.getMemberById(user_id)
 
+    def _change_user_password(self, user, value):
+        acl_users = getToolByName(self.context, 'acl_users')
+        acl_users.userSetPassword(user.getUserId(), value)
+
     def reply(self):
         user_settings_to_update = json.loads(self.request.get('BODY', '{}'))
         user = self._get_user(self._get_user_id)
@@ -60,7 +64,7 @@ class UsersPatch(Service):
         if self.can_manage_users:
             for key, value in user_settings_to_update.items():
                 if key == 'password':
-                    user.userSetPassword(user.getUserId(), value)
+                    self._change_user_password(user, value)
                 elif key == 'username':
                     set_own_login_name(user, value)
                 else:
@@ -87,7 +91,7 @@ class UsersPatch(Service):
                 if key == 'password' and \
                    security.enable_user_pwd_choice and \
                    self.can_set_own_password:
-                    user.userSetPassword(user.getUserId(), value)
+                    self._change_user_password(user, value)
                 else:
                     user.setMemberProperties(mapping={key: value})
 


### PR DESCRIPTION
After the change of MemberData to MemberAdapter, there is no longer a method userSetPassword of the user instance. Using the same approach as the PasswordResetTool.