### PR TITLE
Use longer password in another test.

### DIFF
--- a/src/plone/restapi/tests/test_services_types.py
+++ b/src/plone/restapi/tests/test_services_types.py
@@ -108,7 +108,7 @@ class TestServicesTypes(unittest.TestCase):
 
     def test_addable_types_for_non_manager_user(self):
         user = api.user.create(
-            email="noam.chomsky@example.com", username="noam", password="1234"
+            email="noam.chomsky@example.com", username="noam", password="12345"
         )
 
         folder = api.content.create(
@@ -128,7 +128,7 @@ class TestServicesTypes(unittest.TestCase):
 
         transaction.commit()
 
-        self.api_session.auth = ("noam", "1234")
+        self.api_session.auth = ("noam", "12345")
         # In the folder, the user should be able to add types since we granted
         # Contributor role on it
         response = self.api_session.get("/folder/@types")


### PR DESCRIPTION
This is a followup for the merged #873. I overlooked this failure at first.
See [Jenkins job](https://jenkins.plone.org/job/pull-request-5.2-3.7/946/testReport/junit/plone.restapi.tests.test_services_types/TestServicesTypes/test_addable_types_for_non_manager_user/).