### PR TITLE
Fix some differences with http test output in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     - secure: "tj9kO7Uyn7AY2Z6zhdOggLSYheaD8e+qKA7ZXvdWTrL2HtPAtnNJK8keQGj1JLQyy6bRfoOCt51aL8+Lc0fzcACaLFpAPjleSLtUChphPOh/dqTu1QX5oL0SxZ94B4ZC5+qfaSAQHMwbiiWUW0us9QtJpxQQmiJUekqiTdQDNEo="
     - secure: "j06un+j2gHjlGfg+xMcvKG2osf1HSzBq/cPPNIonnjGQY3GJfT/YRzYnHe5LJPPt7IJDD7hAEPentRJ4C0zP66U6gcQ2HjWPsMIcvzlgnXoT2QaaCVkMA9YS4WOsN0C5iY/R64GjFwR7J+/bgeG64XvfhpuQ/UBP2+U68PqSBtM="
+    - ZSERVER_PORT=55001
 matrix:
   include:
   - python: "2.7"

--- a/src/plone/restapi/services/__init__.py
+++ b/src/plone/restapi/services/__init__.py
@@ -19,7 +19,8 @@ class Service(RestService):
         content = self.reply()
         if content is not _no_content_marker:
             self.request.response.setHeader("Content-Type", self.content_type)
-            return json.dumps(content, indent=2, sort_keys=True)
+            return json.dumps(
+                content, indent=2, sort_keys=True, separators=(', ', ': '))
 
     def check_permission(self):
         sm = getSecurityManager()

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -132,6 +132,7 @@ def save_request_and_response_for_docs(name, response):
                 # ever decide to dump that header
                 response.request.prepare_body(data=body, files=None)
 
+            req.flush()
             if (isinstance(response.request.body, six.text_type)
                     or not hasattr(req, 'buffer')):
                 req.write(response.request.body)


### PR DESCRIPTION
* Keep space after JSON items
* Use port 55001 on travis
* Be sure to flush file before writing request body

There are still some differences in the output in Python 3 but now it's much easier to see the real differences.