### PR TITLE
docs : HTTP 301 err on EXAMPLE APIs in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,11 @@ http://plonedemo.kitconcept.com
 
 Example GET request on the portal root::
 
-  $ curl -i http://plonedemo.kitconcept.com -H "Accept: application/json"
+  $ curl -i https://plonedemo.kitconcept.com -H "Accept: application/json"
 
 Example POST request to create a new document::
 
-  $ curl -i -X POST http://plonedemo.kitconcept.com -H "Accept: application/json" -H "Content-Type: application/json" --data-raw '{"@type": "Document", "title": "My Document"}' --user admin:admin
+  $ curl -i -X POST https://plonedemo.kitconcept.com -H "Accept: application/json" -H "Content-Type: application/json" --data-raw '{"@type": "Document", "title": "My Document"}' --user admin:admin
 
 .. note:: You will need some kind of API browser application to explore the API. We recommend using `Postman <http://www.getpostman.com/>`_.
 


### PR DESCRIPTION
The example API URLs in the docs are `http` whereas the actual route is `https`. On making a request to the endpoint mentioned in the docs using `curl` responds with HTTP 301 error code :arrow_down: 
```
HTTP/1.1 301 Moved Permanently
Server: nginx/1.14.2
Date: Sun, 24 Feb 2019 08:41:36 GMT
Content-Type: text/html
Content-Length: 185
Connection: keep-alive
Location: https://plonedemo.kitconcept.com/

<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.14.2</center>
</body>
</html>

```