### PR TITLE
Pin six to 1.11.0 for plone-4.3.x.cfg to be buildoutable again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ Changelog
 3.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed the 4.3.x travis build by pinning six up to 1.11.0 for the 4.3.x buildout.
+  [Rotonen]
 
 
 3.6.0 (2019-02-16)

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -6,4 +6,5 @@ extends =
 
 [versions]
 pytz = 2017.3
+six = 1.11.0
 zope.interface = 4.1.0


### PR DESCRIPTION
How come we need to pin six up for 4.3? Or is 4.3 not a compatibility target for master anymore?

Never the less, the tests do pass when one pins six to `1.11.0`.

Green on Travis again.