### PR TITLE
Properly include HTTP examples in installed egg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure to include HTTP examples in installed egg, so test_documentation
+  tests also work against a installed release of plone.restapi.
+  [lgraf]
 
 
 3.1.0 (2018-06-27)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
 
+import os
+
 version = '3.1.1.dev0'
 
 long_description = (
@@ -9,6 +11,30 @@ long_description = (
     open('CONTRIBUTORS.rst').read() + '\n' +
     open('CHANGES.rst').read() + '\n'
 )
+
+
+HTTP_EXAMPLES_PATH = 'docs/source/_json/'
+
+
+def collect_http_examples():
+    """Gather relative paths to every HTTP example file.
+
+    We need to do this dynamically because the data_files argument to
+    setup() doesn't support globs (wildcards).
+
+    If the HTTP examples directory is ever moved, the HTTP_EXAMPLES_PATH
+    above needs to be updated before a new release is cut.
+
+    The examples need to be included via data_files because they are outside
+    a Python package. So we can't include them using package_data, which only
+    works relative to Python packages. (The MANIFEST only controls what gets
+    included in the source distribution. Listing these files in data_files
+    ensures they actually get copied to the installed .egg).
+    """
+    examples_path = HTTP_EXAMPLES_PATH
+    example_filenames = os.listdir(examples_path)
+    return [os.path.join(examples_path, fn) for fn in example_filenames]
+
 
 setup(name='plone.restapi',
       version=version,
@@ -36,6 +62,9 @@ setup(name='plone.restapi',
       license='gpl',
       packages=find_packages('src'),
       package_dir={'': 'src'},
+      data_files=[
+          (HTTP_EXAMPLES_PATH, collect_http_examples()),
+      ],
       namespace_packages=['plone', ],
       include_package_data=True,
       zip_safe=False,

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from freezegun import freeze_time
 from mock import patch
 from pkg_resources import parse_version
+from pkg_resources import resource_filename
 from plone import api
 from plone.app.discussion.interfaces import IConversation
 from plone.app.discussion.interfaces import IDiscussionSettings
@@ -71,14 +72,8 @@ RESPONSE_HEADER_KEYS = [
     'location',
 ] + TUS_HEADERS
 
-base_path = os.path.join(
-    os.path.dirname(__file__),
-    '..',
-    '..',
-    '..',
-    '..',
-    'docs/source/_json'
-)
+
+base_path = resource_filename('plone.restapi', '../../../docs/source/_json')
 
 UPLOAD_DATA = 'abcdefgh'
 UPLOAD_MIMETYPE = 'text/plain'

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -215,6 +215,19 @@ class TestDocumentation(unittest.TestCase):
         self.time_freezer.stop()
         popGlobalRegistry(getSite())
 
+    def test_http_example_path_exists(self):
+        """Tripwire test to ensure changes in the HTTP examples base path
+
+        are caught *before* release time, since setup.py relies on it.
+        """
+        path = resource_filename('plone.restapi', '../../../docs/source/_json')
+        self.assertTrue(
+            os.path.isdir(path),
+            'It looks like the directory for the HTTP examples has changed. '
+            'Please make sure to update HTTP_EXAMPLES_PATH in setup.py '
+            'accordingly, as well as base_path at the top of this file and '
+            'the one in this test.')
+
     def test_documentation_content_crud(self):
         folder = self.create_folder()
         transaction.commit()


### PR DESCRIPTION
Make sure to include HTTP examples in the **installed egg**, so `test_documentation` tests also work against an installed release of `plone.restapi`.

We need to do this dynamically because the `data_files` argument to `setup()` doesn't support globs (wildcards).

The examples need to be included [via `data_files`](https://docs.python.org/3/distutils/setupscript.html#installing-additional-files) because they are outside a Python package. So we can't include them using `package_data`, which [only works relative to Python packages](https://docs.python.org/3/distutils/setupscript.html#installing-package-data). (The `MANIFEST` only controls what gets included in the *source distribution*. Listing these files in `data_files` ensures they actually get *copied to the installed `.egg`*).

If the HTTP examples directory is ever moved, the `HTTP_EXAMPLES_PATH` in `setup.py` needs to be updated before a new release is cut. I included a tripwire test that should catch this ahead of release time.

---

I tested the changes to `setup.py` as well as I could locally (ran `python setup.py sdist` as well as `python setup.py install`), so the collecting and copying of the HTTP examples into the egg works.