### PR TITLE
Fixed deprecation warnings for zope.site.hooks and ILanguageSchema.

### DIFF
--- a/news/975.bugfix
+++ b/news/975.bugfix
@@ -1,2 +1,3 @@
-Fixed deprecation warnings for ``zope.site.hooks`` and ``CMFPlone.interfaces.ILanguageSchema``.
+Fixed deprecation warnings for ``zope.site.hooks``, ``CMFPlone.interfaces.ILanguageSchema``
+and ``plone.dexterity.utils.splitSchemaName``.
 [maurits]

--- a/news/975.bugfix
+++ b/news/975.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warnings for ``zope.site.hooks`` and ``CMFPlone.interfaces.ILanguageSchema``.
+[maurits]

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -99,7 +99,12 @@ def enable_request_language_negotiation(portal):
     pieces of content in different languages.
     """
     if PLONE_5:
-        from Products.CMFPlone.interfaces import ILanguageSchema
+        try:
+            # Plone 5.2+
+            from plone.i18n.interfaces import ILanguageSchema
+        except ImportError:  # pragma: no cover
+            # Plone 5.0/5.1
+            from Products.CMFPlone.interfaces import ILanguageSchema
 
         registry = getUtility(IRegistry)
         settings = registry.forInterface(ILanguageSchema, prefix="plone")

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -33,7 +33,7 @@ from six.moves import range
 from zope.component import createObject
 from zope.component import getUtility
 from zope.interface import alsoProvides
-from zope.site.hooks import getSite
+from zope.component.hooks import getSite
 
 import collections
 import json

--- a/src/plone/restapi/tests/test_serializer_summary.py
+++ b/src/plone/restapi/tests/test_serializer_summary.py
@@ -13,7 +13,7 @@ from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from plone.restapi.testing import register_static_uuid_utility
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
-from zope.site.hooks import getSite
+from zope.component.hooks import getSite
 
 import Missing
 import unittest

--- a/src/plone/restapi/types/utils.py
+++ b/src/plone/restapi/types/utils.py
@@ -22,7 +22,6 @@ from plone.behavior.interfaces import IBehavior
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.utils import getAdditionalSchemata
-from plone.dexterity.utils import splitSchemaName
 from plone.i18n.normalizer import idnormalizer
 from plone.restapi.interfaces import IFieldDeserializer
 from plone.restapi.serializer.converters import IJsonCompatible
@@ -42,6 +41,14 @@ from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
+
+try:
+    # Plone 5.1+
+    from plone.dexterity.schema import splitSchemaName
+except ImportError:
+    # Plone 4.3
+    from plone.dexterity.utils import splitSchemaName
+
 
 _marker = []  # Create a new marker object.
 


### PR DESCRIPTION
Note: zope.component.hooks already works in Plone 4.3.
Part of https://github.com/plone/plone.restapi/issues/975