### PR TITLE
Explicitly load zcml of dependencies

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Explicitly load zcml of dependencies, instead of using ``includeDependencies``
+[maurits]

--- a/src/plone/restapi/configure.zcml
+++ b/src/plone/restapi/configure.zcml
@@ -9,6 +9,9 @@
 
   <i18n:registerTranslations directory="locales" />
 
+  <include package="plone.behavior" file="meta.zcml"/>
+  <include package="plone.rest" file="meta.zcml"/>
+
   <include package="plone.behavior" />
   <include package="plone.rest" />
   <include package="plone.schema" />

--- a/src/plone/restapi/configure.zcml
+++ b/src/plone/restapi/configure.zcml
@@ -9,7 +9,9 @@
 
   <i18n:registerTranslations directory="locales" />
 
-  <includeDependencies package="." />
+  <include package="plone.behavior" />
+  <include package="plone.rest" />
+  <include package="plone.schema" />
 
   <five:registerPackage package="." initialize=".initialize" />
 


### PR DESCRIPTION
This is instead of using `includeDependencies`.

See https://github.com/plone/Products.CMFPlone/issues/2952