### PR TITLE
Fix related item review state 376

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -2,17 +2,20 @@
     place names and roles of the people who contribute to this package
     in this file, one to a line, like so:
 
-- Timo Stollenwerk, Original Author
-- Thomas Buchberger
-- Lukas Graf
-- Víctor Fernández de Alba
-- Paul Roeland
-- Mikel Larreategi
-- Eric Brehault
+- Andrea Cecchi
 - Andreas Zeidler
 - Carsten Senger
-- Tom Gross
-- Roel Bruggink
-- Yann Fouillat, alias Gagaro
-- Sune Brøndum Wøller
+- Eric Brehault
+- Giacomo Monari
+- Luca Bellenghi
+- Lukas Graf
+- Mikel Larreategi
+- Paul Roeland
 - Philippe Gross
+- Roel Bruggink
+- Sune Brøndum Wøller
+- Thomas Buchberger
+- Timo Stollenwerk, Original Author
+- Tom Gross
+- Víctor Fernández de Alba
+- Yann Fouillat, alias Gagaro

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -2,20 +2,20 @@
     place names and roles of the people who contribute to this package
     in this file, one to a line, like so:
 
-- Andrea Cecchi
+- Timo Stollenwerk, Original Author
+- Thomas Buchberger
+- Lukas Graf
+- Víctor Fernández de Alba
+- Paul Roeland
+- Mikel Larreategi
+- Eric Brehault
 - Andreas Zeidler
 - Carsten Senger
-- Eric Brehault
-- Giacomo Monari
-- Luca Bellenghi
-- Lukas Graf
-- Mikel Larreategi
-- Paul Roeland
-- Philippe Gross
-- Roel Bruggink
-- Sune Brøndum Wøller
-- Thomas Buchberger
-- Timo Stollenwerk, Original Author
 - Tom Gross
-- Víctor Fernández de Alba
+- Roel Bruggink
 - Yann Fouillat, alias Gagaro
+- Sune Brøndum Wøller
+- Philippe Gross
+- Andrea Cecchi
+- Luca Bellenghi
+- Giacomo Monari

--- a/news/376.bugfix
+++ b/news/376.bugfix
@@ -1,0 +1,2 @@
+Fix WorkflowException for related items with no review_state.
+[arsenico13]

--- a/src/plone/restapi/serializer/summary.py
+++ b/src/plone/restapi/serializer/summary.py
@@ -64,6 +64,7 @@ class DefaultJSONSummarySerializer(object):
                 if callable(value):
                     value = value()
             except WorkflowException:
+                summary[field] = None
                 continue
             summary[field] = json_compatible(value)
         return summary

--- a/src/plone/restapi/serializer/summary.py
+++ b/src/plone/restapi/serializer/summary.py
@@ -3,6 +3,7 @@ from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from Products.CMFCore.utils import getToolByName
+from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import adapter
 from zope.interface import implementer
@@ -59,8 +60,11 @@ class DefaultJSONSummarySerializer(object):
                 continue
             accessor = FIELD_ACCESSORS.get(field, field)
             value = getattr(obj, accessor, None)
-            if callable(value):
-                value = value()
+            try:
+                if callable(value):
+                    value = value()
+            except WorkflowException:
+                continue
             summary[field] = json_compatible(value)
         return summary
 

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -64,6 +64,13 @@ except pkg_resources.DistributionNotFound:
 else:
     HAS_AT = True
 
+try:
+    pkg_resources.get_distribution("plone.dexterity")
+except pkg_resources.DistributionNotFound:
+    HAS_DX = False
+else:
+    HAS_DX = True
+
 ENABLED_LANGUAGES = ["de", "en", "es", "fr"]
 
 

--- a/src/plone/restapi/tests/test_content_get.py
+++ b/src/plone/restapi/tests/test_content_get.py
@@ -5,6 +5,7 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.app.textfield.value import RichTextValue
+from plone.namedfile.file import NamedBlobImage
 from plone.restapi.testing import HAS_AT
 from plone.restapi.testing import PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
@@ -13,6 +14,7 @@ from z3c.relationfield import RelationValue
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
+import os
 import requests
 import transaction
 import unittest
@@ -23,8 +25,6 @@ class TestContentGet(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
-        if not HAS_AT:
-            raise unittest.SkipTest("Skip tests if Archetypes is not present")
         self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
@@ -134,6 +134,44 @@ class TestContentGet(unittest.TestCase):
                     u"description": u"",
                     u"review_state": u"published",
                     u"title": u"My Document 2",
+                }
+            ],
+            response.json()["relatedItems"],
+        )
+
+    def test_get_content_related_items_without_workflow(self):
+        intids = getUtility(IIntIds)
+
+        self.portal.invokeFactory("Image", id="imagewf")
+        self.portal.imagewf.title = "Image without workflow"
+        self.portal.imagewf.description = u"This is an image"
+        image_file = os.path.join(os.path.dirname(__file__), u"image.png")
+        with open(image_file, "rb") as f:
+            image_data = f.read()
+        self.portal.imagewf.image = NamedBlobImage(
+            data=image_data, contentType="image/png", filename=u"image.png"
+        )
+        transaction.commit()
+
+        self.portal.folder1.doc1.relatedItems = [
+            RelationValue(intids.getId(self.portal.imagewf))
+        ]
+        transaction.commit()
+        response = requests.get(
+            self.portal.folder1.doc1.absolute_url(),
+            headers={"Accept": "application/json"},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(1, len(response.json()["relatedItems"]))
+        self.assertEqual(
+            [
+                {
+                    u"@id": self.portal_url + u"/imagewf",
+                    u"@type": u"Image",
+                    u"description": u"This is an image",
+                    u"review_state": None,
+                    u"title": u"Image without workflow",
                 }
             ],
             response.json()["relatedItems"],

--- a/src/plone/restapi/tests/test_content_get.py
+++ b/src/plone/restapi/tests/test_content_get.py
@@ -7,6 +7,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.textfield.value import RichTextValue
 from plone.namedfile.file import NamedBlobImage
 from plone.restapi.testing import HAS_AT
+from plone.restapi.testing import HAS_DX
 from plone.restapi.testing import PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from Products.CMFCore.utils import getToolByName
@@ -25,6 +26,8 @@ class TestContentGet(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
+        if not HAS_DX:
+            raise unittest.SkipTest("Skip tests if Dexterity is not present")
         self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()


### PR DESCRIPTION
Fix the WorkflowException when requesting a fullobject with a related item that doesn't have a workflow (see issue #376).

I added one test about this topic. When tryint to run all `TestContentGet` I saw that all of them were skipped. I had to remove the check at the top of the test class:
```
if not HAS_AT:
    raise unittest.SkipTest("Skip tests if Archetypes is not present")
```

because this is a DX test.

For compatibilty reasons, do we need to add a HAS_DX check here?
