### PR TITLE
Fix `@history` when full history is empty.

### DIFF
--- a/news/1113.bugfix
+++ b/news/1113.bugfix
@@ -1,0 +1,2 @@
+Fix ``@history`` when full history is empty.
+[deiferni]

--- a/src/plone/restapi/services/history/get.py
+++ b/src/plone/restapi/services/history/get.py
@@ -40,6 +40,8 @@ class HistoryGet(Service):
         content_history_viewlet.navigation_root_url = site_url
         content_history_viewlet.site_url = site_url
         history = content_history_viewlet.fullHistory()
+        if history is None:
+            history = []
 
         unwanted_keys = [
             "diff_current_url",


### PR DESCRIPTION
The re-used viewlet returns `None` in its `fullHistory` when there is no (visible) workflow history and when there is no (visible) revision history.

We did not take this into account and always attempt to iterate the returned value, which will fail for `None` for obvious reasons.

I'm adding a simple fix for the issue by initializing the value to an empty list in such cases.

Fixes #1113