### PR TITLE
Fix GA in 6.x.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       # test no uncommited changes
       - name: test no uncommited changes
         run: bin/test-no-uncommitted-doc-changes
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          PLONE_VERSION: ${{ matrix.plone-version }}
 
       # test sphinx warnings
       - name: sphinx

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ pip-selfcheck.json
 /.ipython
 /.mypy_cache/
 .*project
+/.settings/

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -1,23 +1,33 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/4.3.19/versions.cfg
+    https://dist.plone.org/release/4.3.20/versions.cfg
     versions.cfg
 
 [versions]
-plone.restapi =
-plone.schema = 1.2.1
+plone.testing = 5.0.0
 pytz = 2017.3
 zope.interface = 4.1.0
+
 # fixes zlib failure: https://stackoverflow.com/questions/34631806/fail-during-installation-of-pillow-python-module-in-linux
 # Pillow = 5.4.1
 future = 0.17.1
 six = 1.11.0
+
 # fixes: SyntaxError: invalid syntax (more.py, line 340)
 zipp = 0.5.2
+
 # more-itertools >= 6.0.0 dropped python2.7 support
 more-itertools = 5.0.0
+
 # Error: The requirement ('Pygments>=2.5.1') is not allowed by your [versions] constraint (2.2.0)
 Pygments = 2.5.2
+
 # Last pyrsistent version that is python 2 compatible:
 pyrsistent = 0.15.7
+
+# Error: The requirement ('distlib<1,>=0.3.1') is not allowed by your [versions] constraint (0.3.0)
+distlib = 0.3.1
+
+# plone.restapi specific pins
+plone.restapi =

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -1,23 +1,24 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.1.6/versions.cfg
+    https://dist.plone.org/release/5.1.7/versions.cfg
     versions.cfg
 
 [versions]
+plone.testing = 5.0.0
+
+# Error: The requirement ('virtualenv>=20.0.35') is not allowed by your [versions] constraint (20.0.26)
+virtualenv = 20.0.35
+
+# Error: The requirement ('distlib<1,>=0.3.1') is not allowed by your [versions] constraint (0.3.0)
+distlib = 0.3.1
+
 # fixes: SyntaxError: invalid syntax (more.py, line 340)
 zipp = 0.5.2
-
-# plone.restapi specific
-plone.schema = 1.2.1
-
-# Last pyrsistent version that is python 2 compatible:
-pyrsistent = 0.15.7
 
 # zest.releaser
 zest.releaser = 6.20.1
 twine = 1.11.0
-requests = 2.18.4
 towncrier = 19.2.0
 zestreleaser.towncrier = 1.1.0
 # docutils = 0.13.1
@@ -32,3 +33,7 @@ sphinx-rtd-theme = 0.2.4
 Jinja2 = 2.10
 Babel = 2.5.1
 astunparse = 1.6.2
+
+# plone.restapi specific pins
+plone.restapi =
+plone.schema = 1.2.1

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,19 +1,24 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.2.2/versions.cfg
-find-links += http://dist.plone.org/thirdparty/
+    https://dist.plone.org/release/5.2.3/versions.cfg
+find-links += https://dist.plone.org/thirdparty/
 versions=versions
 
 [versions]
-plone.restapi =
-plone.namedfile = 5.2.2
+black = 20.8b1
 
-# Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.23)
-importlib-metadata = 2.0.0
+# Error: The requirement ('virtualenv>=20.0.35') is not allowed by your [versions] constraint (20.0.26)
+virtualenv = 20.0.35
 
 # Error: The requirement ('pep517>=0.9') is not allowed by your [versions] constraint (0.8.2)
 pep517 = 0.9.1
 
-# Error: The requirement ('virtualenv>=20.0.35') is not allowed by your [versions] constraint (20.0.26)
-virtualenv = 20.0.35
+# Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.23)
+importlib-metadata = 2.0.0
+
+# avoid dynamic schema updates: https://github.com/plone/plone.dexterity/pull/137
+plone.dexterity = 2.9.8
+
+# plone.restapi specific pins
+plone.restapi =

--- a/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
@@ -252,8 +252,7 @@ Content-Type: application/json+schema
     }
   }, 
   "required": [
-    "title", 
-    "nextPreviousEnabled"
+    "title"
   ], 
   "title": "Carpeta", 
   "type": "object"

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -23,12 +23,7 @@ from zope.interface.verify import verifyClass
 
 import os
 import six
-
-
-if PLONE_VERSION.base_version >= "5.1":
-    GIF_SCALE_FORMAT = "png"
-else:
-    GIF_SCALE_FORMAT = "jpeg"
+import unittest
 
 
 class TestDexterityFieldSerializing(TestCase):
@@ -240,70 +235,6 @@ class TestDexterityFieldSerializing(TestCase):
             value,
         )
 
-    def test_namedimage_field_serialization_returns_dict(self):
-        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
-        with open(image_file, "rb") as f:
-            image_data = f.read()
-        fn = "test_namedimage_field"
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
-            value = self.serialize(
-                fn,
-                NamedImage(
-                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
-                ),
-            )
-            self.assertTrue(isinstance(value, dict), "Not a <dict>")
-
-            scale_url_uuid = "uuid_1"
-            obj_url = self.doc1.absolute_url()
-            download_url = u"{}/@@images/{}.{}".format(
-                obj_url, scale_url_uuid, GIF_SCALE_FORMAT
-            )
-            scales = {
-                u"listing": {u"download": download_url, u"width": 16, u"height": 12},
-                u"icon": {u"download": download_url, u"width": 32, u"height": 24},
-                u"tile": {u"download": download_url, u"width": 64, u"height": 48},
-                u"thumb": {u"download": download_url, u"width": 128, u"height": 96},
-                u"mini": {u"download": download_url, u"width": 200, u"height": 150},
-                u"preview": {u"download": download_url, u"width": 400, u"height": 300},
-                u"large": {u"download": download_url, u"width": 768, u"height": 576},
-            }
-            self.assertEqual(
-                {
-                    u"filename": u"1024x768.gif",
-                    u"content-type": u"image/gif",
-                    u"size": 1514,
-                    u"download": download_url,
-                    u"width": 1024,
-                    u"height": 768,
-                    u"scales": scales,
-                },
-                value,
-            )
-
-    def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
-        image_data = b"INVALID IMAGE DATA"
-        fn = "test_namedimage_field"
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
-            value = self.serialize(
-                fn,
-                NamedImage(
-                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
-                ),
-            )
-        self.assertEqual(
-            {
-                u"content-type": u"image/gif",
-                u"download": None,
-                u"filename": u"1024x768.gif",
-                u"height": -1,
-                u"scales": {},
-                u"size": 18,
-                u"width": -1,
-            },
-            value,
-        )
-
     def test_namedblobfile_field_serialization_returns_dict(self):
         value = self.serialize(
             "test_namedblobfile_field",
@@ -325,47 +256,6 @@ class TestDexterityFieldSerializing(TestCase):
             },
             value,
         )
-
-    def test_namedblobimage_field_serialization_returns_dict(self):
-        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
-        with open(image_file, "rb") as f:
-            image_data = f.read()
-        fn = "test_namedblobimage_field"
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
-            value = self.serialize(
-                fn,
-                NamedBlobImage(
-                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
-                ),
-            )
-            self.assertTrue(isinstance(value, dict), "Not a <dict>")
-
-            scale_url_uuid = "uuid_1"
-            obj_url = self.doc1.absolute_url()
-            download_url = u"{}/@@images/{}.{}".format(
-                obj_url, scale_url_uuid, GIF_SCALE_FORMAT
-            )
-            scales = {
-                u"listing": {u"download": download_url, u"width": 16, u"height": 12},
-                u"icon": {u"download": download_url, u"width": 32, u"height": 24},
-                u"tile": {u"download": download_url, u"width": 64, u"height": 48},
-                u"thumb": {u"download": download_url, u"width": 128, u"height": 96},
-                u"mini": {u"download": download_url, u"width": 200, u"height": 150},
-                u"preview": {u"download": download_url, u"width": 400, u"height": 300},
-                u"large": {u"download": download_url, u"width": 768, u"height": 576},
-            }
-            self.assertEqual(
-                {
-                    u"filename": u"1024x768.gif",
-                    u"content-type": u"image/gif",
-                    u"size": 1514,
-                    u"download": download_url,
-                    u"width": 1024,
-                    u"height": 768,
-                    u"scales": scales,
-                },
-                value,
-            )
 
     def test_relationchoice_field_serialization_returns_summary_dict(self):
         doc2 = self.portal[
@@ -424,6 +314,683 @@ class TestDexterityFieldSerializing(TestCase):
                     "review_state": "private",
                 },
             ],
+            value,
+        )
+
+
+@unittest.skipUnless(
+    PLONE_VERSION.base_version < "5.1",
+    "Plone < 5.1: original image url is a scaled image in JPEG format because we test with a GIF image",
+)
+class TestDexterityImageFieldsSerializingOriginalScaledInJPEG(TestCase):
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+    maxDiff = None
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+
+        self.doc1 = self.portal[
+            self.portal.invokeFactory(
+                "DXTestDocument", id="doc1", title="Test Document"
+            )
+        ]
+
+    def serialize(self, fieldname, value):
+        for schema in iterSchemata(self.doc1):
+            if fieldname in schema:
+                field = schema.get(fieldname)
+                break
+        dm = getMultiAdapter((self.doc1, field), IDataManager)
+        dm.set(value)
+        serializer = getMultiAdapter((field, self.doc1, self.request), IFieldSerializer)
+        return serializer()
+
+    def test_namedimage_field_serialization_returns_dict(self):
+        """In Plone < 5.1 the image returned when requesting an image
+           scale with the same width and height of the original image is
+           a Pillow-generated image scale in JPEG format"""
+        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
+        with open(image_file, "rb") as f:
+            image_data = f.read()
+        fn = "test_namedimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+            self.assertTrue(isinstance(value, dict), "Not a <dict>")
+
+            scale_url_uuid = "uuid_1"
+            obj_url = self.doc1.absolute_url()
+
+            # Original image is still a "scale"
+            # scaled images are converted to JPEG in Plone < 5.1
+            original_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "jpeg"
+            )
+
+            scale_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "jpeg"
+            )
+            scales = {
+                u"listing": {
+                    u"download": scale_download_url,
+                    u"width": 16,
+                    u"height": 12,
+                },
+                u"icon": {u"download": scale_download_url, u"width": 32, u"height": 24},
+                u"tile": {u"download": scale_download_url, u"width": 64, u"height": 48},
+                u"thumb": {
+                    u"download": scale_download_url,
+                    u"width": 128,
+                    u"height": 96,
+                },
+                u"mini": {
+                    u"download": scale_download_url,
+                    u"width": 200,
+                    u"height": 150,
+                },
+                u"preview": {
+                    u"download": scale_download_url,
+                    u"width": 400,
+                    u"height": 300,
+                },
+                u"large": {
+                    u"download": scale_download_url,
+                    u"width": 768,
+                    u"height": 576,
+                },
+            }
+            self.assertEqual(
+                {
+                    u"filename": u"1024x768.gif",
+                    u"content-type": u"image/gif",
+                    u"size": 1514,
+                    u"download": original_download_url,
+                    u"width": 1024,
+                    u"height": 768,
+                    u"scales": scales,
+                },
+                value,
+            )
+
+    def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
+        """ Original image url will be None because the original image is corrupted
+            and the created url should be an image scale """
+        image_data = b"INVALID IMAGE DATA"
+        fn = "test_namedimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+
+        self.assertEqual(
+            {
+                u"content-type": u"image/gif",
+                u"download": None,
+                u"filename": u"1024x768.gif",
+                u"height": -1,
+                u"scales": {},
+                u"size": 18,
+                u"width": -1,
+            },
+            value,
+        )
+
+    def test_namedblobimage_field_serialization_returns_dict(self):
+        """In Plone < 5.1 the image returned when requesting an image
+           scale with the same width and height of the original image is
+           a Pillow-generated image scale in JPEG format"""
+        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
+        with open(image_file, "rb") as f:
+            image_data = f.read()
+        fn = "test_namedblobimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedBlobImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+            self.assertTrue(isinstance(value, dict), "Not a <dict>")
+
+            scale_url_uuid = "uuid_1"
+            obj_url = self.doc1.absolute_url()
+
+            # Original image is still a "scale"
+            # scaled images are converted to JPEG in Plone < 5.1
+            original_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "jpeg"
+            )
+
+            scale_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "jpeg"
+            )
+            scales = {
+                u"listing": {
+                    u"download": scale_download_url,
+                    u"width": 16,
+                    u"height": 12,
+                },
+                u"icon": {u"download": scale_download_url, u"width": 32, u"height": 24},
+                u"tile": {u"download": scale_download_url, u"width": 64, u"height": 48},
+                u"thumb": {
+                    u"download": scale_download_url,
+                    u"width": 128,
+                    u"height": 96,
+                },
+                u"mini": {
+                    u"download": scale_download_url,
+                    u"width": 200,
+                    u"height": 150,
+                },
+                u"preview": {
+                    u"download": scale_download_url,
+                    u"width": 400,
+                    u"height": 300,
+                },
+                u"large": {
+                    u"download": scale_download_url,
+                    u"width": 768,
+                    u"height": 576,
+                },
+            }
+            self.assertEqual(
+                {
+                    u"filename": u"1024x768.gif",
+                    u"content-type": u"image/gif",
+                    u"size": 1514,
+                    u"download": original_download_url,
+                    u"width": 1024,
+                    u"height": 768,
+                    u"scales": scales,
+                },
+                value,
+            )
+
+    def test_namedblobimage_field_serialization_doesnt_choke_on_corrupt_image(self):
+        """ Original image url will be None because the original image is corrupted
+            and the created url should be an image scale """
+        image_data = b"INVALID IMAGE DATA"
+        fn = "test_namedblobimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedBlobImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+
+        self.assertEqual(
+            {
+                u"content-type": u"image/gif",
+                u"download": None,
+                u"filename": u"1024x768.gif",
+                u"height": -1,
+                u"scales": {},
+                u"size": 18,
+                u"width": -1,
+            },
+            value,
+        )
+
+
+@unittest.skipUnless(
+    PLONE_VERSION.base_version == "5.1",
+    "Plone 5.1: original image url is a scaled image in PNG format because we test with a GIF image",
+)
+class TestDexterityImageFieldSerializingOriginalScaledInPNG(TestCase):
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+    maxDiff = None
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+
+        self.doc1 = self.portal[
+            self.portal.invokeFactory(
+                "DXTestDocument", id="doc1", title="Test Document"
+            )
+        ]
+
+    def serialize(self, fieldname, value):
+        for schema in iterSchemata(self.doc1):
+            if fieldname in schema:
+                field = schema.get(fieldname)
+                break
+        dm = getMultiAdapter((self.doc1, field), IDataManager)
+        dm.set(value)
+        serializer = getMultiAdapter((field, self.doc1, self.request), IFieldSerializer)
+        return serializer()
+
+    def test_namedimage_field_serialization_returns_dict(self):
+        """In Plone == 5.1 the image returned when requesting an image
+           scale with the same width and height of the original image is
+           a Pillow-generated image scale in PNG format"""
+        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
+        with open(image_file, "rb") as f:
+            image_data = f.read()
+        fn = "test_namedimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+            self.assertTrue(isinstance(value, dict), "Not a <dict>")
+
+            scale_url_uuid = "uuid_1"
+            obj_url = self.doc1.absolute_url()
+
+            # Original image is still a "scale"
+            # scaled images are converted to PNG in Plone = 5.1
+            original_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "png"
+            )
+
+            scale_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "jpeg"
+            )
+            scales = {
+                u"listing": {
+                    u"download": scale_download_url,
+                    u"width": 16,
+                    u"height": 12,
+                },
+                u"icon": {u"download": scale_download_url, u"width": 32, u"height": 24},
+                u"tile": {u"download": scale_download_url, u"width": 64, u"height": 48},
+                u"thumb": {
+                    u"download": scale_download_url,
+                    u"width": 128,
+                    u"height": 96,
+                },
+                u"mini": {
+                    u"download": scale_download_url,
+                    u"width": 200,
+                    u"height": 150,
+                },
+                u"preview": {
+                    u"download": scale_download_url,
+                    u"width": 400,
+                    u"height": 300,
+                },
+                u"large": {
+                    u"download": scale_download_url,
+                    u"width": 768,
+                    u"height": 576,
+                },
+            }
+            self.assertEqual(
+                {
+                    u"filename": u"1024x768.gif",
+                    u"content-type": u"image/gif",
+                    u"size": 1514,
+                    u"download": original_download_url,
+                    u"width": 1024,
+                    u"height": 768,
+                    u"scales": scales,
+                },
+                value,
+            )
+
+    def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
+        """ Original image url will be None because the original image is corrupted
+            and the created url should be an image scale """
+        image_data = b"INVALID IMAGE DATA"
+        fn = "test_namedimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+
+        self.assertEqual(
+            {
+                u"content-type": u"image/gif",
+                u"download": None,
+                u"filename": u"1024x768.gif",
+                u"height": -1,
+                u"scales": {},
+                u"size": 18,
+                u"width": -1,
+            },
+            value,
+        )
+
+    def test_namedblobimage_field_serialization_returns_dict(self):
+        """In Plone = 5.1 the image returned when requesting an image
+           scale with the same width and height of the original image is
+           a Pillow-generated image scale in PNG format"""
+        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
+        with open(image_file, "rb") as f:
+            image_data = f.read()
+        fn = "test_namedblobimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedBlobImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+            self.assertTrue(isinstance(value, dict), "Not a <dict>")
+
+            scale_url_uuid = "uuid_1"
+            obj_url = self.doc1.absolute_url()
+
+            # Original image is still a "scale"
+            # scaled images are converted to PNG in Plone = 5.1
+            original_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "png"
+            )
+
+            scale_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "jpeg"
+            )
+            scales = {
+                u"listing": {
+                    u"download": scale_download_url,
+                    u"width": 16,
+                    u"height": 12,
+                },
+                u"icon": {u"download": scale_download_url, u"width": 32, u"height": 24},
+                u"tile": {u"download": scale_download_url, u"width": 64, u"height": 48},
+                u"thumb": {
+                    u"download": scale_download_url,
+                    u"width": 128,
+                    u"height": 96,
+                },
+                u"mini": {
+                    u"download": scale_download_url,
+                    u"width": 200,
+                    u"height": 150,
+                },
+                u"preview": {
+                    u"download": scale_download_url,
+                    u"width": 400,
+                    u"height": 300,
+                },
+                u"large": {
+                    u"download": scale_download_url,
+                    u"width": 768,
+                    u"height": 576,
+                },
+            }
+            self.assertEqual(
+                {
+                    u"filename": u"1024x768.gif",
+                    u"content-type": u"image/gif",
+                    u"size": 1514,
+                    u"download": original_download_url,
+                    u"width": 1024,
+                    u"height": 768,
+                    u"scales": scales,
+                },
+                value,
+            )
+
+    def test_namedblobimage_field_serialization_doesnt_choke_on_corrupt_image(self):
+        """ Original image url will be None because the original image is corrupted
+            and the created url should be an image scale """
+        image_data = b"INVALID IMAGE DATA"
+        fn = "test_namedblobimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedBlobImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+
+        self.assertEqual(
+            {
+                u"content-type": u"image/gif",
+                u"download": None,
+                u"filename": u"1024x768.gif",
+                u"height": -1,
+                u"scales": {},
+                u"size": 18,
+                u"width": -1,
+            },
+            value,
+        )
+
+
+@unittest.skipUnless(
+    PLONE_VERSION.base_version >= "5.2",
+    "Plone 5.2: original image url is the original image",
+)
+class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
+    maxDiff = None
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+
+        self.doc1 = self.portal[
+            self.portal.invokeFactory(
+                "DXTestDocument", id="doc1", title="Test Document"
+            )
+        ]
+
+    def serialize(self, fieldname, value):
+        for schema in iterSchemata(self.doc1):
+            if fieldname in schema:
+                field = schema.get(fieldname)
+                break
+        dm = getMultiAdapter((self.doc1, field), IDataManager)
+        dm.set(value)
+        serializer = getMultiAdapter((field, self.doc1, self.request), IFieldSerializer)
+        return serializer()
+
+    def test_namedimage_field_serialization_returns_dict_with_original_scale(self):
+        """In Plone >= 5.2 the image returned when requesting an image
+           scale with the same width and height of the original image is
+           the actual original image in its original format """
+        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
+        with open(image_file, "rb") as f:
+            image_data = f.read()
+        fn = "test_namedimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+            self.assertTrue(isinstance(value, dict), "Not a <dict>")
+
+            scale_url_uuid = "uuid_1"
+            obj_url = self.doc1.absolute_url()
+
+            # Original image is still a "scale"
+            # scaled images are converted to PNG in Plone = 5.2
+            original_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "gif"
+            )
+
+            scale_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "png"
+            )
+            scales = {
+                u"listing": {
+                    u"download": scale_download_url,
+                    u"width": 16,
+                    u"height": 12,
+                },
+                u"icon": {u"download": scale_download_url, u"width": 32, u"height": 24},
+                u"tile": {u"download": scale_download_url, u"width": 64, u"height": 48},
+                u"thumb": {
+                    u"download": scale_download_url,
+                    u"width": 128,
+                    u"height": 96,
+                },
+                u"mini": {
+                    u"download": scale_download_url,
+                    u"width": 200,
+                    u"height": 150,
+                },
+                u"preview": {
+                    u"download": scale_download_url,
+                    u"width": 400,
+                    u"height": 300,
+                },
+                u"large": {
+                    u"download": scale_download_url,
+                    u"width": 768,
+                    u"height": 576,
+                },
+            }
+            self.assertEqual(
+                {
+                    u"filename": u"1024x768.gif",
+                    u"content-type": u"image/gif",
+                    u"size": 1514,
+                    u"download": original_download_url,
+                    u"width": 1024,
+                    u"height": 768,
+                    u"scales": scales,
+                },
+                value,
+            )
+
+    def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
+        """ In Plone >= 5.2 the original image file is not a "scale", so its url
+            is returned as is and we need to check it, but the scales should be empty"""
+        image_data = b"INVALID IMAGE DATA"
+        fn = "test_namedimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+
+        obj_url = self.doc1.absolute_url()
+        scale_url_uuid = "uuid_1"
+        self.assertEqual(
+            {
+                u"content-type": u"image/gif",
+                u"download": u"{}/@@images/{}.{}".format(
+                    obj_url, scale_url_uuid, "gif"
+                ),
+                u"filename": u"1024x768.gif",
+                u"height": -1,
+                u"scales": {},
+                u"size": 18,
+                u"width": -1,
+            },
+            value,
+        )
+
+    def test_namedblobimage_field_serialization_returns_dict_with_original_scale(self):
+        """In Plone >= 5.2 the image returned when requesting an image
+           scale with the same width and height of the original image is
+           the actual original image in its original format"""
+        image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
+        with open(image_file, "rb") as f:
+            image_data = f.read()
+        fn = "test_namedblobimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedBlobImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+            self.assertTrue(isinstance(value, dict), "Not a <dict>")
+
+            scale_url_uuid = "uuid_1"
+            obj_url = self.doc1.absolute_url()
+
+            # Original image is still a "scale"
+            # scaled images are converted to PNG in Plone = 5.2
+            original_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "gif"
+            )
+
+            scale_download_url = u"{}/@@images/{}.{}".format(
+                obj_url, scale_url_uuid, "png"
+            )
+            scales = {
+                u"listing": {
+                    u"download": scale_download_url,
+                    u"width": 16,
+                    u"height": 12,
+                },
+                u"icon": {u"download": scale_download_url, u"width": 32, u"height": 24},
+                u"tile": {u"download": scale_download_url, u"width": 64, u"height": 48},
+                u"thumb": {
+                    u"download": scale_download_url,
+                    u"width": 128,
+                    u"height": 96,
+                },
+                u"mini": {
+                    u"download": scale_download_url,
+                    u"width": 200,
+                    u"height": 150,
+                },
+                u"preview": {
+                    u"download": scale_download_url,
+                    u"width": 400,
+                    u"height": 300,
+                },
+                u"large": {
+                    u"download": scale_download_url,
+                    u"width": 768,
+                    u"height": 576,
+                },
+            }
+            self.assertEqual(
+                {
+                    u"filename": u"1024x768.gif",
+                    u"content-type": u"image/gif",
+                    u"size": 1514,
+                    u"download": original_download_url,
+                    u"width": 1024,
+                    u"height": 768,
+                    u"scales": scales,
+                },
+                value,
+            )
+
+    def test_namedblobimage_field_serialization_doesnt_choke_on_corrupt_image(self):
+        """ In Plone >= 5.2 the original image file is not a "scale", so its url
+            is returned as is and we need to check it, but the scales should be empty"""
+        image_data = b"INVALID IMAGE DATA"
+        fn = "test_namedblobimage_field"
+        with patch.object(storage, "uuid4", return_value="uuid_1"):
+            value = self.serialize(
+                fn,
+                NamedBlobImage(
+                    data=image_data, contentType=u"image/gif", filename=u"1024x768.gif"
+                ),
+            )
+
+        obj_url = self.doc1.absolute_url()
+        scale_url_uuid = "uuid_1"
+        self.assertEqual(
+            {
+                u"content-type": u"image/gif",
+                u"download": u"{}/@@images/{}.{}".format(
+                    obj_url, scale_url_uuid, "gif"
+                ),
+                u"filename": u"1024x768.gif",
+                u"height": -1,
+                u"scales": {},
+                u"size": 18,
+                u"width": -1,
+            },
             value,
         )
 

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -348,8 +348,8 @@ class TestDexterityImageFieldsSerializingOriginalScaledInJPEG(TestCase):
 
     def test_namedimage_field_serialization_returns_dict(self):
         """In Plone < 5.1 the image returned when requesting an image
-           scale with the same width and height of the original image is
-           a Pillow-generated image scale in JPEG format"""
+        scale with the same width and height of the original image is
+        a Pillow-generated image scale in JPEG format"""
         image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
         with open(image_file, "rb") as f:
             image_data = f.read()
@@ -418,8 +418,8 @@ class TestDexterityImageFieldsSerializingOriginalScaledInJPEG(TestCase):
             )
 
     def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
-        """ Original image url will be None because the original image is corrupted
-            and the created url should be an image scale """
+        """Original image url will be None because the original image is corrupted
+        and the created url should be an image scale"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedimage_field"
         with patch.object(storage, "uuid4", return_value="uuid_1"):
@@ -445,8 +445,8 @@ class TestDexterityImageFieldsSerializingOriginalScaledInJPEG(TestCase):
 
     def test_namedblobimage_field_serialization_returns_dict(self):
         """In Plone < 5.1 the image returned when requesting an image
-           scale with the same width and height of the original image is
-           a Pillow-generated image scale in JPEG format"""
+        scale with the same width and height of the original image is
+        a Pillow-generated image scale in JPEG format"""
         image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
         with open(image_file, "rb") as f:
             image_data = f.read()
@@ -515,8 +515,8 @@ class TestDexterityImageFieldsSerializingOriginalScaledInJPEG(TestCase):
             )
 
     def test_namedblobimage_field_serialization_doesnt_choke_on_corrupt_image(self):
-        """ Original image url will be None because the original image is corrupted
-            and the created url should be an image scale """
+        """Original image url will be None because the original image is corrupted
+        and the created url should be an image scale"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedblobimage_field"
         with patch.object(storage, "uuid4", return_value="uuid_1"):
@@ -571,8 +571,8 @@ class TestDexterityImageFieldSerializingOriginalScaledInPNG(TestCase):
 
     def test_namedimage_field_serialization_returns_dict(self):
         """In Plone == 5.1 the image returned when requesting an image
-           scale with the same width and height of the original image is
-           a Pillow-generated image scale in PNG format"""
+        scale with the same width and height of the original image is
+        a Pillow-generated image scale in PNG format"""
         image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
         with open(image_file, "rb") as f:
             image_data = f.read()
@@ -641,8 +641,8 @@ class TestDexterityImageFieldSerializingOriginalScaledInPNG(TestCase):
             )
 
     def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
-        """ Original image url will be None because the original image is corrupted
-            and the created url should be an image scale """
+        """Original image url will be None because the original image is corrupted
+        and the created url should be an image scale"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedimage_field"
         with patch.object(storage, "uuid4", return_value="uuid_1"):
@@ -668,8 +668,8 @@ class TestDexterityImageFieldSerializingOriginalScaledInPNG(TestCase):
 
     def test_namedblobimage_field_serialization_returns_dict(self):
         """In Plone = 5.1 the image returned when requesting an image
-           scale with the same width and height of the original image is
-           a Pillow-generated image scale in PNG format"""
+        scale with the same width and height of the original image is
+        a Pillow-generated image scale in PNG format"""
         image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
         with open(image_file, "rb") as f:
             image_data = f.read()
@@ -738,8 +738,8 @@ class TestDexterityImageFieldSerializingOriginalScaledInPNG(TestCase):
             )
 
     def test_namedblobimage_field_serialization_doesnt_choke_on_corrupt_image(self):
-        """ Original image url will be None because the original image is corrupted
-            and the created url should be an image scale """
+        """Original image url will be None because the original image is corrupted
+        and the created url should be an image scale"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedblobimage_field"
         with patch.object(storage, "uuid4", return_value="uuid_1"):
@@ -794,8 +794,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
 
     def test_namedimage_field_serialization_returns_dict_with_original_scale(self):
         """In Plone >= 5.2 the image returned when requesting an image
-           scale with the same width and height of the original image is
-           the actual original image in its original format """
+        scale with the same width and height of the original image is
+        the actual original image in its original format"""
         image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
         with open(image_file, "rb") as f:
             image_data = f.read()
@@ -864,8 +864,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
 
     def test_namedimage_field_serialization_doesnt_choke_on_corrupt_image(self):
-        """ In Plone >= 5.2 the original image file is not a "scale", so its url
-            is returned as is and we need to check it, but the scales should be empty"""
+        """In Plone >= 5.2 the original image file is not a "scale", so its url
+        is returned as is and we need to check it, but the scales should be empty"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedimage_field"
         with patch.object(storage, "uuid4", return_value="uuid_1"):
@@ -895,8 +895,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
 
     def test_namedblobimage_field_serialization_returns_dict_with_original_scale(self):
         """In Plone >= 5.2 the image returned when requesting an image
-           scale with the same width and height of the original image is
-           the actual original image in its original format"""
+        scale with the same width and height of the original image is
+        the actual original image in its original format"""
         image_file = os.path.join(os.path.dirname(__file__), u"1024x768.gif")
         with open(image_file, "rb") as f:
             image_data = f.read()
@@ -965,8 +965,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
 
     def test_namedblobimage_field_serialization_doesnt_choke_on_corrupt_image(self):
-        """ In Plone >= 5.2 the original image file is not a "scale", so its url
-            is returned as is and we need to check it, but the scales should be empty"""
+        """In Plone >= 5.2 the original image file is not a "scale", so its url
+        is returned as is and we need to check it, but the scales should be empty"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedblobimage_field"
         with patch.object(storage, "uuid4", return_value="uuid_1"):

--- a/test-no-uncommitted-doc-changes.in
+++ b/test-no-uncommitted-doc-changes.in
@@ -13,7 +13,7 @@ function red {
     echo "$RED $1 $RESET"
 }
 
-if [ "$PLONE_VERSION" == "5.2.x" ] && [ $TRAVIS_PYTHON_VERSION == '3.7' ]; then
+if [ "$PLONE_VERSION" == "5.2" ] && [ "$PYTHON_VERSION" == '3.7' ]; then
     echo "Running check for undocumented changes for Plone 5.2.x on Python 3.7"
 else
     # request/response dumps have known differences for Plone 5

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,14 +7,12 @@ zc.recipe.egg = 2.0.3
 # fixes Getting distribution for 'configparser'. assert newdist is not None  # newloc above is missing our dist?!
 configparser = 3.5.3
 
-# fixes Error: The requirement ('Pygments>=2.5.1') is not allowed by your [versions] constraint (2.2.0)
-Pygments = 2.5.1
-
 # plone.recipe.varnish
 plone.recipe.varnish = 1.3
 
 # Code-analysis
 plone.recipe.codeanalysis = 3.0.1
+check-manifest = 0.41
 coverage = 3.7.1
 pep8 = 1.7.1
 flake8 = 3.5.0
@@ -24,7 +22,6 @@ pycodestyle = 2.3.1
 # Release
 zest.releaser = 6.17.0
 twine = 1.11.0
-requests = 2.18.4
 towncrier = 19.2.0
 zestreleaser.towncrier = 1.1.0
 docutils = 0.13.1
@@ -32,9 +29,15 @@ docutils = 0.13.1
 # Sphinx
 Sphinx = 1.6.5
 docutils = 0.14
-Pygments = 2.2.0
+# Latest version compatible with Python 2
+Pygments = 2.5.2
 sphinxcontrib-httpexample = 0.7.0
 sphinxcontrib-httpdomain = 1.5.0
 sphinx-rtd-theme = 0.2.4
 Jinja2 = 2.10
 Babel = 2.5.1
+
+# plone.rest(api) specific pins
+
+# last py2 compatible version
+httpie = 1.0.3


### PR DESCRIPTION
This is a cherry-pick of #1033.

A cherry-pick of https://github.com/plone/plone.restapi/commit/2a5accbe46cef96d6c327b48edee013a2c6e22af was required for the tests to work on Plone 5.2.3. This fix #974.