### PR TITLE
Fix Zope 4.5.2 compatibility: make sure Location header is string [master]

### DIFF
--- a/news/1019.bugfix
+++ b/news/1019.bugfix
@@ -1,0 +1,4 @@
+Fixed compatibility with Zope 4.5.2 by making sure Location header is string.
+On Python 2 it could be unicode for the users and groups end points.
+Fixes `issue 1019 <https://github.com/plone/plone.restapi/issues/1019>`_.
+[maurits]

--- a/src/plone/restapi/services/groups/add.py
+++ b/src/plone/restapi/services/groups/add.py
@@ -9,6 +9,7 @@ from zope.component.hooks import getSite
 from zope.interface import alsoProvides
 
 import plone.protect.interfaces
+import six
 
 
 class GroupsPost(Service):
@@ -65,6 +66,10 @@ class GroupsPost(Service):
             group.addMember(userid)
 
         self.request.response.setStatus(201)
+        # Note: to please Zope 4.5.2+ we make sure the header is a string,
+        # and not unicode on Python 2.
+        if six.PY2 and not isinstance(groupname, str):
+            groupname = groupname.encode("utf-8")
         self.request.response.setHeader(
             "Location", portal.absolute_url() + "/@groups/" + groupname
         )

--- a/src/plone/restapi/services/users/add.py
+++ b/src/plone/restapi/services/users/add.py
@@ -18,6 +18,7 @@ from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 
 import plone.protect.interfaces
+import six
 
 
 try:  # pragma: no cover
@@ -215,6 +216,10 @@ class UsersPost(Service):
         if send_password_reset:
             registration.registeredNotify(username)
         self.request.response.setStatus(201)
+        # Note: to please Zope 4.5.2+ we make sure the header is a string,
+        # and not unicode on Python 2.
+        if six.PY2 and not isinstance(username, str):
+            username = username.encode("utf-8")
         self.request.response.setHeader(
             "Location", portal.absolute_url() + "/@users/" + username
         )


### PR DESCRIPTION
On Python 2 it could be unicode for the users and groups end points.
Fixes https://github.com/plone/plone.restapi/issues/1019