### PR TITLE
- Take the `include_items` parameter into account in `SerializeCollectionToJson`, see #957

### DIFF
--- a/news/957.bugfix
+++ b/news/957.bugfix
@@ -1,0 +1,1 @@
+- Take the `include_items` parameter into account in `SerializeCollectionToJson`. [gbastien]

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -15,9 +15,7 @@ from zope.interface import Interface
 @adapter(ICollection, Interface)
 class SerializeCollectionToJson(SerializeToJson):
     def __call__(self, version=None, include_items=True):
-        result = super(SerializeCollectionToJson, self).__call__(
-            version=version
-        )
+        result = super(SerializeCollectionToJson, self).__call__(version=version)
 
         include_items = self.request.form.get("include_items", include_items)
         include_items = boolean_value(include_items)
@@ -33,7 +31,9 @@ class SerializeCollectionToJson(SerializeToJson):
 
             if "fullobjects" in list(self.request.form):
                 result["items"] = [
-                    getMultiAdapter((brain.getObject(), self.request), ISerializeToJson)()
+                    getMultiAdapter(
+                        (brain.getObject(), self.request), ISerializeToJson
+                    )()
                     for brain in batch
                 ]
             else:

--- a/src/plone/restapi/serializer/collection.py
+++ b/src/plone/restapi/serializer/collection.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.interfaces import ICollection
 from plone.restapi.batching import HypermediaBatch
+from plone.restapi.deserializer import boolean_value
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
-from plone.restapi.deserializer import boolean_value
 from plone.restapi.serializer.dxcontent import SerializeToJson
 from zope.component import adapter
 from zope.component import getMultiAdapter

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -380,12 +380,12 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
             u"Collection", self.serialize(self.portal.collection1).get("@type")
         )
 
-        self.request.form['include_items'] = False
+        self.request.form["include_items"] = False
         without_items = self.serialize(self.portal.collection1)
         self.assertFalse("items" in without_items)
         self.assertFalse("items_total" in without_items)
 
-        self.request.form['include_items'] = True
+        self.request.form["include_items"] = True
         serialized = self.serialize(self.portal.collection1)
         items = serialized.get("items")
         self.assertEqual(items[0]["title"], self.portal.doc1.Title())

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -358,6 +358,40 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
         self.assertIn("UID", items[1])
         self.assertEqual(items[1]["id"], self.portal.doc2.getId())
 
+    def test_serialize_to_json_collection_include_items(self):
+        self.portal.invokeFactory("Collection", id="collection1")
+        self.portal.collection1.title = "My Collection"
+        self.portal.collection1.description = u"This is a collection with two documents"
+        self.portal.collection1.query = [
+            {
+                "i": "portal_type",
+                "o": "plone.app.querystring.operation.string.is",
+                "v": "Document",
+            }
+        ]
+        self.portal.invokeFactory("Document", id="doc2", title="Document 2")
+        self.portal.doc1.reindexObject()
+        self.portal.doc2.reindexObject()
+
+        self.assertEqual(
+            u"Collection", self.serialize(self.portal.collection1).get("@type")
+        )
+        self.assertEqual(
+            u"Collection", self.serialize(self.portal.collection1).get("@type")
+        )
+
+        self.request.form['include_items'] = False
+        without_items = self.serialize(self.portal.collection1)
+        self.assertFalse("items" in without_items)
+        self.assertFalse("items_total" in without_items)
+
+        self.request.form['include_items'] = True
+        serialized = self.serialize(self.portal.collection1)
+        items = serialized.get("items")
+        self.assertEqual(items[0]["title"], self.portal.doc1.Title())
+        self.assertEqual(items[1]["title"], self.portal.doc2.Title())
+        self.assertEqual(serialized.get("items_total"), 2)
+
     def test_serialize_returns_site_root_common(self):
         self.assertIn("title", self.serialize(self.portal))
         self.assertIn("description", self.serialize(self.portal))


### PR DESCRIPTION
Hi,

this is a fix for #957, it takes include_items parameter into account in SerializeCollectionToJson.

Please review and merge if ok!

Thank you,

Gauthier