### PR TITLE
Eliminate non-pythonic 'return None' usage

### DIFF
--- a/news/1158.bugfix
+++ b/news/1158.bugfix
@@ -1,0 +1,1 @@
+Eliminate non-pythonic 'return None' usage. [jensens]

--- a/src/plone/restapi/batching.py
+++ b/src/plone/restapi/batching.py
@@ -64,7 +64,7 @@ class HypermediaBatch(object):
         """Get a dictionary with batching links."""
         # Don't provide batching links if resultset isn't batched
         if self.items_total <= self.b_size:
-            return None
+            return
 
         links = {}
 

--- a/src/plone/restapi/deserializer/mixins.py
+++ b/src/plone/restapi/deserializer/mixins.py
@@ -83,8 +83,7 @@ class OrderingMixin(object):
     def getOrdering(self):
         if IPloneSiteRoot.providedBy(self.context):
             return self.context
-        elif getattr(self.context, "getOrdering", None):
+        if getattr(self.context, "getOrdering", None):
             ordering = self.context.getOrdering()
-            if not IExplicitOrdering.providedBy(ordering):
-                return None
-            return ordering
+            if IExplicitOrdering.providedBy(ordering):
+                return ordering

--- a/src/plone/restapi/imaging.py
+++ b/src/plone/restapi/imaging.py
@@ -47,11 +47,9 @@ def get_original_image_url(context, fieldname, width, height):
     scale = images_view.scale(
         fieldname, width=width, height=height, direction="thumbnail"
     )
-    if not scale:
-        # This might happen for corrupt images.
-        return None
-
-    return scale.url
+    if scale:
+        return scale.url
+    # Corrupt images may not have a scale.
 
 
 def get_actual_scale(dimensions, bbox):

--- a/src/plone/restapi/indexers.py
+++ b/src/plone/restapi/indexers.py
@@ -96,7 +96,7 @@ class SlateTextIndexer(object):
         block = block or {}
 
         if block.get("searchableText"):
-            return None
+            return
 
         # BBB compatibility with slate blocks that used the "plaintext" field
         return (block or {}).get("plaintext", "")

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -101,13 +101,10 @@ class JWTAuthenticationPlugin(BasePlugin):
         creds = {}
         auth = request._auth
         if auth is None:
-            return None
+            return
         if auth[:7].lower() == "bearer ":
             creds["token"] = auth.split()[-1]
-        else:
-            return None
-
-        return creds
+            return creds
 
     security.declarePrivate("authenticateCredentials")
 
@@ -116,14 +113,14 @@ class JWTAuthenticationPlugin(BasePlugin):
         # Ignore credentials that are not from our extractor
         extractor = credentials.get("extractor")
         if extractor != self.getId():
-            return None
+            return
 
         payload = self._decode_token(credentials["token"])
         if not payload:
-            return None
+            return
 
         if "sub" not in payload:
-            return None
+            return
 
         userid = payload["sub"]
         if six.PY2:
@@ -131,9 +128,9 @@ class JWTAuthenticationPlugin(BasePlugin):
 
         if self.store_tokens:
             if userid not in self._tokens:
-                return None
+                return
             if credentials["token"] not in self._tokens[userid]:
-                return None
+                return
 
         return (userid, userid)
 
@@ -173,7 +170,7 @@ class JWTAuthenticationPlugin(BasePlugin):
         try:
             return jwt.decode(token, secret, verify=verify, algorithms=["HS256"])
         except jwt.InvalidTokenError:
-            return None
+            pass
 
     def _signing_secret(self):
         if self.use_keyring:

--- a/src/plone/restapi/serializer/converters.py
+++ b/src/plone/restapi/serializer/converters.py
@@ -204,4 +204,4 @@ def i18n_message_converter(value):
 @adapter(Missing.Value.__class__)
 @implementer(IJsonCompatible)
 def missing_value_converter(value):
-    return None
+    pass

--- a/src/plone/restapi/serializer/discussion.py
+++ b/src/plone/restapi/serializer/discussion.py
@@ -92,9 +92,9 @@ class CommentSerializer(object):
 
     def get_author_image(self, username=None):
         if username is None:
-            return None
+            return
         portal_membership = getToolByName(self.context, "portal_membership", None)
         image = portal_membership.getPersonalPortrait(username).absolute_url()
         if image.endswith("defaultUser.png"):
-            return None
+            return
         return image

--- a/src/plone/restapi/serializer/dxfields.py
+++ b/src/plone/restapi/serializer/dxfields.py
@@ -92,7 +92,7 @@ class ImageFieldSerializer(DefaultFieldSerializer):
     def __call__(self):
         image = self.field.get(self.context)
         if not image:
-            return None
+            return
 
         width, height = image.getImageSize()
 
@@ -116,7 +116,7 @@ class FileFieldSerializer(DefaultFieldSerializer):
     def __call__(self):
         namedfile = self.field.get(self.context)
         if namedfile is None:
-            return None
+            return
 
         url = "/".join((self.context.absolute_url(), "@@download", self.field.__name__))
         result = {

--- a/src/plone/restapi/services/addons/post.py
+++ b/src/plone/restapi/services/addons/post.py
@@ -62,6 +62,4 @@ class AddonsPost(Service):
 
             self.request.response.setStatus(200)
             return result
-        else:
-            self.request.response.setStatus(204)
-            return None
+        self.request.response.setStatus(204)

--- a/src/plone/restapi/services/auth/login.py
+++ b/src/plone/restapi/services/auth/login.py
@@ -101,7 +101,6 @@ class Login(Service):
 
         if info:
             return uf
-        return None
 
     def check_permission(self):
-        return
+        pass

--- a/src/plone/restapi/services/content/tus.py
+++ b/src/plone/restapi/services/content/tus.py
@@ -142,12 +142,12 @@ class UploadFileBase(TUSBaseService):
 
     def tus_upload(self):
         if self.uid is None:
-            return None
+            return
 
         tus_upload = TUSUpload(self.uid)
         length = tus_upload.length()
         if length == 0:
-            return None
+            return
 
         return tus_upload
 

--- a/src/plone/restapi/services/contextnavigation/get.py
+++ b/src/plone/restapi/services/contextnavigation/get.py
@@ -248,7 +248,7 @@ class NavigationPortletRenderer(object):
 
         # Root content item gone away or similar issue
         if not nav_root:
-            return None
+            return
 
         if INavigationRoot.providedBy(nav_root) or ISiteRoot.providedBy(nav_root):
             # For top level folders go to the sitemap
@@ -312,7 +312,7 @@ class NavigationPortletRenderer(object):
         portal = self.urltool.getPortalObject()
         rootPath = self.getNavRootPath()
         if rootPath is None:
-            return None
+            return
 
         if rootPath == self.urltool.getPortalPath():
             return portal
@@ -347,13 +347,13 @@ class NavigationPortletRenderer(object):
         """
         if getattr(self.data, "no_thumbs", False):
             # Individual setting overrides
-            return None
+            return
         thsize = getattr(self.data, "thumb_scale", None)
         if thsize:
             return thsize
 
         if IS_PLONE4:
-            return None  # no support in Plone 4 to override the thumb scale
+            return  # no support in Plone 4 to override the thumb scale
         else:
             registry = getUtility(IRegistry)
             settings = registry.forInterface(ISiteSchema, prefix="plone", check=False)
@@ -365,7 +365,7 @@ class NavigationPortletRenderer(object):
     def getMimeTypeIcon(self, node):
         try:
             if not node["normalized_portal_type"] == "file":
-                return None
+                return
             fileo = node["item"].getObject().file
             portal_url = getNavigationRoot(self.context)
             mtt = getToolByName(self.context, "mimetypes_registry")
@@ -373,8 +373,7 @@ class NavigationPortletRenderer(object):
                 ctype = mtt.lookup(fileo.contentType)
                 return os.path.join(portal_url, guess_icon_path(ctype[0]))
         except AttributeError:
-            return None
-        return None
+            pass
 
     def render(self):
         res = {
@@ -507,7 +506,7 @@ class NavigationPortletRenderer(object):
 
 def get_url(item):
     if not item:
-        return None
+        return
 
     if hasattr(aq_base(item), "getURL"):
         # Looks like a brain
@@ -519,7 +518,7 @@ def get_url(item):
 
 def get_id(item):
     if not item:
-        return None
+        return
     getId = getattr(item, "getId")
 
     if not utils.safe_callable(getId):
@@ -583,15 +582,15 @@ def getRootPath(context, currentFolderOnly, topLevel, root_path):
     if topLevel > 0:
         contextPath = "/".join(context.getPhysicalPath())
         if not contextPath.startswith(rootPath):
-            return None
+            return
         contextSubPathElements = contextPath[len(rootPath) + 1 :]
         if contextSubPathElements:
             contextSubPathElements = contextSubPathElements.split("/")
             if len(contextSubPathElements) < topLevel:
-                return None
+                return
             rootPath = rootPath + "/" + "/".join(contextSubPathElements[:topLevel])
         else:
-            return None
+            return
 
     return rootPath
 
@@ -619,7 +618,7 @@ def extract_data(schema, raw_data, prefix):
 
 def get_root(context, root_path):
     if root_path is None:
-        return None
+        return
 
     urltool = getToolByName(context, "portal_url")
     portal = urltool.getPortalObject()

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -94,10 +94,10 @@ class DefaultJsonSchemaProvider(object):
         raise NotImplementedError
 
     def get_factory(self):
-        return None
+        pass
 
     def get_widget(self):
-        return None
+        pass
 
     def get_widget_params(self):
         all_params = get_widget_params([self.field.interface])


### PR DESCRIPTION
Sorry, it hurts my eyes. So, be more pythonic and just return, pass or drop it and end of method/function.