### PR TITLE
Pin pyrsistent to 0.15.7 in buildout configs.

### DIFF
--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -19,3 +19,5 @@ zipp = 0.5.2
 more-itertools = 5.0.0
 # Error: The requirement ('Pygments>=2.5.1') is not allowed by your [versions] constraint (2.2.0)
 Pygments = 2.5.2
+# Last pyrsistent version that is python 2 compatible:
+pyrsistent = 0.15.7

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -9,3 +9,5 @@ plone.restapi =
 plone.schema = 1.2.1
 pytz = 2017.3
 zope.interface = 4.1.0
+# Last pyrsistent version that is python 2 compatible:
+pyrsistent = 0.15.7

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -12,6 +12,9 @@ zipp = 0.5.2
 # plone.restapi specific
 plone.schema = 1.2.1
 
+# Last pyrsistent version that is python 2 compatible:
+pyrsistent = 0.15.7
+
 # zest.releaser
 zest.releaser = 6.20.1
 twine = 1.11.0


### PR DESCRIPTION
This is the last pyrsistent version that is python 2 compatible.
On 5.2 it is pinned in the core versions.
It is a dependency of jsonschema.

Just a Travis test fix, so no changelog entry, and no Jenkins jobs needed.