### PR TITLE
Fix startup on Plone 4 without plone.app.contenttypes.

### DIFF
--- a/news/1166.bugfix
+++ b/news/1166.bugfix
@@ -1,0 +1,2 @@
+Fix startup on Plone 4 without plone.app.contenttypes.
+[maurits]

--- a/src/plone/restapi/deserializer/configure.zcml
+++ b/src/plone/restapi/deserializer/configure.zcml
@@ -12,12 +12,15 @@
   <adapter factory=".dxfields.CollectionFieldDeserializer" />
   <adapter factory=".dxfields.DictFieldDeserializer" />
   <adapter factory=".dxfields.TextLineFieldDeserializer" />
-  <adapter factory=".dxfields.LinkTextLineFieldDeserializer" />
   <adapter factory=".dxfields.TimeFieldDeserializer" />
   <adapter factory=".dxfields.TimedeltaFieldDeserializer" />
   <adapter factory=".dxfields.NamedFieldDeserializer" />
   <adapter factory=".dxfields.RichTextFieldDeserializer" />
   <adapter factory=".blocks.BlocksJSONFieldDeserializer" />
+
+  <configure zcml:condition="installed plone.app.contenttypes">
+    <adapter factory=".dxfields.LinkTextLineFieldDeserializer" />
+  </configure>
 
   <subscriber factory=".blocks.TextBlockDeserializer"
     provides="plone.restapi.interfaces.IBlockFieldDeserializationTransformer"/>

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -11,6 +11,7 @@
 
     <configure zcml:condition="installed plone.app.contenttypes">
         <adapter factory=".collection.SerializeCollectionToJson" />
+        <adapter factory=".dxfields.TextLineFieldSerializer" />
     </configure>
 
     <adapter factory=".summary.DefaultJSONSummarySerializer" />
@@ -24,7 +25,6 @@
     <adapter factory=".dxfields.RichttextFieldSerializer" />
     <adapter factory=".dxfields.DefaultPrimaryFieldTarget" />
     <adapter factory=".dxfields.PrimaryFileFieldTarget" />
-    <adapter factory=".dxfields.TextLineFieldSerializer" />
 
     <adapter factory=".blocks.BlocksJSONFieldSerializer" />
     <subscriber factory=".blocks.TextBlockSerializer"


### PR DESCRIPTION
plone.restapi 7.0.0b2 introduced a serializer/deserializer for remoteUrl Link's field, in PR #1005.
This introduced an undeclared dependency on plone.app.contenttypes.
Solution: use conditional imports and use zcml:condition to register the serializer and deserializer.

Use case: collective.exportimport on Plone 4 loads `serializers/dxfields.py` and this fails without plone.app.contenttypes.