### PR TITLE
Add a catalog serializer guard when returning fullobjects in case the…

### DIFF
--- a/news/877.bugfix
+++ b/news/877.bugfix
@@ -1,0 +1,3 @@
+Add a catalog serializer guard when returning fullobjects in case the object doesn't
+exist anymore because for some reason it failed to uncatalog itself.
+[sneridagh]


### PR DESCRIPTION
… object doesn't exist anymore because for some reason it failed to uncatalog itself.