### PR TITLE
handle quoted urls in copymove endpoint

### DIFF
--- a/news/bugfix.1067
+++ b/news/bugfix.1067
@@ -1,0 +1,1 @@
+Handle quoted urls into copymove endpoint [cekk]

--- a/src/plone/restapi/services/copymove/copymove.py
+++ b/src/plone/restapi/services/copymove/copymove.py
@@ -11,6 +11,11 @@ from zope.security import checkPermission
 import plone
 import six
 
+if six.PY2:
+    from urllib2 import unquote
+else:
+    from urllib.parse import unquote
+
 
 class BaseCopyMove(Service):
     """Base service for copy/move operations."""
@@ -25,6 +30,7 @@ class BaseCopyMove(Service):
 
     def get_object(self, key):
         """Get an object by url, path or UID."""
+        key = unquote(key)
         if key.startswith(self.portal_url):
             # Resolve by URL
             key = key[len(self.portal_url) + 1 :]

--- a/src/plone/restapi/tests/test_copymove.py
+++ b/src/plone/restapi/tests/test_copymove.py
@@ -73,7 +73,7 @@ class TestCopyMove(unittest.TestCase):
         Volto returns paths like this
         """
         service = self.traverse("/plone/@copy", method="POST")
-        obj = service.get_object('/doc2-with%20spaces')
+        obj = service.get_object("/doc2-with%20spaces")
         self.assertEqual(self.doc2, obj)
 
 

--- a/src/plone/restapi/tests/test_copymove.py
+++ b/src/plone/restapi/tests/test_copymove.py
@@ -27,7 +27,9 @@ class TestCopyMove(unittest.TestCase):
             self.portal.invokeFactory("Document", id="doc1", title="My Document")
         ]
         self.doc2 = self.portal[
-            self.portal.invokeFactory("Document", id="doc2-with spaces", title="My Document")
+            self.portal.invokeFactory(
+                "Document", id="doc2-with spaces", title="My Document"
+            )
         ]
         self.folder1 = self.portal[
             self.portal.invokeFactory("Folder", id="folder1", title="My Folder")

--- a/src/plone/restapi/tests/test_copymove.py
+++ b/src/plone/restapi/tests/test_copymove.py
@@ -26,6 +26,9 @@ class TestCopyMove(unittest.TestCase):
         self.doc1 = self.portal[
             self.portal.invokeFactory("Document", id="doc1", title="My Document")
         ]
+        self.doc2 = self.portal[
+            self.portal.invokeFactory("Document", id="doc2-with spaces", title="My Document")
+        ]
         self.folder1 = self.portal[
             self.portal.invokeFactory("Folder", id="folder1", title="My Folder")
         ]
@@ -58,6 +61,20 @@ class TestCopyMove(unittest.TestCase):
         obj = service.get_object(self.doc1.UID())
 
         self.assertEqual(self.doc1, obj)
+
+    def test_get_object_with_quoted_chars_by_url(self):
+        service = self.traverse("/plone/@copy", method="POST")
+        obj = service.get_object(self.doc2.absolute_url())
+
+        self.assertEqual(self.doc2, obj)
+
+    def test_get_object_with_quoted_chars_by_path(self):
+        """
+        Volto returns paths like this
+        """
+        service = self.traverse("/plone/@copy", method="POST")
+        obj = service.get_object('/doc2-with%20spaces')
+        self.assertEqual(self.doc2, obj)
 
 
 class TestCopyMoveFunctional(unittest.TestCase):


### PR DESCRIPTION
This pr solves the following problem:

i have a folder with a space in the id (/aaa/b b/)..maybe from an old migration.

With Volto i can't copy/paste items inside it because Volto calls the endpoint with the quoted path (/aaa/b%20b) and restapi don't find the right object to move.