### PR TITLE
Use longer password in tests.

### DIFF
--- a/news/3044.bugfix
+++ b/news/3044.bugfix
@@ -1,0 +1,1 @@
+Use longer password in tests.  [maurits]

--- a/src/plone/restapi/tests/test_services_comments.py
+++ b/src/plone/restapi/tests/test_services_comments.py
@@ -39,7 +39,7 @@ class TestCommentsEndpoint(unittest.TestCase):
         )
         api.content.transition(self.doc, "publish")
 
-        api.user.create(username="jos", password="jos", email="jos@plone.org")
+        api.user.create(username="jos", password="josjos", email="jos@plone.org")
 
         # Admin session
         self.api_session = RelativeSession(self.portal_url)


### PR DESCRIPTION
This is needed because the password strength is tested in more places with PloneHotfix20200121.
The tests of https://github.com/plone/Products.CMFPlone/pull/3044 currently fail because of this.

See [Jenkins job failure](https://jenkins.plone.org/job/pull-request-5.2/993/):

    ValueError: Your password must contain at least 5 characters.

(We can test and merge this, and later rerun the CMFPlone PR jobs. I checked locally that they pass then.)