### PR TITLE
Docs: Make sure application/json+schema examples also get syntax highlighted.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,20 @@ extensions = [
     'sphinxcontrib.httpexample',
 ]
 
+
+def patch_pygments_to_highlight_jsonschema():
+    """Append 'application/json+schema' to the list of mimetypes the
+    Pygments JSON lexer is registered to handle.
+    """
+    try:
+        from pygments.lexers._mapping import LEXERS
+        mod, lexer_name, aliases, filenames, mimetypes = LEXERS['JsonLexer']
+        mimetypes = mimetypes + ('application/json+schema', )
+        LEXERS['JsonLexer'] = (mod, lexer_name, aliases, filenames, mimetypes)
+    except:
+        # Be defensive (don't fail a docs build if this doesn't work)
+        pass
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -248,3 +262,4 @@ texinfo_documents = [
 
 suppress_warnings = ['image.nonlocal_uri']
 
+patch_pygments_to_highlight_jsonschema()

--- a/news/764.bugfix
+++ b/news/764.bugfix
@@ -1,0 +1,2 @@
+Docs: Make sure application/json+schema examples also get syntax highlighted.
+[lgraf]


### PR DESCRIPTION
This adds `application/json+schema` to the list of MIME types that the Pygments JSON lexer is registered to handle. This will fix **syntax highlighting** for our large **JSON schema dumps** in the documentation of the `@types` endpoint.

See [before](https://plonerestapi.readthedocs.io/en/latest/types.html) and [after](https://plonerestapi.readthedocs.io/en/syntax-highlight-jsonschema/types.html) _(example response at the bottom of those pages)_.

Fixes #764 