### PR TITLE
Skip doActionFor for items without workflow

### DIFF
--- a/news/1190.bugfix
+++ b/news/1190.bugfix
@@ -1,0 +1,1 @@
+Do not break @workflow endpoint when trying to change the state of a content without workflow [cekk]

--- a/src/plone/restapi/services/workflow/transition.py
+++ b/src/plone/restapi/services/workflow/transition.py
@@ -108,7 +108,8 @@ class WorkflowTransition(Service):
             if obj.EffectiveDate() == "None":
                 obj.setEffectiveDate(DateTime())
                 obj.reindexObject()
-
+            if not self.wftool.getWorkflowsFor(obj):
+                continue
             self.wftool.doActionFor(obj, self.transition, comment=comment)
             if include_children and IFolderish.providedBy(obj):
                 self.recurse_transition(

--- a/src/plone/restapi/tests/test_workflow.py
+++ b/src/plone/restapi/tests/test_workflow.py
@@ -233,3 +233,17 @@ class TestWorkflowTransition(TestCase):
 
         self.assertEqual(200, self.request.response.getStatus(), res)
         self.assertEqual("restricted", res["review_state"], res)
+
+    def test_transition_including_children_without_wf(self):
+        folder = self.portal[self.portal.invokeFactory("Folder", id="folder")]
+        folder.invokeFactory("File", id="file", title="File")
+        document = folder[
+            folder.invokeFactory("Document", id="document", title="Document")
+        ]
+
+        self.request["BODY"] = '{"comment": "A comment", "include_children": true}'
+        service = self.traverse("/plone/folder/@workflow/publish")
+        service.reply()
+        self.assertEqual(200, self.request.response.getStatus())
+        self.assertEqual("published", self.wftool.getInfoFor(folder, "review_state"))
+        self.assertEqual("published", self.wftool.getInfoFor(document, "review_state"))


### PR DESCRIPTION
Do not break with a 400 if we are trying to change wf for a content without workflow.

I wanted to fix that on children contents but right now it does not return a 400 also if we try to call this action directly on a content without a workflow. Should we keep the 400 error in this case?