### PR TITLE
Fail when renewing invalid authentication tokens.

### DIFF
--- a/news/721.bugfix
+++ b/news/721.bugfix
@@ -1,0 +1,2 @@
+When renewing an expired or invalid authentication token with ``@login-renew`` fail with a ``401`` error instead of returning a new authentication token.
+[thet]

--- a/src/plone/restapi/services/auth/renew.py
+++ b/src/plone/restapi/services/auth/renew.py
@@ -32,6 +32,12 @@ class Renew(Service):
                          plone.protect.interfaces.IDisableCSRFProtection)
 
         mtool = getToolByName(self.context, 'portal_membership')
+        if (bool(mtool.isAnonymousUser())):
+            # Don't generate authentication tokens for anonymous users.
+            self.request.response.setStatus(401)
+            return dict(error=dict(
+                type='Invalid authentication token',
+                message='The authentication token is invalid.'))
         user = mtool.getAuthenticatedMember()
         payload = {}
         payload['fullname'] = user.getProperty('fullname')

--- a/src/plone/restapi/tests/test_auth.py
+++ b/src/plone/restapi/tests/test_auth.py
@@ -174,6 +174,9 @@ class TestRenew(TestCase):
         self.assertIn('error', res)
 
     def test_renew_returns_token(self):
+        self.portal.acl_users.jwt_auth.store_tokens = True
+        token = self.portal.acl_users.jwt_auth.create_token('admin')
+        self.request._auth = 'Bearer {}'.format(token)
         service = self.traverse()
         res = service.reply()
         self.assertIn('token', res)
@@ -187,3 +190,17 @@ class TestRenew(TestCase):
         self.assertIn('token', res)
         self.assertEqual(
             1, len(self.portal.acl_users.jwt_auth._tokens['admin']))
+
+    def test_renew_fails_on_invalid_token(self):
+        token = 'this is an invalid token'
+        self.request._auth = 'Bearer {}'.format(token)
+        service = self.traverse()
+        res = service.reply()
+        self.assertEqual(
+            service.request.response.status,
+            401
+        )
+        self.assertEqual(
+            res['error']['type'],
+            'Invalid authentication token'
+        )


### PR DESCRIPTION
When renewing an expired or invalid authentication token with ``@login-renew`` fail with a ``401`` error instead of returning a new authentication token.

Fixes #721 