### PR TITLE
Fix release

### DIFF
--- a/news/682.feature
+++ b/news/682.feature
@@ -1,2 +1,0 @@
-- Add group roles to @groups serializer
-  [sneridagh]

--- a/news/684.bugfix
+++ b/news/684.bugfix
@@ -1,0 +1,1 @@
+Fix release to not create universal (Python 2/3) wheels.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 import sys
 
-version = '3.7.1-dev.0'
+version = '3.7.1.dev.0'
 
 long_description = (
     open('README.rst').read() + '\n' +


### PR DESCRIPTION
- the release version must use periods between micro and suffix (if any), otherwise setuptools keeps complaining about it
- universal wheels can not be built due to a check on setup.py regarding which python version is being used to install the package