### PR TITLE
fix sort_order in querystring-search api

### DIFF
--- a/src/plone/restapi/services/querystringsearch/get.py
+++ b/src/plone/restapi/services/querystringsearch/get.py
@@ -31,7 +31,7 @@ class QuerystringSearchPost(Service):
             raise Exception("No query supplied")
 
         if sort_order:
-            sort_order = "descending" if sort_order else "ascending"
+            sort_order = "descending" if sort_order == "descending" else "ascending"
 
         querybuilder = getMultiAdapter(
             (self.context, self.request), name="querybuilderresults"

--- a/src/plone/restapi/tests/test_services_querystringsearch.py
+++ b/src/plone/restapi/tests/test_services_querystringsearch.py
@@ -167,3 +167,98 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
             response.json()["items"][0]["@id"],
             "{}/testdocument2".format(self.portal.absolute_url()),
         )
+
+    def test_querystringsearch_sort(self):
+        # id: testdocument1, title: M Test Document 1
+        # id: testdocument2, title: L Test Document 2
+        # ...
+        for a in range(1, 10):
+            self.portal.invokeFactory(
+                "Document", "testdocument" + str(a),
+                title=chr(ord('M') - a + 1) + " Test Document " + str(a)
+            )
+            self.doc = self.portal.testdocument
+
+        transaction.commit()
+
+        query = [
+            {
+                "i": "portal_type",
+                "o": "plone.app.querystring.operation.selection.is",
+                "v": ["Document"],
+            }
+        ]
+        # default order 'ascending'
+        response = self.api_session.post(
+            "/testdocument/@querystring-search",
+            json={
+                "query": query,
+                "sort_on": "sortable_title",
+            },
+        )
+        self.assertEqual(response.json()["items_total"], 9)
+        self.assertEqual(
+            response.json()["items"][-1]["@id"],
+            "{}/testdocument1".format(self.portal.absolute_url()),
+        )
+        self.assertEqual(
+            response.json()["items"][0]["@id"],
+            "{}/testdocument9".format(self.portal.absolute_url()),
+        )
+
+        # force order 'ascending'
+        response = self.api_session.post(
+            "/testdocument/@querystring-search",
+            json={
+                "query": query,
+                "sort_on": "sortable_title",
+                "sort_order": "ascending",
+            },
+        )
+        self.assertEqual(response.json()["items_total"], 9)
+        self.assertEqual(
+            response.json()["items"][-1]["@id"],
+            "{}/testdocument1".format(self.portal.absolute_url()),
+        )
+        self.assertEqual(
+            response.json()["items"][0]["@id"],
+            "{}/testdocument9".format(self.portal.absolute_url()),
+        )
+
+        # force order 'descending'
+        response = self.api_session.post(
+            "/testdocument/@querystring-search",
+            json={
+                "query": query,
+                "sort_on": "sortable_title",
+                "sort_order": "descending",
+            },
+        )
+        self.assertEqual(response.json()["items_total"], 9)
+        self.assertEqual(
+            response.json()["items"][0]["@id"],
+            "{}/testdocument1".format(self.portal.absolute_url()),
+        )
+        self.assertEqual(
+            response.json()["items"][-1]["@id"],
+            "{}/testdocument9".format(self.portal.absolute_url()),
+        )
+
+        # sort by id, 'ascending'
+        response = self.api_session.post(
+            "/testdocument/@querystring-search",
+            json={
+                "query": query,
+                "sort_on": "getId",
+                "sort_order": "ascending",
+            },
+        )
+        self.assertEqual(response.json()["items_total"], 9)
+        self.assertEqual(
+            response.json()["items"][0]["@id"],
+            "{}/testdocument1".format(self.portal.absolute_url()),
+        )
+        self.assertEqual(
+            response.json()["items"][-1]["@id"],
+            "{}/testdocument9".format(self.portal.absolute_url()),
+        )


### PR DESCRIPTION
Currently, if you set a value for sort_order, any value, even "ascending", the API returns the sorted items "descending". This tries to fix it and test it. 