### PR TITLE
Fix time freezing in Plone 5.1 tests

### DIFF
--- a/news/745.bugfix
+++ b/news/745.bugfix
@@ -1,0 +1,2 @@
+Fix time freezing in Plone 5.1 tests.
+[lgraf]

--- a/src/plone/restapi/tests/test_time_freezing.py
+++ b/src/plone/restapi/tests/test_time_freezing.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from freezegun import freeze_time
+import freezegun
+import time
+import unittest
+
+
+class TestTimeFreezing(unittest.TestCase):
+
+    def test_freezegun_provides_original_time_functions(self):
+        """This test guards against future API changes in freezegun.
+        """
+        # These module globals in freezegun.api provide access to the
+        # original time functions.
+        self.assertTrue(hasattr(freezegun.api, 'real_time'))
+        self.assertTrue(hasattr(freezegun.api, 'real_gmtime'))
+
+        # Before freezing time, they should be references to the
+        # real time functions
+        self.assertTrue(freezegun.api.real_time is time.time)
+        self.assertTrue(freezegun.api.real_gmtime is time.gmtime)
+
+        # After freezing, we expect them to differ
+        with freeze_time("2016-10-21 19:00:00"):
+            self.assertFalse(freezegun.api.real_time is time.time)
+            self.assertFalse(freezegun.api.real_gmtime is time.gmtime)


### PR DESCRIPTION
Our patch for `ZODB.utils.newTid` got made ineffective by internal API changes in `freezegun`:

The patch, which was supposed to ensure that `ZODB.utils.newTid` always uses the real time functions (never the patched ones) relied on an attribute `previous_time_function` being present on the patched `time.time()`, in order to recognize time being patched and access the original, real time function.

That was true for an older version of `freezegun`, but since `0.3.12` it stows aways references to the original time functions in [module globals in `freezegun.api` (`real_time`, `real_gmtime`, etc)](https://github.com/spulec/freezegun/blob/64a0541cec8e9e3d7b63fdccb80db19cd7a613fe/freezegun/api.py#L24-L30). The `previous_time_function` reference to the original time function got removed during a refactoring in spulec/freezegun#267).

This change therefore updates the patch to (always) use those references to the original time functions, and adds a regression test to guard against future changes in freezegun's API.

Closes #745