### PR TITLE
Fix problem when deserializing for nested Dexterity content structure…

### DIFF
--- a/news/661.bugfix
+++ b/news/661.bugfix
@@ -1,0 +1,4 @@
+Fix problem when deserializing for nested Dexterity content structures and setting values for the same field.
+A value for a sub node was not set when it was the same value as it's parent node due to Acquisition.
+Fixes: #660
+[thet]

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.utils import getToolByName
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
@@ -8,9 +7,10 @@ from plone.app.vocabularies.catalog import CatalogSource
 from plone.autoform.directives import read_permission
 from plone.autoform.directives import write_permission
 from plone.autoform.interfaces import IFormFieldProvider
-from plone.dexterity.content import Item
+from plone.dexterity.content import Container
 from plone.namedfile import field as namedfile
 from plone.supermodel import model
+from Products.CMFCore.utils import getToolByName
 from pytz import timezone
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -142,7 +142,7 @@ class IDXTestDocumentSchema(model.Schema):
         required=True, defaultFactory=default_factory)
 
 
-class DXTestDocument(Item):
+class DXTestDocument(Container):
     """A Dexterity based test type containing a set of standard fields."""
 
     # Plone standard types (both, dx and at) do provide exclude_from_nav


### PR DESCRIPTION
…s and setting values for the same field.

When creating a nested content structure and setting the same value for same fields, a value for a sub node was not set when it was the same value as it's parent node due to Acquisition. The attribute for the sub node doesn't exist at time of creation, so the datamanger compares the value to be set against the parent's attribute value.
Fixes: #660