### PR TITLE
Fix issue with serialization of vocabulary items

### DIFF
--- a/news/788.bugfix
+++ b/news/788.bugfix
@@ -1,0 +1,2 @@
+Fix serialization of vocabulary items for fields that need hashable items (e.g. sets).
+[buchi]

--- a/src/plone/restapi/serializer/dxfields.py
+++ b/src/plone/restapi/serializer/dxfields.py
@@ -68,7 +68,7 @@ class CollectionFieldSerializer(DefaultFieldSerializer):
             for v in value:
                 term = value_type.vocabulary.getTerm(v)
                 values.append({u"token": term.token, u"title": term.title})
-            value = self.field._type(values)
+            value = values
         return json_compatible(value)
 
 

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -193,6 +193,18 @@ class IDXTestDocumentSchema(model.Schema):
         required=False,
     )
     test_set_field = schema.Set(required=False)
+    test_set_field_with_choice_with_vocabulary = schema.Set(
+        value_type=schema.Choice(
+            vocabulary=SimpleVocabulary(
+                [
+                    SimpleTerm(u"value1", "token1", u"title1"),
+                    SimpleTerm(u"value2", "token2", u"title2"),
+                    SimpleTerm(u"value3", "token3", u"title3"),
+                ]
+            )
+        ),
+        required=False,
+    )
     test_text_field = schema.Text(required=False)
     test_textline_field = schema.TextLine(required=False)
     test_time_field = schema.Time(required=False)

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -156,6 +156,19 @@ class TestDexterityFieldSerializing(TestCase):
         self.assertTrue(isinstance(value, list), "Not a <list>")
         self.assertEqual([u"a", u"b", u"c"], sorted(value))
 
+    def test_set_field_with_vocabulary_choice_serialization_returns_terms(self):
+        value = self.serialize(
+            "test_set_field_with_choice_with_vocabulary", set([u"value1", u"value3"])
+        )
+        self.assertTrue(isinstance(value, list), "Not a <list>")
+        self.assertEqual(
+            [
+                {u"token": u"token1", u"title": u"title1"},
+                {u"token": u"token3", u"title": u"title3"},
+            ],
+            sorted(value, key=lambda x: x[u"token"]),
+        )
+
     def test_text_field_serialization_returns_unicode(self):
         value = self.serialize("test_text_field", u"Käfer")
         self.assertTrue(isinstance(value, six.text_type), "Not an <unicode>")


### PR DESCRIPTION
Vocabulary items are not hashable and thus we can't cast them to the
fields type. We always return lists as JSON doesn't support other
container types anyway.

Closes #788 