### PR TITLE
types endpoint: Fix support for context aware default factories

### DIFF
--- a/news/748.bugfix
+++ b/news/748.bugfix
@@ -1,0 +1,2 @@
+@types endpoint: Fix support for context aware default factories.
+[lgraf]

--- a/src/plone/restapi/tests/test_types.py
+++ b/src/plone/restapi/tests/test_types.py
@@ -1,24 +1,23 @@
 # -*- coding: utf-8 -*-
 from datetime import date
 from decimal import Decimal
-from unittest import TestCase
-
-from zope.component import getMultiAdapter
-from zope import schema
-from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
 from plone.app.textfield import RichText
 from plone.autoform import directives as form
 from plone.dexterity.fti import DexterityFTI
-from plone.supermodel import model
-from Products.CMFCore.utils import getToolByName
-
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from plone.restapi.types.interfaces import IJsonSchemaProvider
 from plone.restapi.types.utils import get_fieldsets
 from plone.restapi.types.utils import get_jsonschema_for_fti
 from plone.restapi.types.utils import get_jsonschema_for_portal_type
 from plone.restapi.types.utils import get_jsonschema_properties
+from plone.supermodel import model
+from Products.CMFCore.utils import getToolByName
+from unittest import TestCase
 from z3c.form.browser.text import TextWidget
+from zope import schema
+from zope.component import getMultiAdapter
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 
 
 class IDummySchema(model.Schema):

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """JsonSchema providers."""
 from plone.app.textfield.interfaces import IRichText
+from plone.restapi.types.interfaces import IJsonSchemaProvider
+from plone.restapi.types.utils import get_fieldsets, get_widget_params
+from plone.restapi.types.utils import get_jsonschema_properties
+from plone.restapi.types.utils import get_vocabulary_url
 from plone.schema import IJSONField
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -27,11 +31,6 @@ from zope.schema.interfaces import ISet
 from zope.schema.interfaces import IText
 from zope.schema.interfaces import ITextLine
 from zope.schema.interfaces import ITuple
-
-from plone.restapi.types.interfaces import IJsonSchemaProvider
-from plone.restapi.types.utils import get_fieldsets, get_widget_params
-from plone.restapi.types.utils import get_jsonschema_properties
-from plone.restapi.types.utils import get_vocabulary_url
 
 
 @adapter(IField, Interface, Interface)

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -37,7 +37,7 @@ from zope.schema.interfaces import ITuple
 @implementer(IJsonSchemaProvider)
 class DefaultJsonSchemaProvider(object):
     def __init__(self, field, context, request):
-        self.field = field
+        self.field = field.bind(context)
         self.context = context
         self.request = request
 


### PR DESCRIPTION
A `defaultFactory` might be context aware (if it implements `IContextAwareDefaultFactory`).

However, in order for these context aware default factories to be invoked with the correct context, the field needs to be bound first before attempting to access `field.default`. The `DefaultJsonSchemaProvider` used in the `@types` endpoint currently doesn't do this, and therefore always invokes `field.default` on unbound fields.

This change makes sure the `DefaultJsonSchemaProvider` (and providers inheriting from it) always operates on bound fields.

Fixes #748 