### PR TITLE
Remove IAPIRequest marker interface

### DIFF
--- a/news/819.bugfix
+++ b/news/819.bugfix
@@ -1,0 +1,1 @@
+Remove IAPIRequest marker interface from plone.restapi. The correct interface should be imported from plone.rest.interfaces instead. If anybody was using this marker Interface, it didn't do anything.

--- a/src/plone/restapi/interfaces.py
+++ b/src/plone/restapi/interfaces.py
@@ -13,11 +13,6 @@ class IPloneRestapiLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
 
 
-class IAPIRequest(Interface):
-    """Marker for API requests.
-    """
-
-
 class ISerializeToJson(Interface):
     """Adapter to serialize a Dexterity object into a JSON object.
     """


### PR DESCRIPTION
It's not used in plone.restapi and should be imported from plone.rest.interfaces instead. If anybody was using this marker, it didn't do anything.

We coul alias/import it from plone.rest to here, but then it suddenly would start to work..... I don't know if that's better than removing it.