### PR TITLE
Fix Travis on 6.x.x.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ pip-selfcheck.json
 /.vscode
 /.ipython
 /.mypy_cache/
+.*project

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,11 @@ before_install:
   - echo "[buildout]" > $HOME/.buildout/default.cfg
   - echo "download-cache = $HOME/buildout-cache/downloads" >> $HOME/.buildout/default.cfg
   - echo "eggs-directory = $HOME/buildout-cache/eggs" >> $HOME/.buildout/default.cfg
-  - pip install -r requirements.txt
+  - virtualenv -p `which python` .
+  - bin/pip install -r requirements.txt
 install:
   - sed -ie "s#plone-x.x.x.cfg#plone-$PLONE_VERSION.cfg#" travis.cfg
-  - buildout -t 10 -c travis.cfg
+  - bin/buildout -t 10 -c travis.cfg
 script:
   - if [ "$PLONE_VERSION" == "5.2.x" ] && [ $TRAVIS_PYTHON_VERSION == '3.7' ]; then pip install black && black src/ --check; fi
   - bin/code-analysis

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -8,3 +8,12 @@ versions=versions
 [versions]
 plone.restapi =
 plone.namedfile = 5.2.2
+
+# Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.23)
+importlib-metadata = 2.0.0
+
+# Error: The requirement ('pep517>=0.9') is not allowed by your [versions] constraint (0.8.2)
+pep517 = 0.9.1
+
+# Error: The requirement ('virtualenv>=20.0.35') is not allowed by your [versions] constraint (20.0.26)
+virtualenv = 20.0.35


### PR DESCRIPTION
This is a backport of https://github.com/plone/plone.restapi/pull/1013 because Travis fails on the 6.x.x branch as well.  See for example:
https://travis-ci.org/github/plone/plone.restapi/jobs/743167173