### PR TITLE
Pinn check-manifest = 0.4.1 in Python 2

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -14,6 +14,7 @@ Pygments = 2.5.1
 plone.recipe.varnish = 1.3
 
 # Code-analysis
+check-manifest = 0.41
 plone.recipe.codeanalysis = 3.0.1
 coverage = 3.7.1
 pep8 = 1.7.1


### PR DESCRIPTION
This is the latest version compatible with Python 2. See:

https://github.com/mgedmin/check-manifest/blob/920816f6fd9c1c4d21f8322398f493d544ae6f76/setup.py#L47

This also fix the error:

```bash
Version and requirements information containing toml:
  [versions] constraint on toml: 0.9.6
While:
  Requirement of check-manifest: toml
  Installing.
  Requirement of build>=0.1: toml>=0.10.0
  Getting section code-analysis.
  Initializing section code-analysis.
  Installing recipe plone.recipe.codeanalysis.
Error: The requirement ('toml>=0.10.0') is not allowed by your [versions] constraint (0.9.6)
```

in Plone 5.1.

Fix: https://github.com/plone/plone.restapi/runs/2656778250?check_suite_focus=true