### PR TITLE
Fix Plone 4.3.x build

### DIFF
--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -11,3 +11,7 @@ zope.interface = 4.1.0
 # Pillow = 5.4.1
 future = 0.17.1
 six = 1.11.0
+
+# Required for Python 2.7 compatibility
+more-itertools = <6.0.0
+zipp = >=0.5, <2a


### PR DESCRIPTION
This adds version constraints to `plone-4.3.x.cfg` needed for Python 2.7 compatibility.

Fixes build failures like these:
https://travis-ci.org/plone/plone.restapi/jobs/640324488