### PR TITLE
Add query criteria schema to types service

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,14 @@
 Changelog
 =========
 
-3.5.1 (unreleased)
+3.6.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+New Features:
+
+- Improve the types service to include schema for the criteria
+  that can be saved in a Collection's query field.
+  [davisagli]
 
 
 3.5.0 (2018-11-06)

--- a/src/plone/restapi/tests/test_services_types.py
+++ b/src/plone/restapi/tests/test_services_types.py
@@ -112,6 +112,11 @@ class TestServicesTypes(unittest.TestCase):
         self.assertIn(
             'file.data', response['properties']['file']['properties'])
 
+    def test_collection_type(self):
+        response = self.api_session.get('/@types/Collection')
+        response = response.json()
+        self.assertIn('anyOf', response['properties']['query']['items'])
+
     def test_addable_types_for_non_manager_user(self):
         user = api.user.create(
             email='noam.chomsky@example.com',

--- a/src/plone/restapi/types/configure.zcml
+++ b/src/plone/restapi/types/configure.zcml
@@ -29,5 +29,6 @@
     <adapter factory=".adapters.DateJsonSchemaProvider" />
     <adapter factory=".adapters.DatetimeJsonSchemaProvider" />
     <adapter factory=".adapters.JSONFieldSchemaProvider" />
+    <adapter factory=".adapters.QueryFieldJsonSchemaProvider" name="ICollection.query" />
 
 </configure>


### PR DESCRIPTION
This adds JSON schema for the criteria values that can be placed in a collection's query field. It should be possible to use this as the basis for building the query widget.