### PR TITLE
Drop support for Python 2 and Plone 5.1 and 4.3.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,27 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.7, 3.6, 2.7]
-        plone-version: [5.2, 5.1, 4.3]
-        exclude:
-          - python-version: 3.6
-            plone-version: 4.3
-          - python-version: 3.6
-            plone-version: 5.0
-          - python-version: 3.6
-            plone-version: 5.1
-          - python-version: 3.7
-            plone-version: 4.3
-          - python-version: 3.7
-            plone-version: 5.0
-          - python-version: 3.7
-            plone-version: 5.1
-          - python-version: 3.8
-            plone-version: 4.3
-          - python-version: 3.8
-            plone-version: 5.0
-          - python-version: 3.8
-            plone-version: 5.1
+        python-version: [3.8, 3.7, 3.6]
+        plone-version: [5.2]
 
     steps:
       # git checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.7, 3.6]
+        python-version: [3.9, 3.8, 3.7, 3.6]
         plone-version: [5.2]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.8, 3.7, 3.6]
+        python-version: [3.8, 3.7, 3.6]
         plone-version: [5.2]
 
     steps:

--- a/news/1121.breaking
+++ b/news/1121.breaking
@@ -1,0 +1,2 @@
+- Drop support for Python 2 and Plone 5.1 and 4.3. Plone RESTAPI >= 8 supports Python 3 and Plone 5.2/6.x only.
+ [timo]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[bdist_wheel]
+# Do not make the generated wheels have `py3` tag
+# See https://packaging.python.org/guides/dropping-older-python-versions/#dealing-with-the-universal-wheels
+universal = 0 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 from setuptools import setup, find_packages
+import sys
 
 version = "7.3.6.dev0"
 
+assert sys.version_info >= (3, 6, 0), "plone.restapi requires Python 3.6.0+"
 
 def read(filename):
     with open(filename) as myfile:
@@ -57,15 +59,11 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: 4.3",
-        "Framework :: Plone :: 5.0",
-        "Framework :: Plone :: 5.1",
         "Framework :: Plone :: 5.2",
         "Framework :: Plone :: Core",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     keywords="plone rest restful hypermedia api json",

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ version = "7.3.6.dev0"
 
 assert sys.version_info >= (3, 6, 0), "plone.restapi requires Python 3.6.0+"
 
+
 def read(filename):
     with open(filename) as myfile:
         try:
@@ -79,6 +80,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     namespace_packages=["plone"],
+    python_requires=">=3.6.0",
     include_package_data=True,
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
https://packaging.python.org/guides/dropping-older-python-versions/