### PR TITLE
Gracefully handle corrupt images when serializing scales.

### DIFF
--- a/news/729.bugfix
+++ b/news/729.bugfix
@@ -1,0 +1,2 @@
+Gracefully handle corrupt images when serializing scales.
+[lgraf]

--- a/src/plone/restapi/imaging.py
+++ b/src/plone/restapi/imaging.py
@@ -33,6 +33,10 @@ def get_scales(context, field, width, height):
                 field.__name__, width=actual_width, height=actual_height
             )
 
+        if scale is None:
+            # If we still can't get a scale, it's probably a corrupt image
+            continue
+
         url = scale.url
         actual_width = scale.width
         actual_height = scale.height
@@ -52,6 +56,9 @@ def get_original_image_url(context, fieldname, width, height):
     scale = images_view.scale(
         fieldname, width=width, height=height, direction="thumbnail"
     )
+    if not scale:
+        # This might happen for corrupt images.
+        return None
 
     return scale.url
 

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -257,6 +257,28 @@ class TestDexterityFieldSerializing(TestCase):
                 value,
             )
 
+    def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
+        image_data = b'INVALID IMAGE DATA'
+        fn = "test_namedimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+        self.assertEqual(
+            {
+                u'content-type': u'image/gif',
+                u'download': None,
+                u'filename': u'1024x768.gif',
+                u'height': -1,
+                u'scales': {},
+                u'size': 18,
+                u'width': -1,
+            },
+            value)
+
     def test_namedblobfile_field_serialization_returns_dict(self):
         value = self.serialize(
             "test_namedblobfile_field",


### PR DESCRIPTION
Because on `POST` we also return the serialized, created object in the response, the serialization of image scales produced a confusing error when uploading a corrupt or possibly misnamed image.

Since it is, at least in some cases, also possible to get corrupted images into Plone using the classic user interface, I opted for not guarding against that in `plone.restapi`.

Instead, I modified the code for serializing image scales in a way that it fails gracefully. For corrupt images, it will now
- return `None` as the download URL
- return an empty scales dict
- return a width and height of `-1`

Fixes #729