### PR TITLE
Feature relations service

### DIFF
--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.2rc3/versions.cfg
+    http://dist.plone.org/release/5.2/versions.cfg
 find-links += http://dist.plone.org/thirdparty/
 versions=versions
 

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -20,6 +20,7 @@
   <include package=".locking" />
   <include package=".principals"/>
   <include package=".registry"/>
+  <include package=".relations"/>
   <include package=".roles"/>
   <include package=".search"/>
   <include package=".types"/>

--- a/src/plone/restapi/services/relations/configure.zcml
+++ b/src/plone/restapi/services/relations/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone">
+
+  <adapter factory=".get.Relations" name="relations"/>
+
+  <plone:service
+    method="GET"
+    for="z3c.relationfield.interfaces.IHasRelations"
+    factory=".get.RelationsGet"
+    name="@relations"
+    permission="zope2.View"
+    />
+
+</configure>

--- a/src/plone/restapi/services/relations/get.py
+++ b/src/plone/restapi/services/relations/get.py
@@ -41,7 +41,7 @@ class Relations(object):
             else:
                 query = dict(from_id=intid)
                 direction = 'to'
-            for rel in catalog.findRelations(query):
+            for rel in sorted(catalog.findRelations(query)):
                 if rel.isBroken():
                     # skip broken relations
                     continue

--- a/src/plone/restapi/services/relations/get.py
+++ b/src/plone/restapi/services/relations/get.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.services import Service
+from z3c.relationfield.interfaces import IHasRelations
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+from Acquisition import aq_inner
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+from zope.security import checkPermission
+from zc.relation.interfaces import ICatalog
+from plone.restapi.interfaces import ISerializeToJsonSummary
+
+
+@implementer(IExpandableElement)
+@adapter(IHasRelations, Interface)
+class Relations(object):
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, expand=False):
+        result = {"relations": {"@id": "{}/@relations".format(self.context.absolute_url())}}
+        if not expand:
+            return result
+
+        data = {
+            "incoming": {},
+            "outgoing": {}
+        }
+
+        catalog = getUtility(ICatalog)
+        intids = getUtility(IIntIds)
+        intid = intids.getId(aq_inner(self.context))
+        for relation_type in data.keys():
+            if relation_type == "incoming":
+                query = dict(to_id=intid)
+            else:
+                query = dict(from_id=intid)
+            for rel in catalog.findRelations(query):
+                if relation_type == "incoming":
+                    obj = intids.queryObject(rel.from_id)
+                else:
+                    obj = intids.queryObject(rel.to_id)
+
+                if obj is not None and checkPermission('zope2.View', obj):
+                    summary = getMultiAdapter(
+                        (obj, self.request), ISerializeToJsonSummary
+                    )()
+                    if rel.from_attribute in data[relation_type]:
+                        data[relation_type][rel.from_attribute].append(summary)
+                    else:
+                        data[relation_type][rel.from_attribute] = [summary]
+        result["relations"].update(data)
+        return result
+
+
+class RelationsGet(Service):
+    def reply(self):
+        relations = Relations(self.context, self.request)
+        return relations(expand=True)["relations"]

--- a/src/plone/restapi/services/relations/get.py
+++ b/src/plone/restapi/services/relations/get.py
@@ -21,13 +21,13 @@ class Relations(object):
         self.request = request
 
     def __call__(self, expand=False):
-        result = {"relations": {"@id": "{}/@relations".format(self.context.absolute_url())}}
+        result = {'relations': {'@id': '{}/@relations'.format(self.context.absolute_url())}}
         if not expand:
             return result
 
         data = {
-            "incoming": {},
-            "outgoing": {}
+            'incoming': {},
+            'outgoing': {}
         }
 
         portal_catalog = api.portal.get_tool('portal_catalog')
@@ -35,12 +35,12 @@ class Relations(object):
         intids = getUtility(IIntIds)
         intid = intids.getId(aq_inner(self.context))
         for relation_type in data.keys():
-            if relation_type == "incoming":
+            if relation_type == 'incoming':
                 query = dict(to_id=intid)
-                direction = "from"
+                direction = 'from'
             else:
                 query = dict(from_id=intid)
-                direction = "to"
+                direction = 'to'
             for rel in catalog.findRelations(query):
                 if rel.isBroken():
                     # skip broken relations
@@ -57,11 +57,11 @@ class Relations(object):
                         data[relation_type][rel.from_attribute].append(summary)
                     else:
                         data[relation_type][rel.from_attribute] = [summary]
-        result["relations"].update(data)
+        result['relations'].update(data)
         return result
 
 
 class RelationsGet(Service):
     def reply(self):
         relations = Relations(self.context, self.request)
-        return relations(expand=True)["relations"]
+        return relations(expand=True)['relations']

--- a/src/plone/restapi/services/relations/get.py
+++ b/src/plone/restapi/services/relations/get.py
@@ -25,10 +25,12 @@ class Relations(object):
         if not expand:
             return result
 
-        data = {
-            'incoming': {},
-            'outgoing': {}
-        }
+        # by default, just list incoming relations. Outgoing relations
+        # are typically serialized as attributes of the current item.
+        data = {'incoming': {}}
+        # render outgoing relations also, if explicitly requested
+        if 'allrelations' in self.request.form:
+            data['outgoing'] = {}
 
         portal_catalog = api.portal.get_tool('portal_catalog')
         catalog = getUtility(ICatalog)

--- a/src/plone/restapi/services/relations/get.py
+++ b/src/plone/restapi/services/relations/get.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
-from plone.restapi.interfaces import IExpandableElement
+from Acquisition import aq_inner
+from plone import api
+from plone.restapi.interfaces import IExpandableElement, ISerializeToJsonSummary
 from plone.restapi.services import Service
 from z3c.relationfield.interfaces import IHasRelations
+from zc.relation.interfaces import ICatalog
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.interface import implementer
 from zope.interface import Interface
-
-from Acquisition import aq_inner
-from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
-from zope.security import checkPermission
-from zc.relation.interfaces import ICatalog
-from plone.restapi.interfaces import ISerializeToJsonSummary
 
 
 @implementer(IExpandableElement)
@@ -32,23 +30,28 @@ class Relations(object):
             "outgoing": {}
         }
 
+        portal_catalog = api.portal.get_tool('portal_catalog')
         catalog = getUtility(ICatalog)
         intids = getUtility(IIntIds)
         intid = intids.getId(aq_inner(self.context))
         for relation_type in data.keys():
             if relation_type == "incoming":
                 query = dict(to_id=intid)
+                direction = "from"
             else:
                 query = dict(from_id=intid)
+                direction = "to"
             for rel in catalog.findRelations(query):
-                if relation_type == "incoming":
-                    obj = intids.queryObject(rel.from_id)
-                else:
-                    obj = intids.queryObject(rel.to_id)
-
-                if obj is not None and checkPermission('zope2.View', obj):
+                if rel.isBroken():
+                    # skip broken relations
+                    continue
+                # query by path so we don't have to wake up any objects. Also this
+                # ensures security check.
+                brains = portal_catalog(path={'query': getattr(rel, direction + '_path'), 'depth': 0})
+                # get summary representation from brain
+                if brains is not None and len(brains):
                     summary = getMultiAdapter(
-                        (obj, self.request), ISerializeToJsonSummary
+                        (brains[0], self.request), ISerializeToJsonSummary
                     )()
                     if rel.from_attribute in data[relation_type]:
                         data[relation_type][rel.from_attribute].append(summary)

--- a/src/plone/restapi/tests/http-examples/collection.resp
+++ b/src/plone/restapi/tests/http-examples/collection.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/collection/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/collection/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/collection/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/content_get.resp
+++ b/src/plone/restapi/tests/http-examples/content_get.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/folder/my-document/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/folder/my-document/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/folder/my-document/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/content_get_folder.resp
+++ b/src/plone/restapi/tests/http-examples/content_get_folder.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/folder/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/folder/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/folder/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/content_patch_representation.resp
+++ b/src/plone/restapi/tests/http-examples/content_patch_representation.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/folder/my-document/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/folder/my-document/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/folder/my-document/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/content_post.resp
+++ b/src/plone/restapi/tests/http-examples/content_post.resp
@@ -13,6 +13,9 @@ Location: http://localhost:55001/plone/folder/my-document
     "navigation": {
       "@id": "http://localhost:55001/plone/folder/my-document/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/folder/my-document/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/folder/my-document/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/document.resp
+++ b/src/plone/restapi/tests/http-examples/document.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/front-page/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/front-page/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/front-page/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/event.resp
+++ b/src/plone/restapi/tests/http-examples/event.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/event/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/event/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/event/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/expansion.resp
+++ b/src/plone/restapi/tests/http-examples/expansion.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/front-page/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/front-page/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/front-page/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/expansion_expanded.resp
+++ b/src/plone/restapi/tests/http-examples/expansion_expanded.resp
@@ -18,6 +18,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/front-page/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/front-page/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/front-page/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/expansion_expanded_full.resp
+++ b/src/plone/restapi/tests/http-examples/expansion_expanded_full.resp
@@ -125,6 +125,9 @@ Content-Type: application/json
         }
       ]
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/front-page/@relations"
+    }, 
     "types": [
       {
         "@id": "http://localhost:55001/plone/@types/Collection", 

--- a/src/plone/restapi/tests/http-examples/file.resp
+++ b/src/plone/restapi/tests/http-examples/file.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/file/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/file/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/file/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/folder.resp
+++ b/src/plone/restapi/tests/http-examples/folder.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/folder/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/folder/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/folder/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/image.resp
+++ b/src/plone/restapi/tests/http-examples/image.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/image/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/image/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/image/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/link.resp
+++ b/src/plone/restapi/tests/http-examples/link.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/link/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/link/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/link/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/newsitem.resp
+++ b/src/plone/restapi/tests/http-examples/newsitem.resp
@@ -12,6 +12,9 @@ Content-Type: application/json
     "navigation": {
       "@id": "http://localhost:55001/plone/newsitem/@navigation"
     }, 
+    "relations": {
+      "@id": "http://localhost:55001/plone/newsitem/@relations"
+    }, 
     "types": {
       "@id": "http://localhost:55001/plone/newsitem/@types"
     }, 

--- a/src/plone/restapi/tests/http-examples/search_fullobjects.resp
+++ b/src/plone/restapi/tests/http-examples/search_fullobjects.resp
@@ -15,6 +15,9 @@ Content-Type: application/json
         "navigation": {
           "@id": "http://localhost:55001/plone/doc1/@navigation"
         }, 
+        "relations": {
+          "@id": "http://localhost:55001/plone/doc1/@relations"
+        }, 
         "types": {
           "@id": "http://localhost:55001/plone/doc1/@types"
         }, 


### PR DESCRIPTION
I added a simple expandable service `@relations`, which adapts objects implementing `IHasRelations` and by default renders incoming relations (summary).

It is also possible to render incoming and outgoing relations, by bypassing the request param `allrelations`.