### PR TITLE
Optional search endpoint follows site settings

### DIFF
--- a/docs/source/searching.rst
+++ b/docs/source/searching.rst
@@ -46,7 +46,6 @@ In order to return specific metadata columns, see the documentation of the ``met
         This is done in order to match also the partial results of the beginning of a search term(s).
         The plone.restapi @search endpoint will not do that for you. You'll have to add it if you want to keep this feature.
 
-
 Query format
 ------------
 
@@ -163,3 +162,8 @@ You do so by specifying the ``fullobjects`` parameter:
 .. warning::
 
     Be aware that this might induce performance issues when retrieving a lot of resources. Normally the search just serializes catalog brains, but with ``fullobjects``, we wake up all the returned objects.
+
+
+Restrict search results to Plone's search settings
+--------------------------------------------------
+By default the search endpoint is not excluding any types from its results. To allow the search to follow Plone's search settings schema, pass the ``use_site_search_settings`` to the ``@search`` endpoint request. By doing this, the search results will be filtered based on the defined types to be searched and will be sorted according to the default sorting order.

--- a/docs/source/searching.rst
+++ b/docs/source/searching.rst
@@ -166,4 +166,4 @@ You do so by specifying the ``fullobjects`` parameter:
 
 Restrict search results to Plone's search settings
 --------------------------------------------------
-By default the search endpoint is not excluding any types from its results. To allow the search to follow Plone's search settings schema, pass the ``use_site_search_settings`` to the ``@search`` endpoint request. By doing this, the search results will be filtered based on the defined types to be searched and will be sorted according to the default sorting order.
+By default the search endpoint is not excluding any types from its results. To allow the search to follow Plone's search settings schema, pass the ``use_site_search_settings=1`` to the ``@search`` endpoint request. By doing this, the search results will be filtered based on the defined types to be searched and will be sorted according to the default sorting order.

--- a/news/1081.feature
+++ b/news/1081.feature
@@ -1,0 +1,1 @@
+Allow passing ``use_site_search_settings=1`` in the ``@search`` endpoint request, to follow Plone's ``ISearchSchema`` settings.

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
+from plone.registry.interfaces import IRegistry
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import IZCatalogCompatibleQuery
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.browser.navtree import getNavigationRoot
+from Products.CMFPlone.interfaces import ISearchSchema
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 
 
 class SearchHandler(object):
@@ -74,6 +78,15 @@ class SearchHandler(object):
         else:
             fullobjects = False
 
+        use_site_search_settings = False
+
+        if "use_site_search_settings" in query:
+            use_site_search_settings = True
+            del query["use_site_search_settings"]
+
+        if use_site_search_settings:
+            query = self.filter_query(query)
+
         self._constrain_query_by_path(query)
         query = self._parse_query(query)
         lazy_resultset = self.catalog.searchResults(**query)
@@ -82,3 +95,43 @@ class SearchHandler(object):
         )
 
         return results
+
+    def filter_types(self, types):
+        plone_utils = getToolByName(self.context, "plone_utils")
+        if not isinstance(types, list):
+            types = [types]
+        return plone_utils.getUserFriendlyTypes(types)
+
+    def filter_query(self, query):
+        registry = getUtility(IRegistry)
+        search_settings = registry.forInterface(ISearchSchema, prefix="plone")
+
+        types = query.get("portal_type", [])
+        if "query" in types:
+            types = types["query"]
+        query["portal_type"] = self.filter_types(types)
+
+        # respect effective/expiration date
+        query["show_inactive"] = False
+
+        # respect navigation root
+        if "path" not in query:
+            query["path"] = {"query": getNavigationRoot(self.context)}
+
+        default_sort_on = search_settings.sort_on
+
+        if "sort_on" not in query:
+            if default_sort_on != "relevance":
+                query["sort_on"] = self.default_sort_on
+        elif query["sort_on"] == "relevance":
+            del query["sort_on"]
+
+        if query.get("sort_on", "") == "Date":
+            query["sort_order"] = "reverse"
+        elif "sort_order" in query:
+            del query["sort_order"]
+
+        if "sort_order" in query and not query["sort_order"]:
+            del query["sort_order"]
+
+        return query

--- a/src/plone/restapi/services/search/get.py
+++ b/src/plone/restapi/services/search/get.py
@@ -8,7 +8,5 @@ from plone.restapi.services import Service
 class SearchGet(Service):
     def reply(self):
         query = self.request.form.copy()
-
         query = unflatten_dotted_dict(query)
-
         return SearchHandler(self.context, self.request).search(query)

--- a/src/plone/restapi/services/search/get.py
+++ b/src/plone/restapi/services/search/get.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from plone.restapi.search.handler import SearchHandler
 from plone.restapi.search.utils import unflatten_dotted_dict
 from plone.restapi.services import Service
@@ -7,5 +8,7 @@ from plone.restapi.services import Service
 class SearchGet(Service):
     def reply(self):
         query = self.request.form.copy()
+
         query = unflatten_dotted_dict(query)
+
         return SearchHandler(self.context, self.request).search(query)

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -158,7 +158,9 @@ class TestSearchFunctional(unittest.TestCase):
         if "virtual_hosting" not in self.app.objectIds():
             # If ZopeLite was imported, we have no default virtual
             # host monster
-            from Products.SiteAccess.VirtualHostMonster import manage_addVirtualHostMonster
+            from Products.SiteAccess.VirtualHostMonster import (
+                manage_addVirtualHostMonster,
+            )
 
             manage_addVirtualHostMonster(self.app, "virtual_hosting")
         transaction.commit()
@@ -184,7 +186,9 @@ class TestSearchFunctional(unittest.TestCase):
         if "virtual_hosting" not in self.app.objectIds():
             # If ZopeLite was imported, we have no default virtual
             # host monster
-            from Products.SiteAccess.VirtualHostMonster import manage_addVirtualHostMonster
+            from Products.SiteAccess.VirtualHostMonster import (
+                manage_addVirtualHostMonster,
+            )
 
             manage_addVirtualHostMonster(self.app, "virtual_hosting")
         transaction.commit()

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -17,6 +17,7 @@ from plone.uuid.interfaces import IMutableUUID
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
 
 import six
 import transaction
@@ -716,27 +717,16 @@ class TestSearchFunctional(unittest.TestCase):
     def test_search_use_site_search_settings_with_navigation_root(self):
 
         alsoProvides(self.folder, INavigationRoot)
+        transaction.commit()
 
         response = self.api_session.get(
             "/folder/@search", params={"use_site_search_settings": 1}
         ).json()
-        titles = [
-            u"Some Folder",
-            u"Lorem Ipsum",
-            u"Other Document",
-            u"Another Folder",
-            u"Document in second folder",
-            u"Doc outside folder",
-        ]
+        titles = [u"Some Folder", u"Lorem Ipsum", u"Other Document"]
         self.assertEqual([item["title"] for item in response["items"]], titles)
 
-        response = self.api_session.get(
-            "/@search", params={"use_site_search_settings": 1, "sort_on": "effective"}
-        ).json()
-        self.assertEqual(
-            [item["title"] for item in response["items"]][0],
-            u"Other Document",
-        )
+        noLongerProvides(self.folder, INavigationRoot)
+        transaction.commit()
 
 
 class TestSearchATFunctional(unittest.TestCase):


### PR DESCRIPTION
The `@search` endpoint can now follow Plone's settings if a `use_site_search_settings` parameter is passed in the request.

This means that the types will be filtered, the navigation root will be respected and the default sort order will be used.