### PR TITLE
Fix tests with Products.MailHost 4.10.

### DIFF
--- a/news/3178.bugfix
+++ b/news/3178.bugfix
@@ -1,0 +1,2 @@
+Fix tests with Products.MailHost 4.10.
+[maurits]

--- a/src/plone/restapi/tests/test_services_email_notification.py
+++ b/src/plone/restapi/tests/test_services_email_notification.py
@@ -69,10 +69,14 @@ class EmailNotificationEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 204)
-        self.assertTrue("Subject: [No Subject]" in self.mailhost.messages[0])
-        self.assertTrue("To: info@plone.org" in self.mailhost.messages[0])
-        self.assertTrue("Reply-To: john@doe.com" in self.mailhost.messages[0])
-        self.assertTrue("Just want to say hi." in self.mailhost.messages[0])
+        msg = self.mailhost.messages[0]
+        if isinstance(msg, bytes) and bytes is not str:
+            # Python 3 with Products.MailHost 4.10+
+            msg = msg.decode("utf-8")
+        self.assertTrue("Subject: [No Subject]" in msg)
+        self.assertTrue("To: info@plone.org" in msg)
+        self.assertTrue("Reply-To: john@doe.com" in msg)
+        self.assertTrue("Just want to say hi." in msg)
 
     def test_email_notification_all_parameters(self):
         response = self.api_session.post(
@@ -87,8 +91,12 @@ class EmailNotificationEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 204)
-        self.assertTrue("=?utf-8?q?This_is_the_subject" in self.mailhost.messages[0])
-        self.assertTrue("To: info@plone.org" in self.mailhost.messages[0])
-        self.assertTrue("John Doe" in self.mailhost.messages[0])
-        self.assertTrue("Reply-To: john@doe.com" in self.mailhost.messages[0])
-        self.assertTrue("Just want to say hi." in self.mailhost.messages[0])
+        msg = self.mailhost.messages[0]
+        if isinstance(msg, bytes) and bytes is not str:
+            # Python 3 with Products.MailHost 4.10+
+            msg = msg.decode("utf-8")
+        self.assertTrue("=?utf-8?q?This_is_the_subject" in msg)
+        self.assertTrue("To: info@plone.org" in msg)
+        self.assertTrue("John Doe" in msg)
+        self.assertTrue("Reply-To: john@doe.com" in msg)
+        self.assertTrue("Just want to say hi." in msg)

--- a/src/plone/restapi/tests/test_services_email_send.py
+++ b/src/plone/restapi/tests/test_services_email_send.py
@@ -62,13 +62,14 @@ class EmailSendEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 204)
-        self.assertTrue(
-            "Subject: =?utf-8?q?A_portal_user_via_Plone_site?="
-            in self.mailhost.messages[0]
-        )
-        self.assertTrue("From: info@plone.org" in self.mailhost.messages[0])
-        self.assertTrue("Reply-To: john@doe.com" in self.mailhost.messages[0])
-        self.assertTrue("Just want to say hi." in self.mailhost.messages[0])
+        msg = self.mailhost.messages[0]
+        if isinstance(msg, bytes) and bytes is not str:
+            # Python 3 with Products.MailHost 4.10+
+            msg = msg.decode("utf-8")
+        self.assertTrue("Subject: =?utf-8?q?A_portal_user_via_Plone_site?=" in msg)
+        self.assertTrue("From: info@plone.org" in msg)
+        self.assertTrue("Reply-To: john@doe.com" in msg)
+        self.assertTrue("Just want to say hi." in msg)
 
     def test_email_send_all_parameters(self):
         response = self.api_session.post(
@@ -84,11 +85,15 @@ class EmailSendEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 204)
-        self.assertTrue("=?utf-8?q?This_is_the_subject" in self.mailhost.messages[0])
-        self.assertTrue("From: info@plone.org" in self.mailhost.messages[0])
-        self.assertTrue("John Doe" in self.mailhost.messages[0])
-        self.assertTrue("Reply-To: john@doe.com" in self.mailhost.messages[0])
-        self.assertTrue("Just want to say hi." in self.mailhost.messages[0])
+        msg = self.mailhost.messages[0]
+        if isinstance(msg, bytes) and bytes is not str:
+            # Python 3 with Products.MailHost 4.10+
+            msg = msg.decode("utf-8")
+        self.assertTrue("=?utf-8?q?This_is_the_subject" in msg)
+        self.assertTrue("From: info@plone.org" in msg)
+        self.assertTrue("John Doe" in msg)
+        self.assertTrue("Reply-To: john@doe.com" in msg)
+        self.assertTrue("Just want to say hi." in msg)
 
     def test_email_send_anonymous(self):
         response = self.anon_api_session.post(

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -208,7 +208,11 @@ class TestUsersEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(201, response.status_code)
-        self.assertTrue("To: howard.zinn@example.com" in self.mailhost.messages[0])
+        msg = self.mailhost.messages[0]
+        if isinstance(msg, bytes) and bytes is not str:
+            # Python 3 with Products.MailHost 4.10+
+            msg = msg.decode("utf-8")
+        self.assertTrue("To: howard.zinn@example.com" in msg)
 
     def test_add_user_send_properties(self):
         response = self.api_session.post(
@@ -822,7 +826,11 @@ class TestUsersEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(201, response.status_code)
-        self.assertTrue("To: avram.chomsky@example.com" in self.mailhost.messages[0])
+        msg = self.mailhost.messages[0]
+        if isinstance(msg, bytes) and bytes is not str:
+            # Python 3 with Products.MailHost 4.10+
+            msg = msg.decode("utf-8")
+        self.assertTrue("To: avram.chomsky@example.com" in msg)
 
     def test_anonymous_can_set_password_with_enable_user_pwd_choice(self):
         security_settings = getAdapter(self.portal, ISecuritySchema)


### PR DESCRIPTION
Part of https://github.com/plone/Products.CMFPlone/issues/3178
Should be tested together with other PRs from that issue.
But the tests here in `plone.restapi` should still pass with older Products.MailHost and older Plone. So if tests are green, it could be merged.