### PR TITLE
Use tokens for serialization and deserialization of vocabulary terms

### DIFF
--- a/docs/source/upgrade-guide.rst
+++ b/docs/source/upgrade-guide.rst
@@ -7,6 +7,47 @@ This upgrade guide lists all breaking changes in plone.restapi and explains the 
 Upgrading to plone.restapi 4.x
 ------------------------------
 
+Serialization and Deserialization of fields with vocabularies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The serialization of fields with vocabularies (e.g. ``Choice``) now returns the
+token of the vocabulary term instead of the stored value. For text values this
+should not make much a difference as the token and the value are usually the
+same. However if the term's value is not equal to it's token it may be neccessary
+to adopt the client implementation.
+
+Example:
+
+The date and time controlpanel previously returned a number for the
+``first_weekday`` property::
+
+  {
+    "@id": "http://localhost:55001/plone/@controlpanels/date-and-time",
+    "data": {
+        ...
+        "first_weekday": 0,
+        ...
+    }
+    ...
+  }
+
+Now it returns a string::
+
+  {
+    "@id": "http://localhost:55001/plone/@controlpanels/date-and-time",
+    "data": {
+        ...
+        "first_weekday": "0",
+        ...
+    }
+    ...
+  }
+
+Deserialization now also expects the token, but still works using the value.
+However it's highly recommended to always use the token as vocabulary terms
+may contain values that are not JSON serializable.
+
+
 Vocabularies
 ^^^^^^^^^^^^
 

--- a/news/691.breaking
+++ b/news/691.breaking
@@ -1,0 +1,4 @@
+Use tokens for serialization/deserialization of vocabulary terms.
+This may break clients if the serialization of a term's value is not equal to the token.
+[buchi]
+

--- a/src/plone/restapi/deserializer/configure.zcml
+++ b/src/plone/restapi/deserializer/configure.zcml
@@ -8,6 +8,7 @@
   <adapter factory=".dxcontent.DeserializeFromJson" />
   <adapter factory=".dxfields.DefaultFieldDeserializer" />
   <adapter factory=".dxfields.DatetimeFieldDeserializer" />
+  <adapter factory=".dxfields.ChoiceFieldDeserializer" />
   <adapter factory=".dxfields.CollectionFieldDeserializer" />
   <adapter factory=".dxfields.DictFieldDeserializer" />
   <adapter factory=".dxfields.TextLineFieldDeserializer" />

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -15,6 +15,8 @@
     <adapter factory=".summary.SiteRootJSONSummarySerializer" />
 
     <adapter factory=".dxfields.DefaultFieldSerializer" />
+    <adapter factory=".dxfields.ChoiceFieldSerializer" />
+    <adapter factory=".dxfields.CollectionFieldSerializer" />
     <adapter factory=".dxfields.FileFieldSerializer" />
     <adapter factory=".dxfields.ImageFieldSerializer" />
     <adapter factory=".dxfields.RichttextFieldSerializer" />

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -54,6 +54,8 @@
     <adapter factory=".converters.zope_DateTime_converter" />
 
     <configure zcml:condition="installed z3c.relationfield">
+        <adapter factory=".relationfield.RelationChoiceFieldSerializer" />
+        <adapter factory=".relationfield.RelationListFieldSerializer" />
         <adapter factory=".relationfield.relationvalue_converter" />
     </configure>
 

--- a/src/plone/restapi/serializer/dxfields.py
+++ b/src/plone/restapi/serializer/dxfields.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from plone.app.textfield.interfaces import IRichText
-from plone.app.vocabularies.catalog import CatalogVocabulary
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.interfaces import INamedFileField
 from plone.namedfile.interfaces import INamedImageField
@@ -67,10 +66,7 @@ class CollectionFieldSerializer(DefaultFieldSerializer):
         value = self.get_value()
         value_type = self.field.value_type
         if (value is not None and IChoice.providedBy(value_type)
-                and IVocabularyTokenized.providedBy(value_type.vocabulary)
-                # CatalogVocabulary provides IVocabularyTokenized but doesn't
-                # implement it
-                and not isinstance(value_type.vocabulary, CatalogVocabulary)):
+                and IVocabularyTokenized.providedBy(value_type.vocabulary)):
             value = self.field._type([value_type.vocabulary.getTerm(v).token
                                       for v in value])
         return json_compatible(value)

--- a/src/plone/restapi/serializer/relationfield.py
+++ b/src/plone/restapi/serializer/relationfield.py
@@ -1,12 +1,18 @@
 # -*- coding: utf-8 -*-
+from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import IJsonCompatible
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.serializer.dxfields import DefaultFieldSerializer
+from z3c.relationfield.interfaces import IRelationChoice
+from z3c.relationfield.interfaces import IRelationList
 from z3c.relationfield.interfaces import IRelationValue
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
+from zope.interface import Interface
 
 
 @adapter(IRelationValue)
@@ -16,3 +22,15 @@ def relationvalue_converter(value):
         summary = getMultiAdapter(
             (value.to_object, getRequest()), ISerializeToJsonSummary)()
         return json_compatible(summary)
+
+
+@adapter(IRelationChoice, IDexterityContent, Interface)
+@implementer(IFieldSerializer)
+class RelationChoiceFieldSerializer(DefaultFieldSerializer):
+    pass
+
+
+@adapter(IRelationList, IDexterityContent, Interface)
+@implementer(IFieldSerializer)
+class RelationListFieldSerializer(DefaultFieldSerializer):
+    pass

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -46,6 +46,11 @@ class IDXTestDocumentSchema(model.Schema):
     test_bytes_field = schema.Bytes(required=False)
     test_bytesline_field = schema.BytesLine(required=False)
     test_choice_field = schema.Choice(values=[u'foo', u'bar'], required=False)
+    test_choice_field_with_vocabulary = schema.Choice(
+        vocabulary=SimpleVocabulary([
+            SimpleTerm(u'value1', 'token1', u'title1'),
+            SimpleTerm(u'value2', 'token2', u'title2'),
+        ]),  required=False)
     test_date_field = schema.Date(required=False)
     test_datetime_field = schema.Datetime(required=False)
     test_datetime_tz_field = schema.Datetime(
@@ -58,6 +63,12 @@ class IDXTestDocumentSchema(model.Schema):
     test_frozenset_field = schema.FrozenSet(required=False)
     test_int_field = schema.Int(required=False)
     test_list_field = schema.List(required=False)
+    test_list_field_with_choice_with_vocabulary = schema.List(
+        value_type=schema.Choice(vocabulary=SimpleVocabulary([
+            SimpleTerm(u'value1', 'token1', u'title1'),
+            SimpleTerm(u'value2', 'token2', u'title2'),
+            SimpleTerm(u'value3', 'token3', u'title3'),
+        ])), required=False)
     test_set_field = schema.Set(required=False)
     test_text_field = schema.Text(required=False)
     test_textline_field = schema.TextLine(required=False)

--- a/src/plone/restapi/tests/test_dxfield_deserializer.py
+++ b/src/plone/restapi/tests/test_dxfield_deserializer.py
@@ -91,6 +91,18 @@ class TestDXFieldDeserializer(unittest.TestCase):
         self.assertTrue(isinstance(value, six.text_type), 'Not an <unicode>')
         self.assertEqual(u'bar', value)
 
+    def test_choice_deserialization_from_token_returns_vocabulary_value(self):
+        value = self.deserialize('test_choice_field_with_vocabulary',
+                                 u'token1')
+        self.assertTrue(isinstance(value, six.text_type), 'Not an <unicode>')
+        self.assertEqual(u'value1', value)
+
+    def test_choice_deserialization_from_value_returns_vocabulary_value(self):
+        value = self.deserialize('test_choice_field_with_vocabulary',
+                                 u'value1')
+        self.assertTrue(isinstance(value, six.text_type), 'Not an <unicode>')
+        self.assertEqual(u'value1', value)
+
     def test_date_deserialization_returns_date(self):
         value = self.deserialize('test_date_field', u'2015-12-20')
         self.assertTrue(isinstance(value, date))
@@ -172,6 +184,18 @@ class TestDXFieldDeserializer(unittest.TestCase):
         value = self.deserialize('test_list_field', [1, 2, 3])
         self.assertTrue(isinstance(value, list), 'Not a <list>')
         self.assertEqual([1, 2, 3], value)
+
+    def test_list_deserialization_from_tokens_returns_list_of_values(self):
+        value = self.deserialize('test_list_field_with_choice_with_vocabulary',
+                                 [u'token1', u'token3'])
+        self.assertTrue(isinstance(value, list), 'Not a <list>')
+        self.assertEqual([u'value1', u'value3'], value)
+
+    def test_list_deserialization_from_values_returns_list_of_values(self):
+        value = self.deserialize('test_list_field_with_choice_with_vocabulary',
+                                 [u'value1', u'value3'])
+        self.assertTrue(isinstance(value, list), 'Not a <list>')
+        self.assertEqual([u'value1', u'value3'], value)
 
     def test_set_deserialization_returns_set(self):
         value = self.deserialize('test_set_field', [1, 2, 3])

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -95,6 +95,11 @@ class TestDexterityFieldSerializing(TestCase):
         self.assertTrue(isinstance(value, six.text_type), 'Not an <unicode>')
         self.assertEqual(u'foo', value)
 
+    def test_choice_field_serialization_returns_vocabulary_token(self):
+        value = self.serialize('test_choice_field_with_vocabulary', u'value1')
+        self.assertTrue(isinstance(value, six.text_type), 'Not an <unicode>')
+        self.assertEqual(u'token1', value)
+
     def test_date_field_serialization_returns_unicode(self):
         value = self.serialize('test_date_field', date(2015, 7, 15))
         self.assertTrue(isinstance(value, six.text_type), 'Not an <unicode>')
@@ -136,6 +141,13 @@ class TestDexterityFieldSerializing(TestCase):
         value = self.serialize('test_list_field', [1, 'two', 3])
         self.assertTrue(isinstance(value, list), 'Not a <list>')
         self.assertEqual([1, u'two', 3], value)
+
+    def test_list_field_with_vocabulary_choice_serialization_returns_tokens(
+            self):
+        value = self.serialize('test_list_field_with_choice_with_vocabulary',
+                               [u'value1', u'value3'])
+        self.assertTrue(isinstance(value, list), 'Not a <list>')
+        self.assertEqual([u'token1', u'token3'], value)
 
     def test_set_field_serialization_returns_list(self):
         value = self.serialize('test_set_field', set(['a', 'b', 'c']))


### PR DESCRIPTION
Fixes #691 

Deserialization from term values still works, however serialization always returns the token.
This may break compatibility with API clients if the term's value is not equal to it's token.
