### PR TITLE
Do not break @workflow endpoint for contents without workflow

### DIFF
--- a/news/1184.bugfix
+++ b/news/1184.bugfix
@@ -1,0 +1,1 @@
+Do not break @workflow endpoint for contents without workflow. @cekk

--- a/src/plone/restapi/services/workflow/info.py
+++ b/src/plone/restapi/services/workflow/info.py
@@ -63,7 +63,10 @@ class WorkflowInfo:
                 title = title.decode("utf8")
             history[item]["title"] = self.context.translate(title)
 
-        current_state = wftool.getInfoFor(self.context, "review_state")
+        try:
+            current_state = wftool.getInfoFor(self.context, "review_state")
+        except WorkflowException:
+            current_state = ""
         current_state_title = wftool.getTitleForStateOnType(
             current_state,
             self.context.portal_type,

--- a/src/plone/restapi/tests/test_workflow.py
+++ b/src/plone/restapi/tests/test_workflow.py
@@ -107,6 +107,19 @@ class TestWorkflowInfo(TestCase):
         self.assertEqual(obj["transitions"], [])
         self.assertEqual(obj["history"], [])
 
+    def test_workflow_info_empty_on_content_without_workflow(self):
+        file_content = self.portal[
+            self.portal.invokeFactory("File", id="file", title="File")
+        ]
+
+        wfinfo = getMultiAdapter(
+            (file_content, self.request), name="GET_application_json_@workflow"
+        )
+        obj = wfinfo.reply()
+
+        self.assertEqual(obj["transitions"], [])
+        self.assertEqual(obj["history"], [])
+        self.assertEqual(obj["state"], {"id": "", "title": ""})
 
 class TestWorkflowTransition(TestCase):
 

--- a/src/plone/restapi/tests/test_workflow.py
+++ b/src/plone/restapi/tests/test_workflow.py
@@ -121,6 +121,7 @@ class TestWorkflowInfo(TestCase):
         self.assertEqual(obj["history"], [])
         self.assertEqual(obj["state"], {"id": "", "title": ""})
 
+
 class TestWorkflowTransition(TestCase):
 
     layer = PLONE_RESTAPI_WORKFLOWS_INTEGRATION_TESTING


### PR DESCRIPTION
There was only half checks for no workflow contents (on history)