### PR TITLE
Fixed tests after German translation update.

### DIFF
--- a/src/plone/restapi/tests/test_roles.py
+++ b/src/plone/restapi/tests/test_roles.py
@@ -60,13 +60,19 @@ class TestRolesGet(unittest.TestCase):
     def test_roles_endpoint_translates_role_titles(self):
         self.api_session.headers.update({'Accept-Language': 'de'})
         response = self.api_session.get('/@roles')
-
+        # One of the roles has changed translation in German.
+        # Reviewer used to be 'Ver\xf6ffentlichen', but is now simply Reviewer.
+        titles = {item['title'] for item in response.json()}
+        options = {u'Ver\xf6ffentlichen', u'Reviewer'}
+        # One of the options must match:
+        self.assertTrue(titles.intersection(options))
+        # Discard them:
+        titles = titles.difference(options)
         self.assertEqual({
             u'Hinzuf\xfcgen',
             u'Bearbeiten',
             u'Benutzer',
             u'Ansehen',
-            u'Ver\xf6ffentlichen',
             u'Website-Administrator',
             u'Verwalten'},
-            {item['title'] for item in response.json()})
+            titles)


### PR DESCRIPTION
This commit in plone.app.locales changed several German strings:
https://github.com/collective/plone.app.locales/commit/426adfc06bbc94eeddf350ba6d7c93059372c6fd
Reviewer was mostly called 'Redacteur', and is called simply 'Reviewer' now.
And in one case it had been translated as 'Veröffentlichen', which is what plone.restapi was testing,
but that one means 'make public', so it wasn't a good translation.
So Jenkins was broken in [5.2](https://jenkins.plone.org/job/plone-5.2-python-2.7/2103/testReport/plone.restapi.tests.test_roles/TestRolesGet/test_roles_endpoint_translates_role_titles/).
Updated the test to check for Reviewer instead.

cc @jzellinter who updated the German text. No one is to blame for the test failure, as you can't know that it breaks. Just checking in to see if I am missing something.