### PR TITLE
Fire ModifiedEvent when field is set to null in a PATCH request.

### DIFF
--- a/news/802.bugfix
+++ b/news/802.bugfix
@@ -1,0 +1,2 @@
+Fire ModifiedEvent when field is set to null in a PATCH request.
+[phgross]

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -65,6 +65,13 @@ class DeserializeFromJson(OrderingMixin, object):
                     # set the field to missing_value if we receive null
                     if data[name] is None:
                         if not field.required:
+                            if dm.get():
+                                # Collect the names of the modified fields
+                                # Use prefixed name because z3c.form does so
+                                prefixed_name = schema.__name__ + '.' + name
+                                modified.setdefault(schema, []).append(
+                                    prefixed_name)
+
                             dm.set(field.missing_value)
                         else:
                             errors.append(

--- a/src/plone/restapi/tests/test_dxcontent_deserializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_deserializer.py
@@ -91,6 +91,18 @@ class TestDXContentDeserializer(unittest.TestCase, OrderingMixin):
             self.event.descriptions[0].attributes,
         )
 
+    def test_deserializer_notifies_when_field_is_set_to_null(self):
+        def handler(obj, event):
+            obj._handler_called = True
+            self.event = event
+        provideHandler(handler, (IDexterityItem, IObjectModifiedEvent,))
+        self.deserialize(body='{"test_textline_field": null}')
+        self.assertTrue(getattr(self.portal.doc1, '_handler_called', False),
+                        'IObjectModifiedEvent not notified')
+        self.assertEqual(
+            ('IDXTestDocumentSchema.test_textline_field',),
+            self.event.descriptions[0].attributes)
+
     def test_deserializer_does_not_update_field_without_write_permission(self):
         self.portal.doc1.test_write_permission_field = u"Test Write Permission"
         setRoles(self.portal, TEST_USER_ID, ["Member", "Contributor", "Editor"])


### PR DESCRIPTION
Setting a field to null in a PATCH request, was not tracked as field change in the DX Content deserializer and therefore no ModifiedEvent was fired. Closes #802 

Besides that, I split up the call method to make code analysis checks happy.