### PR TITLE
Layout based serialization, include default_page in serialization

### DIFF
--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -2,7 +2,6 @@
 from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from Products.CMFPlone.utils import base_hasattr
 from plone.autoform.interfaces import READ_PERMISSIONS_KEY
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
@@ -19,6 +18,7 @@ from plone.restapi.serializer.nextprev import NextPrevious
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.supermodel.utils import mergedTaggedValueDict
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import base_hasattr
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
@@ -80,7 +80,8 @@ class SerializeToJson(object):
         # Insert field values
         primary_field_name = self.get_primary_field_name()
         for schema in iterSchemata(self.context):
-            read_permissions = mergedTaggedValueDict(schema, READ_PERMISSIONS_KEY)
+            read_permissions = mergedTaggedValueDict(
+                schema, READ_PERMISSIONS_KEY)
 
             for name, field in getFields(schema).items():
 
@@ -112,7 +113,8 @@ class SerializeToJson(object):
 
     def _get_workflow_state(self, obj):
         wftool = getToolByName(self.context, "portal_workflow")
-        review_state = wftool.getInfoFor(ob=obj, name="review_state", default=None)
+        review_state = wftool.getInfoFor(
+            ob=obj, name="review_state", default=None)
         return review_state
 
     def get_primary_field_name(self):
@@ -158,7 +160,8 @@ class SerializeFolderToJson(SerializeToJson):
         return query
 
     def __call__(self, version=None, include_items=True):
-        folder_metadata = super(SerializeFolderToJson, self).__call__(version=version)
+        folder_metadata = super(SerializeFolderToJson,
+                                self).__call__(version=version)
 
         folder_metadata.update({"is_folderish": True})
         result = folder_metadata
@@ -185,7 +188,15 @@ class SerializeFolderToJson(SerializeToJson):
                 )(fullobjects=True)["items"]
             else:
                 result["items"] = [
-                    getMultiAdapter((brain, self.request), ISerializeToJsonSummary)()
+                    getMultiAdapter((brain, self.request),
+                                    ISerializeToJsonSummary)()
                     for brain in batch
                 ]
+
+        page = self.context.getDefaultPage()
+        if page:
+            child = self.context._getOb(page)
+            result['default_page'] = getMultiAdapter(
+                (child, self.request), ISerializeToJson)()
+
         return result

--- a/src/plone/restapi/services/content/get.py
+++ b/src/plone/restapi/services/content/get.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
+from Products.CMFDynamicViewFTI.interfaces import ISelectableBrowserDefault
 from zope.component import queryMultiAdapter
 
 
@@ -9,7 +10,18 @@ class ContentGet(Service):
     """
 
     def reply(self):
-        serializer = queryMultiAdapter((self.context, self.request), ISerializeToJson)
+
+        serializer = None
+        if ISelectableBrowserDefault.providedBy(self.context):
+            if not self.context.getDefaultPage():
+                layout = self.context.getLayout()
+                serializer = queryMultiAdapter(
+                    (self.context, self.request), ISerializeToJson,
+                    name=layout)
+
+        if serializer is None:
+            serializer = queryMultiAdapter(
+                (self.context, self.request), ISerializeToJson)
 
         if serializer is None:
             self.request.response.setStatus(501)

--- a/src/plone/restapi/tests/test_services.py
+++ b/src/plone/restapi/tests/test_services.py
@@ -39,7 +39,8 @@ class TestTraversal(unittest.TestCase):
     def test_get_document(self):
         self.portal.invokeFactory("Document", id="doc1", title="My Document")
         self.portal.doc1.description = u"This is a document"
-        self.portal.doc1.text = RichTextValue(u"Lorem ipsum", "text/plain", "text/html")
+        self.portal.doc1.text = RichTextValue(
+            u"Lorem ipsum", "text/plain", "text/html")
         transaction.commit()
 
         response = self.api_session.get(self.portal.doc1.absolute_url())
@@ -67,7 +68,8 @@ class TestTraversal(unittest.TestCase):
             ),
         )
         self.assertEqual("My Document", response.json().get("title"))
-        self.assertEqual("This is a document", response.json().get("description"))
+        self.assertEqual("This is a document",
+                         response.json().get("description"))
         self.assertEqual(
             {
                 u"data": u"<p>Lorem ipsum</p>",
@@ -137,7 +139,8 @@ class TestTraversal(unittest.TestCase):
                 response.json().get("@type")
             ),
         )
-        self.assertEqual(self.portal.folder1.absolute_url(), response.json().get("@id"))
+        self.assertEqual(self.portal.folder1.absolute_url(),
+                         response.json().get("@id"))
         self.assertEqual("My Folder", response.json().get("title"))
 
     def test_get_site_root(self):
@@ -193,7 +196,8 @@ class TestTraversal(unittest.TestCase):
             "When sending a GET request with Content-Type: application/json "
             + "the server should respond with sending back application/json.",
         )
-        self.assertEqual(response.json()["@id"], self.portal.file1.absolute_url())
+        self.assertEqual(response.json()["@id"],
+                         self.portal.file1.absolute_url())
 
     @unittest.skip("Not implemented yet.")
     def test_get_image(self):  # pragma: no cover
@@ -216,4 +220,5 @@ class TestTraversal(unittest.TestCase):
             "When sending a GET request with Content-Type: application/json "
             + "the server should respond with sending back application/json.",
         )
-        self.assertEqual(response.json()["@id"], self.portal.img1.absolute_url())
+        self.assertEqual(response.json()["@id"],
+                         self.portal.img1.absolute_url())


### PR DESCRIPTION
This PR makes it possible to use a different content serializer, based on the ``layout`` property of context.

It also serializes fully serializes the linked ``default_page`` content, where it exists. 