### PR TITLE
Fix test for IBlocks behavior

### DIFF
--- a/news/914.bugfix
+++ b/news/914.bugfix
@@ -1,0 +1,2 @@
+Small fix in IBlocks test, addedd a missing assert call
+[tiberiuichim]

--- a/src/plone/restapi/tests/test_behaviors.py
+++ b/src/plone/restapi/tests/test_behaviors.py
@@ -6,7 +6,6 @@ from plone.app.testing import TEST_USER_NAME
 from plone.dexterity.fti import DexterityFTI
 from plone.restapi.behaviors import IBlocks
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
-from zope.interface import alsoProvides
 
 import unittest
 
@@ -24,8 +23,6 @@ class TestBlocksBehavior(unittest.TestCase):
         self.portal.portal_types._setObject("blocksfolder", fti)
         fti.klass = "plone.dexterity.content.Container"
         fti.behaviors = ("volto.blocks",)
-        self.fti = fti
-        alsoProvides(self.request, IBlocks)
 
     def test_basic_fields(self):
         self.portal.invokeFactory(
@@ -47,4 +44,4 @@ class TestBlocksBehavior(unittest.TestCase):
             "blocksfolder", id="blocksfolder", title=u"Folder with blocks"
         )
 
-        IBlocks.providedBy(self.portal["blocksfolder"])
+        assert IBlocks.providedBy(self.portal["blocksfolder"])


### PR DESCRIPTION
Small fix in IBlocks test, added an assert call that was missing.