### PR TITLE
Pin PyJWT = 1.7.1 for Plone 5.1 and Plone 4.3

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -41,3 +41,6 @@ Babel = 2.5.1
 
 # last py2 compatible version
 httpie = 1.0.3
+
+# Latest version compatible with Python 2
+PyJWT = 1.7.1


### PR DESCRIPTION
PyJWT >= 2.0.0 drop support for Python 2. See:

https://github.com/jpadilla/pyjwt/blob/2.0.0/setup.cfg#L25

This fix: https://github.com/plone/plone.restapi/runs/1624633682