### PR TITLE
Patch Plone 4.3's _install_profile_info method to list the default profile of plone.restapi in the first position.

### DIFF
--- a/news/895.bugfix
+++ b/news/895.bugfix
@@ -1,0 +1,4 @@
+Fix error in Plone 4.3 that installed the blocks profile  when installing the package,
+instead of the default profile.
+Fix `#895 <https://github.com/plone/plone.restapi/issues/895>`
+  [wesleybl]

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "plone.behavior>=1.1",  # adds name to behavior directive
         "plone.rest >= 1.0a6",  # json renderer moved to plone.restapi
         "plone.schema >= 1.2.1",  # new/fixed json field
+        "Products.CMFPlone",
         "PyJWT",
         "pytz",
     ],

--- a/src/plone/restapi/__init__.py
+++ b/src/plone/restapi/__init__.py
@@ -2,8 +2,10 @@
 from AccessControl import allow_module
 from AccessControl.Permissions import add_user_folders
 from plone.restapi.pas import plugin
+from Products.CMFPlone.utils import getFSVersionTuple
 from Products.PluggableAuthService.PluggableAuthService import registerMultiPlugin
 from zope.i18nmessageid import MessageFactory
+
 
 import pkg_resources
 
@@ -32,6 +34,14 @@ except pkg_resources.DistributionNotFound:
     HAS_AT = False
 else:
     HAS_AT = True
+
+PLONE4 = getFSVersionTuple()[0] == 4
+
+# BBB: Fix install profile in Plone 4
+if PLONE4:
+    from plone.restapi.patch import apply_patch
+
+    apply_patch()
 
 
 def initialize(context):

--- a/src/plone/restapi/patch.py
+++ b/src/plone/restapi/patch.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from Products.CMFQuickInstallerTool.QuickInstallerTool import QuickInstallerTool
+
+_original_QuickInstallerTool_install_profile_info = (
+    QuickInstallerTool._install_profile_info
+)
+
+
+def _install_profile_info(self, productname):
+    install_profile_info = _original_QuickInstallerTool_install_profile_info(
+        self, productname
+    )
+    if productname == "plone.restapi" and install_profile_info:
+        default_profile = u"plone.restapi:default"
+        first_profile = install_profile_info[0]["id"]
+        if default_profile != first_profile:
+            install_profile_info[0], install_profile_info[1] = (
+                install_profile_info[1],
+                install_profile_info[0],
+            )
+    return install_profile_info
+
+
+def apply_patch():
+    # BBB: In Plone 4, the profile that runs when installing a product is the first in
+    # the list of profiles, ordered alphabetically. Since plone.restapi has profile
+    # blocks, it comes before the default and that is why it is what is listed for
+    # installing of plone.restapi. This patch changes the order, of the profiles blocks
+    # and default, so that the default is the installed profile.
+    QuickInstallerTool._install_profile_info = _install_profile_info

--- a/src/plone/restapi/tests/test_setup.py
+++ b/src/plone/restapi/tests/test_setup.py
@@ -38,6 +38,20 @@ class TestInstall(unittest.TestCase):
             ]
         self.assertTrue(installed, "package appears not to have been installed")
 
+    def test_install_profile(self):
+        """Checks if the install profile is the default profile."""
+        if HAS_INSTALLER:
+            qi = get_installer(self.portal)
+            install_profile_id = qi.get_install_profile(PROJECT_NAME)["id"]
+        else:
+            qi_tool = api.portal.get_tool("portal_quickinstaller")
+            install_profile_id = qi_tool.getInstallProfile(PROJECT_NAME)["id"]
+        self.assertEqual(
+            install_profile_id,
+            "plone.restapi:default",
+            "The install profile must be plone.restapi:default",
+        )
+
 
 class TestUninstall(unittest.TestCase):
 


### PR DESCRIPTION
Plone 4.3 considers that the first profile, after ordering all profiles in alphabetical order, is the profile to be installed when installing
the product. Since plone.restapi has the profile `blocks`, it is installed, instead of the default profile. This patch puts the `default` profile in the first position, so that it is the installed profile.

Fix #895