### PR TITLE
Better support for IQuerySource vocabularies

### DIFF
--- a/src/plone/restapi/services/querysources/get.py
+++ b/src/plone/restapi/services/querysources/get.py
@@ -24,6 +24,11 @@ class QuerySourcesGet(SourcesGet):
         bound_field = field.bind(self.context)
 
         source = bound_field.source
+        if not source and IQuerySource.providedBy(
+            getattr(bound_field, "vocabulary", None)
+        ):
+            source = bound_field.vocabulary
+
         if not IQuerySource.providedBy(source):
             return self._error(
                 404, "Not Found", "Field %r does not have an IQuerySource" % fieldname

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -10,6 +10,7 @@ from plone.restapi.types.utils import get_vocabulary_url
 from plone.restapi.types.utils import get_widget_params
 from plone.schema import IEmail
 from plone.schema import IJSONField
+import six
 from z3c.formwidget.query.interfaces import IQuerySource
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -102,11 +103,22 @@ class DefaultJsonSchemaProvider(object):
     def get_widget_params(self):
         all_params = get_widget_params([self.field.interface])
         params = all_params.get(self.field.getName(), {})
+
         if "vocabulary" in params:
-            vocab_name = params["vocabulary"]
-            params["vocabulary"] = {
-                "@id": get_vocabulary_url(vocab_name, self.context, self.request)
-            }
+            vocab = params["vocabulary"]
+            if isinstance(vocab, six.text_type):
+                params["vocabulary"] = {
+                    "@id": get_vocabulary_url(vocab, self.context, self.request)
+                }
+            elif IQuerySource.providedBy(vocab):
+                params["vocabulary"] = {
+                    "@id": get_querysource_url(self.field, self.context, self.request)
+                }
+            else:
+                params["vocabulary"] = {
+                    "@id": get_source_url(self.field, self.context, self.request)
+                }
+
         return params
 
 


### PR DESCRIPTION
This PR implements a couple small changes to help facilitate use of Async/AJAX select widgets with fields using a vocabulary providing `IQuerySource`. It makes the following changes.

1) Look for such vocabularies in both the `vocabulary` property of the field as well as the `source`.
2) Handle widgets that set their `vocabulary` attribute to a value other than a vocabulary name string.

This relates to issue #1077 and indirectly to #535.

CC: @pbauer @skleinfeldt 