### PR TITLE
fixes #579

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ Bugfixes:
 - Make setup.py require plone.behavior >= 1.1. This fixes #575.
   [timo]
 
+- Fixes ``test_search`` to work with bug fixed ``plone.indexer``.
+  Now ``DXTestDocument`` explicit got an attribute ``exclude_from_nav``.
+  This fixes `issue 579 <https://github.com/plone/plone.restapi/issues/579>`_.
+  Refers to `Products.CMFPlone Issue 2469 <https://github.com/plone/Products.CMFPlone/issues/2469>`_
+  [jensens]
+
 
 3.2.1 (2018-06-28)
 ------------------

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -145,6 +145,10 @@ class IDXTestDocumentSchema(model.Schema):
 class DXTestDocument(Item):
     """A Dexterity based test type containing a set of standard fields."""
 
+    # Plone standard types (both, dx and at) do provide exclude_from_nav
+    # and at least one test expect it to be here, so make it explicit
+    exclude_from_nav = False
+
 
 @provider(IFormFieldProvider)
 class ITestBehavior(model.Schema):


### PR DESCRIPTION
Fixes ``test_search`` to work with bug fixed ``plone.indexer``.
This fixes #579.
Refers to https://github.com/plone/Products.CMFPlone/issues/2469
