### PR TITLE
Return status 400 if a referenced object can not be resolved during deserialization

### DIFF
--- a/news/777.bugfix
+++ b/news/777.bugfix
@@ -1,0 +1,2 @@
+Return status 400 if a referenced object can not be resolved during deserialization.
+[lgraf]

--- a/src/plone/restapi/deserializer/relationfield.py
+++ b/src/plone/restapi/deserializer/relationfield.py
@@ -54,6 +54,7 @@ class RelationChoiceFieldDeserializer(DefaultFieldDeserializer):
                 resolved_by = "UID"
 
         if obj is None:
+            self.request.response.setStatus(400)
             raise ValueError(
                 u"Could not resolve object for {}={}".format(resolved_by, value)
             )

--- a/src/plone/restapi/tests/test_dxfield_deserializer.py
+++ b/src/plone/restapi/tests/test_dxfield_deserializer.py
@@ -421,6 +421,7 @@ class TestDXFieldDeserializer(unittest.TestCase):
         self.assertEqual(
             str(cm.exception), u"Could not resolve object for intid=123456789"
         )
+        self.assertEqual(400, self.request.response.getStatus())
 
     def test_relationchoice_deserialization_from_invalid_uid_raises(self):
         with self.assertRaises(ValueError) as cm:
@@ -432,6 +433,7 @@ class TestDXFieldDeserializer(unittest.TestCase):
             str(cm.exception),
             u"Could not resolve object for UID=ac12b24913cf45c6863937367aacc263",
         )
+        self.assertEqual(400, self.request.response.getStatus())
 
     def test_relationchoice_deserialization_from_invalid_url_raises(self):
         with self.assertRaises(ValueError) as cm:
@@ -443,6 +445,7 @@ class TestDXFieldDeserializer(unittest.TestCase):
             str(cm.exception),
             u"Could not resolve object for URL=http://nohost/plone/doesnotexist",
         )
+        self.assertEqual(400, self.request.response.getStatus())
 
     def test_relationchoice_deserialization_from_invalid_path_raises(self):
         with self.assertRaises(ValueError) as cm:
@@ -452,6 +455,7 @@ class TestDXFieldDeserializer(unittest.TestCase):
         self.assertEqual(
             str(cm.exception), u"Could not resolve object for path=/doesnotexist"
         )
+        self.assertEqual(400, self.request.response.getStatus())
 
     def test_relationlist_deserialization_returns_list_of_documents(self):
         doc2 = self.portal[


### PR DESCRIPTION
Return status `400` (instead of `500`)  if a referenced object can not be resolved during deserialization since it's a client error.

Fixes #777.