### PR TITLE
Removed useless management of metadata_fields in SearchHandler/LazyCatalogResultSerializer

### DIFF
--- a/news/970.bugfix
+++ b/news/970.bugfix
@@ -1,0 +1,1 @@
+Removed useless management of metadata_fields in SearchHandler/LazyCatalogResultSerializer since it is handled in DefaultJSONSummarySerializer. [gbastien]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 
 import sys
+
 version = "7.0.0a5.dev0"
 
 

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -74,16 +74,12 @@ class SearchHandler(object):
         else:
             fullobjects = False
 
-        metadata_fields = query.pop("metadata_fields", [])
-        if not isinstance(metadata_fields, list):
-            metadata_fields = [metadata_fields]
-
         self._constrain_query_by_path(query)
         query = self._parse_query(query)
 
         lazy_resultset = self.catalog.searchResults(query)
         results = getMultiAdapter((lazy_resultset, self.request), ISerializeToJson)(
-            metadata_fields=metadata_fields, fullobjects=fullobjects
+            fullobjects=fullobjects
         )
 
         return results

--- a/src/plone/restapi/serializer/catalog.py
+++ b/src/plone/restapi/serializer/catalog.py
@@ -28,7 +28,7 @@ class LazyCatalogResultSerializer(object):
         self.lazy_resultset = lazy_resultset
         self.request = request
 
-    def __call__(self, metadata_fields=(), fullobjects=False):
+    def __call__(self, fullobjects=False):
         batch = HypermediaBatch(self.request, self.lazy_resultset)
 
         results = {}


### PR DESCRIPTION
... since it is handled in DefaultJSONSummarySerializer, see #970

Removing it from search still let tests pass as it was not used, computed in search then computed again in DefaultJSONSummarySerializer...

This cleaning is necessary to avoid using it in search using the parameter as it is not taken into account and done after from request.form

Please review, comment, merge, ... ;-)

Thank you!

Gauthier