### PR TITLE
Improve import traceback

### DIFF
--- a/news/1009.feature
+++ b/news/1009.feature
@@ -1,0 +1,2 @@
+Enhance traceback with ``__traceback_info__`` on import to detect the field causing the problem.
+[jensens]

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -84,6 +84,7 @@ class DeserializeFromJson(OrderingMixin, object):
             write_permissions = mergedTaggedValueDict(schema, WRITE_PERMISSIONS_KEY)
 
             for name, field in getFields(schema).items():
+                __traceback_info__ = "field={}".format(field)
 
                 field_data = schema_data.setdefault(schema, {})
 


### PR DESCRIPTION
I got an difficult to interpret traceback on content POST like:
```
2020-10-30 15:50:32,222 ERROR   [Zope.SiteErrorLog:252][waitress-3] 1604069432.22186450.03333581790354878 http://localhost:8080/Plone/reviere/POST_application_json_
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 167, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 364, in publish_module
  Module ZPublisher.WSGIPublisher, line 259, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module plone.rest.service, line 22, in __call__
  Module plone.restapi.services, line 20, in render
  Module plone.restapi.services.content.add, line 77, in reply
  Module plone.restapi.deserializer.dxcontent, line 45, in __call__
  Module plone.restapi.deserializer.dxcontent, line 151, in get_schema_data
  Module plone.app.relationfield.widget, line 30, in get
AttributeError: 'str' object has no attribute 'isBroken'
```
with this change it points me directly to the problem:
```
2020-10-30 15:50:32,222 ERROR   [Zope.SiteErrorLog:252][waitress-3] 1604069432.22186450.03333581790354878 http://localhost:8080/Plone/reviere/POST_application_json_
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 167, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 364, in publish_module
  Module ZPublisher.WSGIPublisher, line 259, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module plone.rest.service, line 22, in __call__
  Module plone.restapi.services, line 20, in render
  Module plone.restapi.services.content.add, line 77, in reply
  Module plone.restapi.deserializer.dxcontent, line 45, in __call__
  Module plone.restapi.deserializer.dxcontent, line 151, in get_schema_data
   - __traceback_info__: field=kup.tfv.db.revier.revier.IRevierBehavior.bewirtschafter
  Module plone.app.relationfield.widget, line 30, in get
AttributeError: 'str' object has no attribute 'isBroken'
```

