### PR TITLE
Pinn Pygments = 2.5.2 only in version.cfg

### DIFF
--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -20,9 +20,6 @@ zipp = 0.5.2
 # more-itertools >= 6.0.0 dropped python2.7 support
 more-itertools = 5.0.0
 
-# Error: The requirement ('Pygments>=2.5.1') is not allowed by your [versions] constraint (2.2.0)
-Pygments = 2.5.2
-
 # Last pyrsistent version that is python 2 compatible:
 pyrsistent = 0.15.7
 


### PR DESCRIPTION
This is latest version compatible with Python 2.7.  `version.cfg` is not used in Plone 5.2