### PR TITLE
Include plone.app.controlpanel permissions.zcml in database service

### DIFF
--- a/news/956.bugfix
+++ b/news/956.bugfix
@@ -1,0 +1,1 @@
+- Include plone.app.controlpanel permissions.zcml in database service to avoid ConfigurationExecutionError regarding 'plone.app.controlpanel.Overview' permission while starting Plone 4.3.x [gbastien]

--- a/src/plone/restapi/services/database/configure.zcml
+++ b/src/plone/restapi/services/database/configure.zcml
@@ -1,6 +1,17 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:plone="http://namespaces.plone.org/plone">
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+  <include
+    zcml:condition="not-installed plone.app.controlpanel"
+    package="Products.CMFPlone.controlpanel"
+    file="permissions.zcml" />
+
+  <include
+    zcml:condition="installed plone.app.controlpanel"
+    package="plone.app.controlpanel"
+    file="permissions.zcml" />
 
   <plone:service
     method="GET"


### PR DESCRIPTION
to avoid ConfigurationExecutionError regarding 'plone.app.controlpanel.Overview' permission while starting Plone 4.3.x, see #956

I added the same fix explained in #526 in configure.zcml of services/database

I think yhis could be done in the services/configure.zcml where we already include CMFCore permissions because service "system" that also use the permission would have the same problem if permission was not loaded in database configure.zcml

So if you think it is better to move it to the parent's configure.zcml, I may change it.

Thank you for review and merge!

Gauthier
