### PR TITLE
Make the querystring-search endpoint context aware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-version = 3.7
+version = 3
 
 # We like colors
 # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects

--- a/news/911.feature
+++ b/news/911.feature
@@ -1,0 +1,2 @@
+- Make ``@querystring-search`` endpoint context aware
+[sneridagh]

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -8,3 +8,8 @@ find-links += http://dist.plone.org/thirdparty/
 plone.restapi =
 astunparse = 1.6.2
 coverage = 5.1
+
+# Add support for not queries in the UUIDIndex
+# This is needed to exclude self from the context-aware
+# querystring-search which is used by the Volto Listing Block
+Products.ZCatalog = 5.1

--- a/src/plone/restapi/services/querystringsearch/configure.zcml
+++ b/src/plone/restapi/services/querystringsearch/configure.zcml
@@ -10,4 +10,11 @@
     permission="zope2.View"
     />
 
+  <plone:service
+    method="POST"
+    for="Products.CMFCore.interfaces.IContentish"
+    factory=".get.QuerystringSearchPost"
+    name="@querystring-search"
+    permission="zope2.View"
+    />
 </configure>

--- a/src/plone/restapi/services/querystringsearch/get.py
+++ b/src/plone/restapi/services/querystringsearch/get.py
@@ -1,9 +1,17 @@
 # -*- coding: utf-8 -*-
+from pkg_resources import get_distribution
+from pkg_resources import parse_version
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import getMultiAdapter
+
+zcatalog_version = get_distribution("Products.ZCatalog").version
+if parse_version(zcatalog_version) >= parse_version("5.1"):
+    SUPPORT_NOT_UUID_QUERIES = True
+else:
+    SUPPORT_NOT_UUID_QUERIES = False
 
 
 class QuerystringSearchPost(Service):
@@ -40,7 +48,7 @@ class QuerystringSearchPost(Service):
             limit=limit,
         )
 
-        if not (IPloneSiteRoot.providedBy(self.context)):
+        if SUPPORT_NOT_UUID_QUERIES and not (IPloneSiteRoot.providedBy(self.context)):
             querybuilder_parameters.update(
                 dict(custom_query={"UID": {"not": self.context.UID()}})
             )

--- a/src/plone/restapi/services/querystringsearch/get.py
+++ b/src/plone/restapi/services/querystringsearch/get.py
@@ -48,7 +48,9 @@ class QuerystringSearchPost(Service):
             limit=limit,
         )
 
-        if SUPPORT_NOT_UUID_QUERIES and not (IPloneSiteRoot.providedBy(self.context)):
+        # Exclude "self" content item from the results when ZCatalog supports NOT UUID
+        # queries and it is called on a content object.
+        if not IPloneSiteRoot.providedBy(self.context) and SUPPORT_NOT_UUID_QUERIES:
             querybuilder_parameters.update(
                 dict(custom_query={"UID": {"not": self.context.UID()}})
             )

--- a/src/plone/restapi/tests/test_services_querystringsearch.py
+++ b/src/plone/restapi/tests/test_services_querystringsearch.py
@@ -129,3 +129,29 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
         self.assertEqual(len(response.json()["items"]), 5)
         self.assertNotIn("effective", response.json()["items"][0])
         self.assertEqual(response.json()["items"][4]["title"], u"Test Document 9")
+
+    def test_querystringsearch_do_not_return_context(self):
+        self.portal.invokeFactory("Document", "testdocument2", title="Test Document 2")
+        self.doc = self.portal.testdocument
+
+        transaction.commit()
+
+        response = self.api_session.post(
+            "/testdocument/@querystring-search",
+            json={
+                "query": [
+                    {
+                        "i": "portal_type",
+                        "o": "plone.app.querystring.operation.selection.is",
+                        "v": ["Document"],
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["items_total"], 1)
+        self.assertEqual(
+            response.json()["items"][0]["@id"],
+            "http://localhost:55001/plone/testdocument2",
+        )

--- a/src/plone/restapi/tests/test_services_querystringsearch.py
+++ b/src/plone/restapi/tests/test_services_querystringsearch.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from pkg_resources import get_distribution
+from pkg_resources import parse_version
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -8,6 +10,12 @@ from plone.restapi.testing import RelativeSession
 
 import transaction
 import unittest
+
+zcatalog_version = get_distribution("Products.ZCatalog").version
+if parse_version(zcatalog_version) >= parse_version("5.1"):
+    SUPPORT_NOT_UUID_QUERIES = True
+else:
+    SUPPORT_NOT_UUID_QUERIES = False
 
 
 class TestQuerystringSearchEndpoint(unittest.TestCase):
@@ -130,6 +138,10 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
         self.assertNotIn("effective", response.json()["items"][0])
         self.assertEqual(response.json()["items"][4]["title"], u"Test Document 9")
 
+    @unittest.skipIf(
+        not SUPPORT_NOT_UUID_QUERIES,
+        "Skipping because ZCatalog allows not queries on UUIDIndex from >=5.1",
+    )
     def test_querystringsearch_do_not_return_context(self):
         self.portal.invokeFactory("Document", "testdocument2", title="Test Document 2")
         self.doc = self.portal.testdocument


### PR DESCRIPTION
The tests will fail until https://github.com/zopefoundation/Products.ZCatalog/pull/99 is merged and released.