### PR TITLE
Close the api_session in tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Changelog
 
 Bugfixes:
 
+- Close the api_session in tests.
+  This prevents lots of ResourceWarnings about unclosed sockets.
+  Fixes issues `636 <https://github.com/plone/plone.restapi/issues/636>`_
+  and `648 <https://github.com/plone/plone.restapi/issues/648>`_.
+  [maurits]
+
 - Standardize errors data structure of email-notification endpoint.
   [cekk]
 

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -228,6 +228,7 @@ class TestDocumentation(unittest.TestCase):
     def tearDown(self):
         self.time_freezer.stop()
         popGlobalRegistry(getSite())
+        self.api_session.close()
 
     def test_documentation_content_crud(self):
         folder = self.create_folder()
@@ -1380,6 +1381,7 @@ class TestDocumentationMessageTranslations(unittest.TestCase):
     def tearDown(self):
         self.time_freezer.stop()
         popGlobalRegistry(getSite())
+        self.api_session.close()
 
     def test_translate_messages_types(self):
         response = self.api_session.get('/@types')
@@ -1440,6 +1442,7 @@ class TestCommenting(unittest.TestCase):
 
     def tearDown(self):
         self.time_freezer.stop()
+        self.api_session.close()
 
     def create_document_with_comments(self):
         self.portal.invokeFactory('Document', id='front-page')
@@ -1627,6 +1630,7 @@ class TestPAMDocumentation(unittest.TestCase):
 
     def tearDown(self):
         self.time_freezer.stop()
+        self.api_session.close()
 
     def test_documentation_translations_post(self):
         response = self.api_session.post(


### PR DESCRIPTION
This prevents lots of ResourceWarnings about unclosed sockets.
Fixes https://github.com/plone/plone.restapi/issues/636 and https://github.com/plone/plone.restapi/issues/648.