### PR TITLE
Pin sphinxcontrib-httpexample==0.9.1 in readthedocs-requirements.txt:

### DIFF
--- a/docs/source/readthedocs-requirements.txt
+++ b/docs/source/readthedocs-requirements.txt
@@ -1,2 +1,2 @@
 sphinxcontrib-httpdomain
-sphinxcontrib-httpexample
+sphinxcontrib-httpexample==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ snowballstemmer==1.2.1
 Sphinx==1.6.5
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-httpdomain==1.5.0
-sphinxcontrib-httpexample==0.7.0
+sphinxcontrib-httpexample==0.9.1
 sphinxcontrib-websupport==1.0.1
 typing==3.6.2
 urllib3==1.22


### PR DESCRIPTION
This is to avoid an [issue in version `0.10.0`](https://github.com/collective/sphinxcontrib-httpexample/issues/41) that prevents requests/responses being included from the filesystem, e.g. using the `:request:` option.

In the medium / long term, we should
- clean up the requirements in `plone.restapi` (duplication between `requirements.txt` and ? `docs/source/readthedocs-requirements.txt`)
- switch the ReadTheJobs build to use the same requirements that are used for local development / docs builds.

For now, this should fix the issue at hand - the HTTP examples not being rendered in our docs. Even though we pinned `0.7.0` in the package root `requirements.txt`, what was previously being used by RTD would have been `0.9.1` - that's why I'm pinning it to that version, and also bumping the constraint in `requirements.txt` (still used for building docs locally).

Closes #627