### PR TITLE
Prevent converting bytestring ids to unicode ids when reordering on python2.

### DIFF
--- a/docs/source/upgrade-guide.rst
+++ b/docs/source/upgrade-guide.rst
@@ -3,6 +3,33 @@ Upgrade Guide
 
 This upgrade guide lists all breaking changes in plone.restapi and explains the necessary steps that are needed to upgrade to the lastest version.
 
+
+Upgrading to plone.restapi X.y
+------------------------------
+
+All versions before plone.restapi x.y.z are potentially affected by an issue
+that converts ids of reordered content to unicode from a bytestring when
+running on python2.
+
+You may be affected by this issue and should run the fix if:
+
+- You used the PATCH "ordering" functionality of plone.restapi
+- Were using Python 2 at that point
+- Are seeing issues with objectIds() returning mixed string types
+
+If you need to fix object ids you can do one of the following:
+
+- Use the browser-view ``@@plone-restapi-upgrade-fix-ordering`` as a "Manager"
+  to fix all folderish content types in your Plone site.
+- Run the helper function
+  ``ensure_child_ordering_object_ids_are_native_strings``
+  from ``plone.restapi.upgrades.ordering`` for all affected objects. You could
+  do this in a custom upgrade-step implemented in your policy.
+
+We expect that most content won't actually be affected. See
+https://github.com/plone/plone.restapi/issues/827 for more details.
+
+
 Upgrading to plone.restapi 5.x
 ------------------------------
 

--- a/news/827.bugfix
+++ b/news/827.bugfix
@@ -1,0 +1,2 @@
+Prevent converting bytestring ids to unicode ids when reordering (see upgrade guide for potential migration).
+[deiferni]

--- a/src/plone/restapi/deserializer/mixins.py
+++ b/src/plone/restapi/deserializer/mixins.py
@@ -3,6 +3,8 @@ from plone.folder.interfaces import IExplicitOrdering
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zExceptions import BadRequest
 
+import six
+
 
 class OrderingMixin(object):
     def handle_ordering(self, data):
@@ -32,6 +34,16 @@ class OrderingMixin(object):
             position_id.sort()
             if subset_ids != [i for position, i in position_id]:
                 raise BadRequest("Client/server ordering mismatch")
+
+        # Make sure we use bytestring ids for PY2.
+        if six.PY2:
+            if isinstance(obj_id, six.text_type):
+                obj_id = obj_id.encode('utf-8')
+            if subset_ids:
+                subset_ids = [
+                    id_.encode('utf-8') if isinstance(id_, six.text_type)
+                    else id_ for id_ in subset_ids
+                ]
 
         # All movement is relative to the subset of ids, if passed in.
         if delta == "top":

--- a/src/plone/restapi/tests/mixin_ordering.py
+++ b/src/plone/restapi/tests/mixin_ordering.py
@@ -195,6 +195,38 @@ class OrderingMixin:
             self.folder.contentIds(),
         )
 
+    def test_ordering_preserves_native_string_obj_id(self):
+        # sanity check, initial situation
+        for id_ in self.folder.objectIds():
+            self.assertIsInstance(id_, str)
+
+        # reorder
+        data = {"ordering": {"delta": "top", "obj_id": "doc9"}}
+        self.deserialize(body=json.dumps(data), context=self.folder)
+
+        # reordering should preserve bytestring ids in PY2 and unicode ids in PY3
+        for id_ in self.folder.objectIds():
+            self.assertIsInstance(id_, str)
+
+    def test_ordering_preserves_native_string_subset_ids(self):
+        # sanity check, initial situation
+        for id_ in self.folder.objectIds():
+            self.assertIsInstance(id_, str)
+
+        # reorder and also provide subset_ids
+        data = {
+            "ordering": {
+                "delta": "bottom",
+                "obj_id": "doc1",
+                "subset_ids": ["doc1", "doc2", "doc3"],
+            }
+        }  # noqa
+        self.deserialize(body=json.dumps(data), context=self.folder)
+
+        # reordering should preserve bytestring ids in PY2 and unicode ids in PY3
+        for id_ in self.folder.objectIds():
+            self.assertIsInstance(id_, str)
+
     def test_reorder_subsetids(self):
         # sanity check, initial situation
         self.assertEqual(

--- a/src/plone/restapi/tests/test_upgrade_ordering.py
+++ b/src/plone/restapi/tests/test_upgrade_ordering.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
+from plone.restapi.upgrades.ordering import ensure_child_ordering_object_ids_are_native_strings
+
+import unittest
+import six
+
+
+class TestUpgradeOrdering(unittest.TestCase):
+
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+
+        self.folder = self.portal[
+            self.portal.invokeFactory("Folder", id="folder1", title="Folder")
+        ]
+        for x in range(1, 4):
+            self.folder.invokeFactory(
+                "Document", id="doc" + str(x), title="Test doc " + str(x)
+            )
+
+    def test_upgrade_ensure_child_ordering_object_ids_are_native_strings(self):
+        ordering = self.folder.getOrdering()
+
+        # use incorrect type for ordering, results in mixed type ordering ids
+        # on folder
+        ordering.moveObjectsToBottom([six.text_type('doc1')])
+
+        ensure_child_ordering_object_ids_are_native_strings(self.folder)
+
+        self.assertEqual(
+            [
+                "doc2",
+                "doc3",
+                "doc1",
+            ],  # noqa
+            self.folder.objectIds(),
+        )
+
+        # upgrade helper should ensure bytestring ids in python2 and do nothing
+        # on python3
+        for id_ in self.folder.objectIds():
+            self.assertIsInstance(id_, str)
+
+    def test_upgrade_can_be_called_with_nonetype(self):
+        ensure_child_ordering_object_ids_are_native_strings(None)
+
+    def test_upgrade_can_be_called_with_not_annotatable(self):
+        ensure_child_ordering_object_ids_are_native_strings(object())
+

--- a/src/plone/restapi/upgrades/configure.zcml
+++ b/src/plone/restapi/upgrades/configure.zcml
@@ -1,7 +1,16 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="plone.restapi">
+
+    <!-- Upgrade to fix ordering, call manually via this browser-view if necessary -->
+    <browser:page
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        name="plone-restapi-upgrade-fix-ordering"
+        class=".ordering.FixOrderingView"
+        permission="cmf.ManagePortal"
+        />
 
     <!-- 0001 -> 0002 -->
     <genericsetup:upgradeStep

--- a/src/plone/restapi/upgrades/ordering.py
+++ b/src/plone/restapi/upgrades/ordering.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from persistent.list import PersistentList
+from plone.folder.default import DefaultOrdering
+from zope.annotation.interfaces import IAnnotatable
+from zope.annotation.interfaces import IAnnotations
+
+import six
+
+
+ORDER_KEY = DefaultOrdering.ORDER_KEY
+
+
+def safe_utf8(to_utf8):
+    if isinstance(to_utf8, six.text_type):
+        to_utf8 = to_utf8.encode('utf-8')
+    return to_utf8
+
+
+def ensure_child_ordering_object_ids_are_native_strings(container):
+    """Make sure the ordering stored on parent contains only native_string
+    object ids.
+
+    This function can be used to fix ordering object ids stored on a parent
+    object in a `DefaultOrdering` ordering adapter. When changing object
+    ordering via PATCH request we used to incorrectly store ids of reordered
+    resouces as unicode instead of a bytestring (on python 2). This
+    lead to mixed types being stored in the ordering annotations and
+    subsequently mixed types being returned when calling `objectIds` of a
+    container.
+
+    The problem only exists with python 2 so we do nothing when we are
+    called on python 3 by mistake.
+    """
+    if six.PY3:
+        return
+
+    if not IAnnotatable.providedBy(container):
+        return
+
+    annotations = IAnnotations(container)
+    if ORDER_KEY not in annotations:
+        return
+
+    fixed_ordering = PersistentList(
+        safe_utf8(item_id) for item_id in annotations[ORDER_KEY])
+    annotations[ORDER_KEY] = fixed_ordering


### PR DESCRIPTION
This PR fixes an issue where ids of reordered content are converted to unicode on python 2. We now convert input ids when necessary and make sure the ordering stored on a container contains only bytestring object ids.

When changing object ordering via PATCH request we used to incorrectly store ids of reordered resources as unicode instead of a bytestring (on python2). This lead to mixed types being stored in the ordering annotations and subsequently mixed types being returned when calling `objectIds` of a container.

The problem only exists with python2 as python3 uses unicode internally.

Things we should probably discuss in this PR:
- Is the suggested upgrade-path feasible?
- The current suggestion pushes responsibility to upgrade ordering to the client, see suggestion in upgrade-guide.

Fixes #827.