### PR TITLE
Fix for the use case while updating user properties in the @user endp…

### DIFF
--- a/news/896.bugfix
+++ b/news/896.bugfix
@@ -1,0 +1,4 @@
+Fix for the use case while updating user properties in the @user endpoint, and the
+portrait is already previously set but the request includes the (previously) serialized
+value as a string because the user are not updating it
+[sneridagh]

--- a/src/plone/restapi/services/users/update.py
+++ b/src/plone/restapi/services/users/update.py
@@ -72,8 +72,10 @@ class UsersPatch(Service):
                 elif key == "username":
                     set_own_login_name(user, value)
                 else:
-
-                    if key == 'portrait':
+                    # If the portrait is already set but has not been changed change it,
+                    # then the serialized value comes again in the request as a string,
+                    # no data on it, then we should not set it since it will fail
+                    if key == "portrait" and isinstance(value, dict):
                         self.set_member_portrait(user, value)
                     user.setMemberProperties(mapping={key: value})
 
@@ -101,7 +103,10 @@ class UsersPatch(Service):
                 ):
                     self._change_user_password(user, value)
                 else:
-                    if key == "portrait":
+                    # If the portrait is already set but has not been changed change it,
+                    # then the serialized value comes again in the request as a string,
+                    # no data on it, then we should not set it since it will fail
+                    if key == "portrait" and isinstance(value, dict):
                         self.set_member_portrait(user, value)
                     user.setMemberProperties(mapping={key: value})
 

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -523,6 +523,38 @@ class TestUsersEndpoint(unittest.TestCase):
 
         self.assertTrue(user.get("portrait") is None)
 
+    def test_update_user_with_portrait_set_without_updating_portrait(self):
+        payload = {
+            "portrait": {
+                "filename": "image.gif",
+                "encoding": "base64",
+                "data": u"R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=",
+                "content-type": "image/gif",
+            }
+        }
+        self.api_session.auth = ("noam", "password")
+        response = self.api_session.patch("/@users/noam", json=payload)
+
+        self.assertEqual(response.status_code, 204)
+        transaction.commit()
+
+        payload = {
+            "fullname": "Noam A. Chomsky",
+            "username": "noam",
+            "email": "avram.chomsky@plone.org",
+            "portrait": "http://localhost:55001/plone/portal_memberdata/portraits/noam",
+        }
+        self.api_session.auth = ("noam", "password")
+        response = self.api_session.patch("/@users/noam", json=payload)
+
+        self.assertEqual(response.status_code, 204)
+        transaction.commit()
+
+        user = self.api_session.get("/@users/noam").json()
+        self.assertTrue(
+            user.get("portrait").endswith("plone/portal_memberdata/portraits/noam")
+        )
+
     def test_anonymous_user_can_not_update_existing_user(self):
         payload = {
             "fullname": "Noam A. Chomsky",


### PR DESCRIPTION
…oint, and the portrait is already previously set but the request includes the (previously) serialized value as a string because the user are not updating it