### PR TITLE
Factor out permission checks in @users endpoint.

### DIFF
--- a/news/771.feature
+++ b/news/771.feature
@@ -1,0 +1,3 @@
+Factor out permission checks in @users endpoint
+to make it more easily customizable.
+[lgraf]


### PR DESCRIPTION
The permission checks in the `@users` endpoint were [hardcoded in the `reply()` method](https://github.com/plone/plone.restapi/blob/master/src/plone/restapi/services/users/get.py#L51-L105). This makes it quite cumbersome to override this endpoint to just do different permission checks for who should be allowed to enumerate, query and access user information.

This PR simply factors them out into individual methods, so that the endpoint can more easily be customized.

Fixes #771