### PR TITLE
Fix filtering vocabs and sources by non-ASCII title

### DIFF
--- a/news/825.bugfix
+++ b/news/825.bugfix
@@ -1,0 +1,2 @@
+Fix filtering vocabs and sources by title with non-ASCII characters.
+[lgraf]

--- a/src/plone/restapi/profiles/testing/types/DXTestDocument.xml
+++ b/src/plone/restapi/profiles/testing/types/DXTestDocument.xml
@@ -22,6 +22,7 @@
   <property name="behaviors">
     <element value="plone.restapi.tests.dxtypes.ITestBehavior"/>
     <element value="plone.restapi.tests.dxtypes.ITestAnnotationsBehavior"/>
+    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
   </property>
 
   <!-- View information -->

--- a/src/plone/restapi/serializer/vocabularies.py
+++ b/src/plone/restapi/serializer/vocabularies.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.interfaces import ISerializeToJson
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.i18n import translate
@@ -27,7 +28,7 @@ class SerializeVocabLikeToJson(object):
 
     def __call__(self, vocabulary_id):
         vocabulary = self.context
-        title = self.request.form.get("title", "")
+        title = safe_unicode(self.request.form.get("title", ""))
         token = self.request.form.get("token", "")
 
         terms = []
@@ -46,7 +47,7 @@ class SerializeVocabLikeToJson(object):
                     continue
                 terms.append(term)
             else:
-                term_title = getattr(term, "title", None) or ""
+                term_title = safe_unicode(getattr(term, "title", None) or "")
                 if title.lower() not in term_title.lower():
                     continue
                 terms.append(term)

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -9,6 +9,7 @@ from plone.autoform.directives import write_permission
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.namedfile import field as namedfile
+from plone.restapi.tests.helpers import ascii_token
 from plone.supermodel import model
 from Products.CMFCore.utils import getToolByName
 from pytz import timezone
@@ -84,9 +85,10 @@ class MyIterableContextSource(object):
         self.context = context
 
         title_words = self.context.title.split()
-        self.terms = [
-            SimpleTerm(value=w.lower(), token=w.lower(), title=w) for w in title_words
-        ]
+        self.terms = [SimpleTerm(value=w.lower(),
+                                 token=ascii_token(w.lower()),
+                                 title=w)
+                      for w in title_words]
 
     def __contains__(self, value):
         return value in [t.value for t in self.terms]
@@ -101,9 +103,10 @@ class MyContextQuerySource(object):
         self.context = context
 
         title_words = self.context.title.split()
-        self.terms = [
-            SimpleTerm(value=w.lower(), token=w.lower(), title=w) for w in title_words
-        ]
+        self.terms = [SimpleTerm(value=w.lower(),
+                                 token=ascii_token(w.lower()),
+                                 title=w)
+                      for w in title_words]
 
     def __contains__(self, value):
         return value in [t.value for t in self.terms]

--- a/src/plone/restapi/tests/helpers.py
+++ b/src/plone/restapi/tests/helpers.py
@@ -2,6 +2,8 @@
 from Products.CMFCore.utils import getToolByName
 from six.moves.urllib.parse import urlparse
 
+import quopri
+
 
 def result_paths(results):
     """Helper function to make it easier to write list-based assertions on
@@ -35,3 +37,10 @@ def add_catalog_indexes(portal, indexes):
             indexables.append(name)
     if len(indexables) > 0:
         catalog.manage_reindexIndex(ids=indexables)
+
+
+def ascii_token(text):
+    """Turn a text (unicode in Py2, str in Py3) into a ASCII-only
+    bytestring that is safe to use in term tokens.
+    """
+    return quopri.encodestring(text.encode('utf-8'))

--- a/src/plone/restapi/tests/test_services_sources.py
+++ b/src/plone/restapi/tests/test_services_sources.py
@@ -179,7 +179,7 @@ class TestSourcesEndpoint(unittest.TestCase):
         )
 
     def test_context_source(self):
-        self.doc.title = "Foo Bar Baz"
+        self.doc.title = u'Foo Bar Baz'
         transaction.commit()
 
         response = self.api_session.get(
@@ -198,6 +198,27 @@ class TestSourcesEndpoint(unittest.TestCase):
                     {u"token": u"baz", u"title": u"Baz"},
                 ],
                 u"items_total": 3,
+            },
+        )
+
+    def test_source_filtered_by_non_ascii_title(self):
+        self.doc.title = u'Bär'
+        transaction.commit()
+
+        response = self.api_session.get(
+            "%s/@sources/test_choice_with_context_source?title=b%%C3%%A4r" % self.doc.absolute_url()
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                u"@id": self.portal_url
+                + u"/testdoc/@sources/test_choice_with_context_source?title=b%C3%A4r",  # noqa
+                u"items": [
+                    {u'token': u'b=C3=A4r', u'title': u'B\xe4r'},
+                ],
+                u"items_total": 1,
             },
         )
 

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -136,6 +136,24 @@ class TestVocabularyEndpoint(unittest.TestCase):
             },
         )
 
+    def test_get_vocabulary_filtered_by_non_ascii_title(self):
+        response = self.api_session.get(
+            "/@vocabularies/plone.restapi.tests.test_vocabulary?title=t%C3%B6tle"
+        )
+
+        self.assertEqual(200, response.status_code)
+        response = response.json()
+        self.assertEqual(
+            response,
+            {
+                u"@id": self.portal_url
+                + u"/@vocabularies/plone.restapi.tests.test_vocabulary?title=t%C3%B6tle",  # noqa
+                u"items": [{u"title": u"T\xf6tle 5", u"token": u"token5"},
+                           {u"title": u"T\xf6tle 6", u"token": u"token6"}],
+                u"items_total": 2,
+            },
+        )
+
     def test_get_vocabulary_filtered_by_token(self):
         response = self.api_session.get(
             "/@vocabularies/plone.restapi.tests.test_vocabulary?token=token1"


### PR DESCRIPTION
This fixes an issue where on Python 2 filtering `@vocabularies` or `@sources` by a `title` that contains non-ASCII characters.

Because request parameters are parsed into UTF-8 encoded bytestrings on Python 2, this leads to a bytestring search query getting compared with unicode term titles. If the search query contains non ASCII characters, the implicit decoding using the default encoding will fail. Making sure we always compare `unicode` (or `str` on Python 3) fixes this.

*(Filtering by `token` doesn't need the same treatment because tokens can [only be 7-bit ASCII](https://github.com/zopefoundation/zope.schema/blob/master/src/zope/schema/interfaces.py#L884-L891))*

Fixes #825