### PR TITLE
Set UID of a content during creation

### DIFF
--- a/docs/source/content.rst
+++ b/docs/source/content.rst
@@ -31,6 +31,8 @@ The 'Content-Type' header indicates that the body uses the 'application/json' fo
 The request body contains the minimal necessary information needed to create a document (the type and the title).
 You could set other properties, like "description" here as well.
 
+A special property during content creation is "UID", as it requires the user to have the *Manage Portal* permission to set it. Without the permission, the request will fail as Unauthorized.
+
 
 Successful Response (201 Created)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/news/497.feature
+++ b/news/497.feature
@@ -1,0 +1,2 @@
+Set UID of a content during creation if the user has Manage Portal permission.
+[ericof]

--- a/src/plone/restapi/services/content/add.py
+++ b/src/plone/restapi/services/content/add.py
@@ -1,3 +1,4 @@
+from AccessControl import getSecurityManager
 from Acquisition import aq_base
 from Acquisition.interfaces import IAcquirer
 from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
@@ -9,6 +10,8 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from plone.restapi.services.content.utils import add
 from plone.restapi.services.content.utils import create
+from Products.CMFCore.permissions import ManagePortal
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_hasattr
 from zExceptions import BadRequest
 from zExceptions import Unauthorized
@@ -17,7 +20,6 @@ from zope.event import notify
 from zope.interface import alsoProvides
 from zope.lifecycleevent import ObjectCreatedEvent
 from zope.component import getMultiAdapter
-from Products.CMFCore.utils import getToolByName
 
 import plone.protect.interfaces
 
@@ -33,6 +35,7 @@ class FolderPost(Service):
         title = data.get("title", None)
         translation_of = data.get("translation_of", None)
         language = data.get("language", None)
+        uid = data.get("UID", None)
 
         if not type_:
             raise BadRequest("Property '@type' is required")
@@ -73,6 +76,11 @@ class FolderPost(Service):
 
         if temporarily_wrapped:
             obj = aq_base(obj)
+
+        # ManagePortal is required to set the uid of an object during creation
+        sm = getSecurityManager()
+        if uid and sm.checkPermission(ManagePortal, self.context):
+            setattr(obj, "_plone.uuid", uid)
 
         if not getattr(deserializer, "notifies_create", False):
             notify(ObjectCreatedEvent(obj))

--- a/src/plone/restapi/tests/test_content_post.py
+++ b/src/plone/restapi/tests/test_content_post.py
@@ -232,5 +232,8 @@ class TestFolderCreate(unittest.TestCase):
                 "UID": "a9597fcb108c4985a713329311bdcca0",
             },
         )
-        self.assertEqual(201, response.status_code)
-        self.assertNotEqual(response.json()["UID"], "a9597fcb108c4985a713329311bdcca0")
+        self.assertEqual(403, response.status_code)
+        self.assertEqual(
+            response.json()["error"]["message"],
+            "Setting UID of an object requires Manage Portal permission",
+        )

--- a/src/plone/restapi/tests/test_content_post.py
+++ b/src/plone/restapi/tests/test_content_post.py
@@ -201,3 +201,36 @@ class TestFolderCreate(unittest.TestCase):
             "<p>example with '</p>", self.portal.folder1.mydocument2.text.raw
         )
         self.assertEqual("<p>example with '</p>", response.json()["text"]["data"])
+
+    def test_post_with_uid_with_manage_portal_permission(self):
+        response = requests.post(
+            self.portal.folder1.absolute_url(),
+            headers={"Accept": "application/json"},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            json={
+                "@type": "Document",
+                "title": "My Document",
+                "UID": "a9597fcb108c4985a713329311bdcca0"
+            },
+        )
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(response.json()["UID"], "a9597fcb108c4985a713329311bdcca0")
+
+    def test_post_with_uid_without_manage_portal_permission(self):
+        user = "test-user-2"
+        password = "secret"
+        self.portal.acl_users.userFolderAddUser(user, password, ["Contributor"], [])
+        transaction.commit()
+
+        response = requests.post(
+            self.portal.folder1.absolute_url(),
+            headers={"Accept": "application/json"},
+            auth=(user, password),
+            json={
+                "@type": "Document",
+                "title": "My Document",
+                "UID": "a9597fcb108c4985a713329311bdcca0"
+            },
+        )
+        self.assertEqual(201, response.status_code)
+        self.assertNotEqual(response.json()["UID"], "a9597fcb108c4985a713329311bdcca0")

--- a/src/plone/restapi/tests/test_content_post.py
+++ b/src/plone/restapi/tests/test_content_post.py
@@ -210,7 +210,7 @@ class TestFolderCreate(unittest.TestCase):
             json={
                 "@type": "Document",
                 "title": "My Document",
-                "UID": "a9597fcb108c4985a713329311bdcca0"
+                "UID": "a9597fcb108c4985a713329311bdcca0",
             },
         )
         self.assertEqual(201, response.status_code)
@@ -229,7 +229,7 @@ class TestFolderCreate(unittest.TestCase):
             json={
                 "@type": "Document",
                 "title": "My Document",
-                "UID": "a9597fcb108c4985a713329311bdcca0"
+                "UID": "a9597fcb108c4985a713329311bdcca0",
             },
         )
         self.assertEqual(201, response.status_code)


### PR DESCRIPTION
Allow setting UID of a content during creation if the user has Manage Portal permission.
If the user has no permission, the content is created but UID is not set.