### PR TITLE
Cleanup/Update pas plugin

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -100,7 +100,6 @@ flake8-ignore = E203, E266, E501, W503, E231
 flake8-max-line-length = 200
 # flake8-select = B,C,E,F,W,T4,B9
 flake8-extensions =
-    flake8-coding
     flake8-debugger
     flake8-print
 #    flake8-isort

--- a/news/1152.bugfix
+++ b/news/1152.bugfix
@@ -1,0 +1,8 @@
+Cleanup and Update of the of the JWT PAS plugin: 
+use Security decorators; 
+increase readability/simplify code;
+remove six in pas module;
+update ZMI-zpt to match Zope4/BS4;
+use f-strings;
+remove strange `return None`;
+do not require a coding magic line, UTF-8 is default in Python 3, so it does not need to be declared.

--- a/src/plone/restapi/pas/add_plugin.zpt
+++ b/src/plone/restapi/pas/add_plugin.zpt
@@ -1,33 +1,36 @@
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:tal="http://xml.zope.org/namespaces/tal">
-  <body>
-    <h1 tal:replace="structure here/manage_page_header">Header</h1>
+<h1 tal:replace="structure here/manage_page_header">Header</h1>
 
-    <h2 tal:define="form_title string:JWT Authentication Plugin"
-        tal:replace="structure here/manage_form_title">Form Title</h2>
+<main class="container-fluid">
+
+  <h2 tal:define="form_title string:Add JWT Authentication Plugin"
+      tal:replace="structure here/manage_form_title">Form Title</h2>
 
     <p class="form-help">
-      Plone PAS plugin for authentication with JSON web tokens (JWT)
+      Plone PAS plugin for authentication with JSON web tokens (JWT).
     </p>
 
-    <form action="addJWTAuthenticationPlugin" method="post">
-      <table>
-        <tr>
-          <td class="form-label">Id</td>
-          <td><input type="text" name="id_" tal:attributes="value request/id|string:jwt_auth"/></td>
-        </tr>
-        <tr>
-          <td class="form-label">Title</td>
-          <td><input type="text" name="title"/></td>
-        </tr>
-        <tr>
-          <td colspan="2">
-            <div class="form-element">
-              <input type="submit" value="Add"/>
-            </div>
-          </td>
-        </tr>
-      </table>
-    </form>
-  </body>
-</html>
+    <form action="addJWTAuthenticationPlugin" method="post" enctype="multipart/form-data">
+
+      <div class="form-group row">
+        <label for="id_" class="form-label col-sm-3 col-md-2">Id</label>
+        <div class="col-sm-9 col-md-10">
+          <input id="id_" name="id" class="form-control" type="text" tal:attributes="value request/id|string:jwt_auth" />
+        </div>
+      </div>
+
+      <div class="form-group row form-optional">
+        <label for="title" class="form-label col-sm-3 col-md-2">Title</label>
+        <div class="col-sm-9 col-md-10">
+          <input id="title" name="title" class="form-control" type="text" tal:attributes="value request/title|string:JWT Authentication" />
+        </div>
+      </div>
+
+      <div class="zmi-controls">
+        <input class="btn btn-primary" type="submit" name="submit" value="Add" />
+      </div>
+
+  </form>
+
+</main>
+
+<h1 tal:replace="structure here/manage_page_footer">Footer</h1>

--- a/src/plone/restapi/pas/config.zpt
+++ b/src/plone/restapi/pas/config.zpt
@@ -1,13 +1,12 @@
 <h1 tal:replace="structure here/manage_page_header"> PAGE HEADER </h1>
-<h2 tal:replace="structure here/manage_tabs"> PAGE HEADER </h2>
+<h2 tal:define="global manage_tabs_message request/manage_tabs_message | nothing;
+                form_title string:JWT Authentication"
+    tal:replace="structure here/manage_tabs"> TABS </h2>
 
 <main class="container-fluid">
-  <h1>JWT Authentication</h1>
-
-  <p class="lead">
-    Plone PAS plugin for authentication with JSON web tokens (JWT).
+  <p class="form-help">
+    Choose the functionality this Plone JWT Authentication Plugin will perform.
   </p>
-
   <form action="manage_updateConfig" method="post">
     <div class="form-group">
       <label class="form-label" for="token_timeout">Token Validity Timeout (in seconds)</label>
@@ -41,7 +40,9 @@
         <small class="form-text text-muted">By default tokens are not stored on the server and thus can't be invalidated. If enabled, tokens that don't expire can be invalidated.</small>
       </div>
     </div>
-    <button class="btn btn-primary" type="submit">Update</button>
+    <div class="zmi-controls">
+      <button class="btn btn-primary" type="submit">Update</button>
+    </div>
   </form>
 
 </main>

--- a/src/plone/restapi/pas/config.zpt
+++ b/src/plone/restapi/pas/config.zpt
@@ -1,47 +1,49 @@
 <h1 tal:replace="structure here/manage_page_header"> PAGE HEADER </h1>
 <h2 tal:replace="structure here/manage_tabs"> PAGE HEADER </h2>
 
-<h3>JWT Authentication</h3>
+<main class="container-fluid">
+  <h1>JWT Authentication</h1>
 
-    <p class="form-help">
-      Plone PAS plugin for authentication with JSON web tokens (JWT).
-    </p>
+  <p class="lead">
+    Plone PAS plugin for authentication with JSON web tokens (JWT).
+  </p>
 
-    <form action="manage_updateConfig" method="post">
-      <table>
-        <tr valign="top">
-          <td><div class="form-label">Token Validity Timeout (in seconds)</div>
-          <div class="form-help">After this, the token is invalid and the user
-          must login again. Set to 0 for the token to remain valid indefinitely.</div>
-          </td>
-          <td><input type="text" name="token_timeout"
-                     tal:attributes="value context/token_timeout|nothing"/></td>
-        </tr>
-        <tr>
-          <td align="left" valign="top">
-            <input type="checkbox" name="use_keyring" id="use-keyring"
-                   tal:attributes="checked python: context.use_keyring and 'checked'"/>&nbsp;<label class="form-label" for="use-keyring">Use Keyring</label>
-            <div class="form-help">If enabled, tokens are signed with a secret from
-            Plone's keyring. If you want tokens that remain valid indefinitely you should disable this.</div>
-          </td>
-        </tr>
-        <tr>
-          <td align="left" valign="top">
-            <input type="checkbox" name="store_tokens" id="store-tokens"
-                   tal:attributes="checked python: context.store_tokens and 'checked'"/>&nbsp;<label class="form-label" for="store-tokens">Store tokens</label>
-            <div class="form-help">By default tokens are not stored on the server and
-            thus can't be invalidated. If enabled, tokens that don't expire can be invalidated.</div>
-          </td>
-        </tr>
-        <tr>
-          <td colspan="2">
-            <div class="form-element">
-              <input type="submit" value="Update"/>
-            </div>
-          </td>
-        </tr>
-      </table>
-    </form>
+  <form action="manage_updateConfig" method="post">
+    <div class="form-group">
+      <label class="form-label" for="token_timeout">Token Validity Timeout (in seconds)</label>
+      <input type="text"       
+             name="token_timeout"
+             class="form-control"
+             tal:attributes="value context/token_timeout|nothing"/>
+      <small class="form-text text-muted">After this, the token is invalid and the user must login again. Set to 0 for the token to remain valid indefinitely.</small>
+    </div>
+    
+    <div class="form-group">
+      <div class="form-check">
+        <input class="form-check-input" 
+               type="checkbox" value="" 
+               name="use_keyring" 
+               id="use_keyring" 
+               tal:attributes="checked python: context.use_keyring and 'checked'">
+        <label class="form-check-label" for="use_keyring">Use Keyring</label>
+        <small class="form-text text-muted">If enabled, tokens are signed with a secret from Plone's keyring. If you want tokens that remain valid indefinitely you should disable this.</small>
+      </div>
+    </div>
 
+    <div class="form-group">
+      <div class="form-check">
+        <input class="form-check-input" 
+               type="checkbox" value="" 
+               name="store_tokens" 
+               id="store_tokens" 
+               tal:attributes="checked python: context.store_tokens and 'checked'">
+        <label class="form-check-label" for="store_tokens">Store tokens</label>
+        <small class="form-text text-muted">By default tokens are not stored on the server and thus can't be invalidated. If enabled, tokens that don't expire can be invalidated.</small>
+      </div>
+    </div>
+    <button class="btn btn-primary" type="submit">Update</button>
+  </form>
 
-<h1 tal:replace="structure here/manage_page_footer"> PAGE FOOTER </h1>
+</main>
+
+<h2 tal:replace="structure here/manage_page_footer"> PAGE FOOTER </h2>

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -65,24 +65,21 @@ class JWTAuthenticationPlugin(BasePlugin):
         self._setId(id_)
         self.title = title
 
-    security.declarePrivate("challenge")
 
     # Initiate a challenge to the user to provide credentials.
+    @security.private
     def challenge(self, request, response, **kw):
-
         realm = response.realm
         if realm:
             response.setHeader("WWW-Authenticate", 'Bearer realm="%s"' % realm)
-        m = "You are not authorized to access this resource."
-
-        response.setBody(m, is_error=1)
+        response.setBody("You are not authorized to access this resource.", is_error=1)
         response.setStatus(401)
         return True
 
-    security.declarePrivate("extractCredentials")
 
     # IExtractionPlugin implementation
     # Extracts a JSON web token from the request.
+    @security.private
     def extractCredentials(self, request):
         """
         Extract credentials either from a JSON POST request or an established JWT token.
@@ -109,9 +106,9 @@ class JWTAuthenticationPlugin(BasePlugin):
 
         return creds
 
-    security.declarePrivate("authenticateCredentials")
 
     # IAuthenticationPlugin implementation
+    @security.private
     def authenticateCredentials(self, credentials):
         # Ignore credentials that are not from our extractor
         extractor = credentials.get("extractor")
@@ -137,8 +134,8 @@ class JWTAuthenticationPlugin(BasePlugin):
 
         return (userid, userid)
 
-    security.declareProtected(ManagePortal, "manage_updateConfig")
 
+    @security.protected(ManagePortal)
     @postonly
     def manage_updateConfig(self, REQUEST):
         """Update configuration of JWT Authentication Plugin."""


### PR DESCRIPTION
- security decorators
- increase readability/simplify code
- remove six in pas module
- update ZMI-zpt to match Zope4/BS4
- f-strings
- remove return None madness ;)
- do not require a coding magic line, UTF-8 is default in Python 3, so it does not need to be declared.