### PR TITLE
Add query by token and translation of the returned title to the vocab…

### DIFF
--- a/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
@@ -92,7 +92,9 @@ Content-Type: application/json+schema
       "type": "array", 
       "uniqueItems": true, 
       "widgetOptions": {
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        }
       }
     }, 
     "creators": {
@@ -107,7 +109,9 @@ Content-Type: application/json+schema
       "type": "array", 
       "uniqueItems": true, 
       "widgetOptions": {
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        }
       }
     }, 
     "description": {
@@ -170,7 +174,9 @@ Content-Type: application/json+schema
         "pattern_options": {
           "recentlyUsed": true
         }, 
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Catalog"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Catalog"
+        }
       }
     }, 
     "rights": {
@@ -192,7 +198,9 @@ Content-Type: application/json+schema
       "type": "array", 
       "uniqueItems": true, 
       "widgetOptions": {
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Keywords"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Keywords"
+        }
       }
     }, 
     "title": {

--- a/src/plone/restapi/tests/http-examples/types_document.resp
+++ b/src/plone/restapi/tests/http-examples/types_document.resp
@@ -95,7 +95,9 @@ Content-Type: application/json+schema
       "type": "array", 
       "uniqueItems": true, 
       "widgetOptions": {
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        }
       }
     }, 
     "creators": {
@@ -110,7 +112,9 @@ Content-Type: application/json+schema
       "type": "array", 
       "uniqueItems": true, 
       "widgetOptions": {
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users"
+        }
       }
     }, 
     "description": {
@@ -167,7 +171,9 @@ Content-Type: application/json+schema
         "pattern_options": {
           "recentlyUsed": true
         }, 
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Catalog"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Catalog"
+        }
       }
     }, 
     "rights": {
@@ -189,7 +195,9 @@ Content-Type: application/json+schema
       "type": "array", 
       "uniqueItems": true, 
       "widgetOptions": {
-        "vocabulary": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Keywords"
+        "vocabulary": {
+          "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Keywords"
+        }
       }
     }, 
     "table_of_contents": {

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -117,6 +117,69 @@ class TestVocabularyEndpoint(unittest.TestCase):
             }
         )
 
+    def test_get_vocabulary_filtered_by_token(self):
+        response = self.api_session.get(
+            '/@vocabularies/plone.restapi.tests.test_vocabulary?token=token1'
+        )
+
+        self.assertEqual(200, response.status_code)
+        response = response.json()
+        self.assertEqual(
+            response,
+            {
+                u'@id': self.portal_url + u'/@vocabularies/plone.restapi.tests.test_vocabulary?token=token1',  # noqa
+                u'items': [
+                    {
+                        u'title': u'Title 1',
+                        u'token': u'token1',
+                    }
+                ],
+                u'items_total': 1,
+            }
+        )
+
+    def test_get_vocabulary_filtered_by_token_ignore_query(self):
+        response = self.api_session.get(
+            '/@vocabularies/plone.restapi.tests.test_vocabulary?token=token1&query=Title' # noqa
+        )
+
+        self.assertEqual(200, response.status_code)
+        response = response.json()
+        self.assertEqual(
+            response,
+            {
+                u'@id': self.portal_url + u'/@vocabularies/plone.restapi.tests.test_vocabulary?token=token1&query=Title',  # noqa
+                u'items': [
+                    {
+                        u'title': u'Title 1',
+                        u'token': u'token1',
+                    }
+                ],
+                u'items_total': 1,
+            }
+        )
+
+    def test_get_corner_case_vocabulary_filtered_by_token(self):
+        response = self.api_session.get(
+            '/@vocabularies/plone.app.vocabularies.Weekdays?token=0'
+        )
+
+        self.assertEqual(200, response.status_code)
+        response = response.json()
+        self.assertEqual(
+            response,
+            {
+                u'@id': self.portal_url + u'/@vocabularies/plone.app.vocabularies.Weekdays?token=0',  # noqa
+                u'items': [
+                    {
+                        'title': 'Monday',
+                        'token': '0'
+                    }
+                ],
+                u'items_total': 1,
+            }
+        )
+
     def test_get_unknown_vocabulary(self):
         response = self.api_session.get(
             '/@vocabularies/unknown.vocabulary')

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -92,8 +92,9 @@ class DefaultJsonSchemaProvider(object):
         params = all_params.get(self.field.getName(), {})
         if 'vocabulary' in params:
             vocab_name = params['vocabulary']
-            params['vocabulary'] = get_vocabulary_url(
-                vocab_name, self.context, self.request)
+            params['vocabulary'] = {
+                    '@id': get_vocabulary_url(
+                        vocab_name, self.context, self.request)}
         return params
 
 


### PR DESCRIPTION
… endpoint

This is required in cases that the initial value is a token, and we need the title. We only can access them via the options, but might be that the options are batched, and we need to get the title anyways. We can't set it in the value, since we need to preserve the serializer-deserializer chain working.

e.g plone.app.vocabularies.Weekdays it returns:

```js
data: {
  available_timezones: ["Europe/Berlin"]
  first_weekday: 0
  portal_timezone: "Europe/Berlin"
}
```

So for the initial value we have "0" but no title whatsoever. In this case, we could find in the options again, but if the results are batched, might be that the token is not in the loaded options tokens.
