### PR TITLE
[WIP] Drop collective mockmailhost

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 3.4.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Drop collective.MockMailHost, use a util class from CMFPlone.
+  [gforcada]
 
 3.4.5 (2018-09-14)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(name='plone.restapi',
       ],
       extras_require={'test': [
           'Products.Archetypes',
-          'collective.MockMailHost',
           'plone.app.collection',
           'plone.app.contenttypes',
           'plone.app.robotframework',

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(name='plone.restapi',
       install_requires=[
           'setuptools',
           'python-dateutil',
-          'plone.behavior>=1.1',  # adds name to behavior directive 
+          'plone.behavior>=1.1',  # adds name to behavior directive
           'plone.rest >= 1.0a6',  # json renderer moved to plone.restapi
-          'plone.schema >= 1.2.0',  # new json field          
+          'plone.schema >= 1.2.0',  # new json field
           'PyJWT',
           'pytz',
       ],

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -11,7 +11,6 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import login
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import quickInstallProduct
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -23,6 +22,7 @@ from plone.testing import z2
 from plone.testing.layer import Layer
 from plone.uuid.interfaces import IUUIDGenerator
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.tests.utils import MockMailHost
 from urlparse import urljoin
 from urlparse import urlparse
 from zope.component import getGlobalSiteManager
@@ -30,7 +30,6 @@ from zope.component import getUtility
 from zope.configuration import xmlconfig
 from zope.interface import implements
 
-import collective.MockMailHost
 import pkg_resources
 import re
 import requests
@@ -160,7 +159,6 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
             context=configurationContext
         )
 
-        self.loadZCML(package=collective.MockMailHost)
         z2.installProduct(app, 'plone.restapi')
 
     def setUpPloneSite(self, portal):
@@ -176,8 +174,7 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
         add_catalog_indexes(portal, DX_TYPES_INDEXES)
         set_available_languages()
         enable_request_language_negotiation(portal)
-        quickInstallProduct(portal, 'collective.MockMailHost')
-        applyProfile(portal, 'collective.MockMailHost:default')
+        portal.MailHost = MockMailHost('MailHost')
         states = portal.portal_workflow['simple_publication_workflow'].states
         states['published'].title = u'Published with accent é'.encode('utf8')
 

--- a/src/plone/restapi/tests/test_services_email_notification.py
+++ b/src/plone/restapi/tests/test_services_email_notification.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from Products.MailHost.interfaces import IMailHost
-
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -32,7 +30,7 @@ class EmailNotificationEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
-        self.mailhost = getUtility(IMailHost)
+        self.mailhost = self.portal.MailHost
 
         registry = getUtility(IRegistry)
         registry['plone.email_from_address'] = 'info@plone.org'

--- a/src/plone/restapi/tests/test_services_email_send.py
+++ b/src/plone/restapi/tests/test_services_email_send.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from Products.MailHost.interfaces import IMailHost
-
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -32,7 +30,7 @@ class EmailSendEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ['Manager', ])
 
-        self.mailhost = getUtility(IMailHost)
+        self.mailhost = self.portal.MailHost
 
         registry = getUtility(IRegistry)
         registry['plone.email_from_address'] = 'info@plone.org'

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.permissions import SetOwnPassword
 from Products.CMFCore.utils import getToolByName
-from Products.MailHost.interfaces import IMailHost
 
 from plone import api
 from plone.app.testing import setRoles
@@ -11,7 +10,6 @@ from plone.app.testing import TEST_USER_ID
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
 from zope.component import getAdapter
-from zope.component import getUtility
 
 try:
     from Products.CMFPlone.interfaces import ISecuritySchema
@@ -32,7 +30,7 @@ class TestUsersEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
-        self.mailhost = getUtility(IMailHost)
+        self.mailhost = self.portal.MailHost
 
         self.api_session = RelativeSession(self.portal_url)
         self.api_session.headers.update({'Accept': 'application/json'})


### PR DESCRIPTION
I see that @pbauer did port c.MockMailHost to python 3, but if we can avoid it with a simpler solution (from CMFPlone), isn't that all the better? :smile: 