### PR TITLE
Respect access inactive content permission in @search

### DIFF
--- a/news/1066.bugfix
+++ b/news/1066.bugfix
@@ -1,0 +1,1 @@
+Respect "Access inactive portal content" permission in @search endpoint [cekk]

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -77,8 +77,8 @@ class SearchHandler(object):
         self._constrain_query_by_path(query)
         query = self._parse_query(query)
         lazy_resultset = self.catalog.searchResults(**query)
-        results = getMultiAdapter(
-            (lazy_resultset, self.request), ISerializeToJson
-        )(fullobjects=fullobjects)
+        results = getMultiAdapter((lazy_resultset, self.request), ISerializeToJson)(
+            fullobjects=fullobjects
+        )
 
         return results

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -76,10 +76,9 @@ class SearchHandler(object):
 
         self._constrain_query_by_path(query)
         query = self._parse_query(query)
-
-        lazy_resultset = self.catalog.searchResults(query)
-        results = getMultiAdapter((lazy_resultset, self.request), ISerializeToJson)(
-            fullobjects=fullobjects
-        )
+        lazy_resultset = self.catalog.searchResults(**query)
+        results = getMultiAdapter(
+            (lazy_resultset, self.request), ISerializeToJson
+        )(fullobjects=fullobjects)
 
         return results

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -653,6 +653,7 @@ class TestSearchFunctional(unittest.TestCase):
         ).json()
         self.assertEqual(response["items_total"], 1)
 
+
 class TestSearchATFunctional(unittest.TestCase):
     layer = PLONE_RESTAPI_AT_FUNCTIONAL_TESTING
 

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -21,6 +21,13 @@ import six
 import transaction
 import unittest
 
+try:
+    from Products.CMFPlone.factory import _IMREALLYPLONE5  # noqa
+except ImportError:
+    PLONE5 = False
+else:
+    PLONE5 = True
+
 
 class TestSearchFunctional(unittest.TestCase):
 
@@ -602,6 +609,9 @@ class TestSearchFunctional(unittest.TestCase):
         response = self.api_session.get("/@search", params=query)
         self.assertEqual([u"/plone/folder/doc"], result_paths(response.json()))
 
+    @unittest.skipIf(
+        not PLONE5, "searchResults in Plone 4 does not handle correctly that permission"
+    )
     def test_respect_access_inactive_permission(self):
         # admin can see everything
         response = self.api_session.get("/@search", params={}).json()
@@ -642,6 +652,7 @@ class TestSearchFunctional(unittest.TestCase):
         response = self.api_session.get(
             "/@search", params={"path": "/plone/folder"}
         ).json()
+
         self.assertEqual(response["items_total"], 3)
         response = self.api_session.get(
             "/@search", params={"Title": "Lorem Ipsum"}


### PR DESCRIPTION
In [Products.CMFPlone](https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/CatalogTool.py#L423) there is a method that checks if the current user has that permission in the list of paths in kw.

In @search handler we call _searchResults_ method passing a query and not kw.
This leads to a problem because if you give that permission to some roles (Editor for example) and you give Editor role to an user in a subfolder, the @search endpoint will not show expired contents in that folder even if the user has the right permission.

You can test it easily with Volto because the "/contents" view does exactly the problematic @search call:
- add Editor to "Access inactive portal content" permission
- assign Editor role to an user inside a subfolder
- create an expired content inside it
- go to /contents view
- expired content is missing
- in the backend you can see it correctly in folder_contents

with this pr i am going to change how we pass parameters to searchResults

I'm doing the fix here because it's easier and quicker but if you think that this should be fixed inside CMFPlone, let me know.