### PR TITLE
Plone 5.2 new clone points to egg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 
 .. towncrier release notes start
 
+- Fix buildout configuration
+  [rodfersou]
+
 6.5.2 (2020-04-01)
 ------------------
 

--- a/base.cfg
+++ b/base.cfg
@@ -202,6 +202,3 @@ eggs = ${instance:eggs}
 [sources]
 plone.rest = git git://github.com/plone/plone.rest.git pushurl=git@github.com:plone/plone.rest.git branch=master
 plone.schema = git git://github.com/plone/plone.schema.git pushurl=git@github.com:plone/plone.schema.git branch=newjsonschemafield
-
-[versions]
-plone.restapi =

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -3,4 +3,6 @@ extends =
     base.cfg
     http://dist.plone.org/release/5.2.1/versions.cfg
 find-links += http://dist.plone.org/thirdparty/
-versions=versions
+
+[versions]
+plone.restapi =

--- a/versions.cfg
+++ b/versions.cfg
@@ -3,6 +3,7 @@
 setuptools =
 zc.buildout =
 zc.recipe.egg = 2.0.3
+plone.restapi =
 
 # plone.recipe.varnish
 plone.recipe.varnish = 1.3


### PR DESCRIPTION
For new clone of package and Plone 5.2 it is using p.restapi egg in tests