### PR TITLE
Circumvent ZODB some read conflicts arising from (hopefully) time freezing

### DIFF
--- a/news/745.bugfix
+++ b/news/745.bugfix
@@ -1,0 +1,2 @@
+Circumvent ZODB some read conflicts arising from (hopefully) time freezing.
+[Rotonen]

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -27,6 +27,7 @@ from Products.CMFCore.utils import getToolByName
 from requests.exceptions import ConnectionError
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlparse
+from time import time
 from zope.component import getGlobalSiteManager
 from zope.component import getUtility
 from zope.configuration import xmlconfig
@@ -123,40 +124,6 @@ class DateTimeFixture(Layer):
 DATE_TIME_FIXTURE = DateTimeFixture()
 
 
-import time  # noqa
-from persistent.TimeStamp import TimeStamp  # noqa
-
-
-def patchedNewTid(old):  # noqa
-    if getattr(time.time, "previous_time_function", False):
-        t = time.time.previous_time_function()
-        ts = TimeStamp(*time.gmtime.previous_gmtime_function(t)[:5] + (t % 60,))
-    else:
-        t = time.time()
-        ts = TimeStamp(*time.gmtime(t)[:5] + (t % 60,))
-    if old is not None:
-        ts = ts.laterThan(TimeStamp(old))
-    return ts.raw()
-
-
-class FreezeTimeFixture(Layer):
-    def setUp(self):
-        if PLONE_VERSION.base_version >= "5.1":
-            from ZODB import utils
-
-            self.ZODB_orig_newTid = utils.newTid
-            utils.newTid = patchedNewTid
-
-    def tearDown(self):
-        if PLONE_VERSION.base_version >= "5.1":
-            from ZODB import utils
-
-            utils.newTid = self.ZODB_orig_newTid
-
-
-FREEZE_TIME_FIXTURE = FreezeTimeFixture()
-
-
 class PloneRestApiDXLayer(PloneSandboxLayer):
 
     defaultBases = (DATE_TIME_FIXTURE, PLONE_APP_CONTENTTYPES_FIXTURE)
@@ -203,10 +170,6 @@ PLONE_RESTAPI_DX_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_RESTAPI_DX_FIXTURE, z2.ZSERVER_FIXTURE),
     name="PloneRestApiDXLayer:Functional",
 )
-PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME = FunctionalTesting(
-    bases=(FREEZE_TIME_FIXTURE, PLONE_RESTAPI_DX_FIXTURE, z2.ZSERVER_FIXTURE),
-    name="PloneRestApiDXLayerFreeze:Functional",
-)
 
 
 class PloneRestApiDXPAMLayer(PloneSandboxLayer):
@@ -252,10 +215,6 @@ PLONE_RESTAPI_DX_PAM_INTEGRATION_TESTING = IntegrationTesting(
 PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_RESTAPI_DX_PAM_FIXTURE, z2.ZSERVER_FIXTURE),
     name="PloneRestApiDXPAMLayer:Functional",
-)
-PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING_FREEZETIME = FunctionalTesting(
-    bases=(FREEZE_TIME_FIXTURE, PLONE_RESTAPI_DX_PAM_FIXTURE, z2.ZSERVER_FIXTURE),
-    name="PloneRestApiDXPAMLayerFreeze:Functional",
 )
 
 
@@ -342,10 +301,6 @@ PLONE_RESTAPI_TILES_INTEGRATION_TESTING = IntegrationTesting(
 PLONE_RESTAPI_TILES_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_RESTAPI_TILES_FIXTURE, z2.ZSERVER_FIXTURE),
     name="PloneRestApiTilesLayer:Functional",
-)
-PLONE_RESTAPI_TILES_FUNCTIONAL_TESTING_FREEZETIME = FunctionalTesting(
-    bases=(FREEZE_TIME_FIXTURE, PLONE_RESTAPI_TILES_FIXTURE, z2.ZSERVER_FIXTURE),
-    name="PloneRestApiTilesLayerFreeze:Functional",
 )
 
 

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -2,8 +2,6 @@
 from base64 import b64encode
 from datetime import datetime
 from DateTime import DateTime
-from datetime import timedelta
-from freezegun import freeze_time
 from mock import patch
 from pkg_resources import parse_version
 from pkg_resources import resource_filename
@@ -25,10 +23,8 @@ from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from plone.registry.interfaces import IRegistry
 from plone.restapi.testing import PAM_INSTALLED
-from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME  # noqa
-from plone.restapi.testing import (
-    PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING_FREEZETIME,
-)  # noqa
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 from plone.restapi.testing import register_static_uuid_utility
 from plone.restapi.testing import RelativeSession
 from plone.scale import storage
@@ -153,7 +149,7 @@ def save_request_and_response_for_docs(name, response):
 
 class TestDocumentation(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.app = self.layer["app"]
@@ -164,9 +160,6 @@ class TestDocumentation(unittest.TestCase):
         # Register custom UUID generator to produce stable UUIDs during tests
         pushGlobalRegistry(getSite())
         register_static_uuid_utility(prefix="SomeUUID")
-
-        self.time_freezer = freeze_time("2016-10-21 19:00:00")
-        self.frozen_time = self.time_freezer.start()
 
         self.api_session = RelativeSession(self.portal_url)
         self.api_session.headers.update({"Accept": "application/json"})
@@ -216,7 +209,6 @@ class TestDocumentation(unittest.TestCase):
 
     def tearDown(self):
         self.api_session.close()
-        self.time_freezer.stop()
         popGlobalRegistry(getSite())
         self.api_session.close()
 
@@ -413,14 +405,12 @@ class TestDocumentation(unittest.TestCase):
         save_request_and_response_for_docs("workflow_get", response)
 
     def test_documentation_workflow_transition(self):
-        self.frozen_time.tick(timedelta(minutes=5))
         response = self.api_session.post(
             "{}/@workflow/publish".format(self.document.absolute_url())
         )
         save_request_and_response_for_docs("workflow_post", response)
 
     def test_documentation_workflow_transition_with_body(self):
-        self.frozen_time.tick(timedelta(minutes=5))
         folder = self.portal[self.portal.invokeFactory("Folder", id="folder")]
         transaction.commit()
         response = self.api_session.post(
@@ -1291,7 +1281,7 @@ class TestDocumentation(unittest.TestCase):
 
 class TestDocumentationMessageTranslations(unittest.TestCase):
 
-    layer = layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.app = self.layer["app"]
@@ -1302,9 +1292,6 @@ class TestDocumentationMessageTranslations(unittest.TestCase):
         # Register custom UUID generator to produce stable UUIDs during tests
         pushGlobalRegistry(getSite())
         register_static_uuid_utility(prefix="SomeUUID")
-
-        self.time_freezer = freeze_time("2016-10-21 19:00:00")
-        self.frozen_time = self.time_freezer.start()
 
         self.api_session = RelativeSession(self.portal_url)
         self.api_session.headers.update({"Accept": "application/json"})
@@ -1343,7 +1330,6 @@ class TestDocumentationMessageTranslations(unittest.TestCase):
         return document
 
     def tearDown(self):
-        self.time_freezer.stop()
         popGlobalRegistry(getSite())
         self.api_session.close()
 
@@ -1370,16 +1356,13 @@ class TestDocumentationMessageTranslations(unittest.TestCase):
 
 class TestCommenting(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING_FREEZETIME
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.app = self.layer["app"]
         self.request = self.layer["request"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
-
-        self.time_freezer = freeze_time("2016-10-21 19:00:00")
-        self.frozen_time = self.time_freezer.start()
 
         registry = getUtility(IRegistry)
         settings = registry.forInterface(IDiscussionSettings, check=False)
@@ -1402,7 +1385,6 @@ class TestCommenting(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.time_freezer.stop()
         self.api_session.close()
 
     def create_document_with_comments(self):
@@ -1523,16 +1505,13 @@ class TestCommenting(unittest.TestCase):
 )  # NOQA
 class TestPAMDocumentation(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING_FREEZETIME
+    layer = PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.app = self.layer["app"]
         self.request = self.layer["request"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
-
-        self.time_freezer = freeze_time("2016-10-21 19:00:00")
-        self.frozen_time = self.time_freezer.start()
 
         self.api_session = RelativeSession(self.portal_url)
         self.api_session.headers.update({"Accept": "application/json"})
@@ -1561,7 +1540,6 @@ class TestPAMDocumentation(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.time_freezer.stop()
         self.api_session.close()
 
     def test_documentation_translations_post(self):


### PR DESCRIPTION
I noticed it's only the time frozen test layers causing issues and that one is luckily freezing time without any reason to do so. I simply stopped freezing time and moved the tests to other layers.

Seems the ZODB DemoStorage on 5.1 somehow gets angry at using (at least) `.invokeFactory()` or `plone.api.user` in a time frozen context and loses(?) the object (or connection?) after the first access to it.

Closes https://github.com/plone/plone.restapi/issues/745

I'm not very fond of this, as this still leaves me with a nagging feeling of whether or not the ZODB stack on 5.1 actually works in regards to MVCC.

https://github.com/zopefoundation/ZODB/issues/139

The worst case is this did not go well or has brought forth silently assumed operational conditions, which are not in place for 5.1.