### PR TITLE
Fix @id attribute to has the expansions query on them when no fullobj…

### DIFF
--- a/news/837.bugfix
+++ b/news/837.bugfix
@@ -1,0 +1,2 @@
+- Fix ``@id`` when content query has no ``fullbojects``
+  [sneridagh]

--- a/src/plone/restapi/serializer/atcontent.py
+++ b/src/plone/restapi/serializer/atcontent.py
@@ -111,8 +111,6 @@ class SerializeFolderToJson(SerializeToJson):
 
             batch = HypermediaBatch(self.request, brains)
 
-            if not self.request.form.get("fullobjects"):
-                result["@id"] = batch.canonical_url
             result["items_total"] = batch.items_total
             if batch.links:
                 result["batching"] = batch.links

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -154,8 +154,6 @@ class SerializeFolderToJson(SerializeToJson):
 
             batch = HypermediaBatch(self.request, brains)
 
-            if "fullobjects" not in self.request.form:
-                result["@id"] = batch.canonical_url
             result["items_total"] = batch.items_total
             if batch.links:
                 result["batching"] = batch.links

--- a/src/plone/restapi/tests/http-examples/content_get_folder.resp
+++ b/src/plone/restapi/tests/http-examples/content_get_folder.resp
@@ -22,7 +22,7 @@ Content-Type: application/json
       "@id": "http://localhost:55001/plone/folder/@workflow"
     }
   }, 
-  "@id": "http://localhost:55001/plone/folder?metadata_fields=UID&metadata_fields=Creator", 
+  "@id": "http://localhost:55001/plone/folder", 
   "@type": "Folder", 
   "UID": "SomeUUID000000000000000000000002", 
   "allow_discussion": false, 

--- a/src/plone/restapi/tests/test_expansion.py
+++ b/src/plone/restapi/tests/test_expansion.py
@@ -372,6 +372,9 @@ class TestTranslationExpansionFunctional(unittest.TestCase):
         self.en_content = createContentInContainer(
             self.portal["en"], "Document", title=u"Test document"
         )
+        self.en_folder = createContentInContainer(
+            self.portal["en"], "Folder", title=u"Test folder"
+        )
         self.es_content = createContentInContainer(
             self.portal["es"], "Document", title=u"Test document"
         )
@@ -397,4 +400,14 @@ class TestTranslationExpansionFunctional(unittest.TestCase):
         translation_dict = {"@id": self.es_content.absolute_url(), "language": "es"}
         self.assertIn(
             translation_dict, response.json()["@components"]["translations"]["items"]
+        )
+
+    def test_expansions_no_fullobjects_do_not_modify_id(self):
+        response = self.api_session.get(
+            "/en/test-folder", params={"expand": "translations"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["@id"], "http://localhost:55001/plone/en/test-folder"
         )

--- a/src/plone/restapi/tests/test_expansion.py
+++ b/src/plone/restapi/tests/test_expansion.py
@@ -408,6 +408,4 @@ class TestTranslationExpansionFunctional(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.json()["@id"], "http://localhost:55001/plone/en/test-folder"
-        )
+        self.assertEqual(response.json()["@id"], self.en_folder.absolute_url())


### PR DESCRIPTION
…ects call is made.

This is the story: We always called `fullobjects` in Volto until Volto 10, when we stopped doing that. That hide this bug, where the `@id` is the canonical_url of the batch. This url has the query string on it, which breaks the assumption `@id` = `absolute_url` item (which we are doing in Volto).

Question is, why this was like this in the beginning? what `batch.canonical_url` gives in addition? I do not remember using it for pagination or anything, at least in Volto...

Might be a leftover from jsonLD or hydra specs?

Proof that this has poor meaning is that removing it, all tests still passed. I added a new one to keep track of it too.