### PR TITLE
Tests: retry request on ConnectionError.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Changelog
 
 Bugfixes:
 
+- Tests: retry request on ConnectionError.
+  On Jenkins we often get one ConnectionError in a seemingly random test.
+  Retrying after a short pause helps.
+  Fixes issue `648 <https://github.com/plone/plone.restapi/issues/648>`_.
+  [maurits, gforcada]
+
 - Close the api_session in tests.
   This prevents lots of ResourceWarnings about unclosed sockets.
   Fixes issues `636 <https://github.com/plone/plone.restapi/issues/636>`_


### PR DESCRIPTION
On Jenkins we often get one ConnectionError in a seemingly random test.
Happens on both Python 2 and 3.
Retrying after a short pause helps.
Fixes https://github.com/plone/plone.restapi/issues/648

Note: I added a print statement so we know if it happens, and maybe detect a pattern in the urls where this goes wrong. I tried `logger.warning` and `logger.error`, but this never showed up in the test output.

In a few local parallel runs, I have seen errors on these urls:

```
http://localhost:64140/plone/@users
http://localhost:64117/plone/@types/Document
http://localhost:49516/plone/@users/noam
```
