### PR TITLE
Fixes #1193: deprecated JWT decode.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,13 +63,6 @@ Install plone.restapi by adding it to your buildout::
 
 and then running ``bin/buildout``
 
-Usage in Plone 5.2:
-
-- Older plone.restapi 7.x. is part of the Plone 5.2.x release series and works on both Python 2.7 and 3.6 to 3.8.
-- plone.restapi 8.x or later works with Plone 5.2:
-  - if Python 3.6 or later is used and
-  - since plone.restapi 8.9.0 if PyJWT 2.1.0 is used. Set a pin `pyjwt = 2.1.0` in the `[versions]` section of the buildout file. 
-
 
 Contribute
 ==========

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,13 @@ Install plone.restapi by adding it to your buildout::
 
 and then running ``bin/buildout``
 
+Usage in Plone 5.2:
+
+- Older plone.restapi 7.x. is part of the Plone 5.2.x release series and works on both Python 2.7 and 3.6 to 3.8.
+- plone.restapi 8.x or later works with Plone 5.2:
+  - if Python 3.6 or later is used and
+  - since plone.restapi 8.9.0 if PyJWT 2.1.0 is used. Set a pin `pyjwt = 2.1.0` in the `[versions]` section of the buildout file. 
+
 
 Contribute
 ==========

--- a/news/1193.bugfix
+++ b/news/1193.bugfix
@@ -1,0 +1,3 @@
+Fixes deprecated JWT `decode`usage.
+Uses and requires latest PyJWT 2.1.0 now. 
+[jensens] 

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -20,3 +20,6 @@ cffi = 1.14.6
 
 # Use the new plone.rest alpha
 plone.rest = 2.0.0a3
+
+# recent pyjwt
+pyjwt = 2.1.0

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -14,6 +14,12 @@ Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git
 [instance]
 recipe = plone.recipe.zope2instance
 zodb-temporary-storage = off
+# On March 24 2022, all ES6 stuff was merged.
+# Since then, mockup is no longer a Python package and is not pulled in by CMFPlone
+# The plone.app.widgets pinned in 6.0.0a3 still tries to import it.
+# So temporarily include the egg explicitly, until Plone 6.0.0a4 is out.
+# Alternative would be to add plone.app.widgets to the checkouts.
+eggs += mockup
 
 [versions]
 # we need the new traversal

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -27,3 +27,6 @@ cffi = 1.14.6
 
 # Error: The requirement ('importlib-metadata<4.3') is not allowed by your [versions] constraint (4.5.0)
 importlib-metadata = 4.2.0
+
+# recent pyjwt
+pyjwt = 2.1.0

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Plone",
         "Framework :: Plone :: 5.2",
+        "Framework :: Plone :: 6.0",
         "Framework :: Plone :: Core",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
@@ -62,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
@@ -82,7 +84,7 @@ setup(
         "plone.behavior>=1.1",  # adds name to behavior directive
         "plone.rest >= 1.0a6",  # json renderer moved to plone.restapi
         "plone.schema >= 1.2.1",  # new/fixed json field
-        "PyJWT",
+        "PyJWT>=2",
         "pytz",
     ],
     extras_require={"test": TEST_REQUIRES},

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -160,7 +160,12 @@ class JWTAuthenticationPlugin(BasePlugin):
         if isinstance(token, str):
             token = token.encode("utf-8")
         try:
-            return jwt.decode(token, secret, verify=verify, algorithms=["HS256"])
+            return jwt.decode(
+                token,
+                secret,
+                options={"verify_signature": verify},
+                algorithms=["HS256"],
+            )
         except jwt.InvalidTokenError:
             pass
 
@@ -194,7 +199,6 @@ class JWTAuthenticationPlugin(BasePlugin):
         if data is not None:
             payload.update(data)
         token = jwt.encode(payload, self._signing_secret(), algorithm="HS256")
-        token = token.decode("utf-8")
         if self.store_tokens:
             if self._tokens is None:
                 self._tokens = OOBTree()

--- a/versions.cfg
+++ b/versions.cfg
@@ -26,3 +26,6 @@ cffi = 1.14.4
 # requirement for json widget tests to pass
 plone.schema = 1.3.0
 plone.dexterity = 2.9.8
+
+# recent pyjwt 
+pyjwt = 2.1.0


### PR DESCRIPTION
- `verify` as kwarg of `decode` was already deprecated in PyJWT and was removed in 2.0. Uses now `options` style to pass this on.
- `encode` returns a str (Py3!) which can not be decoded again.
- Update to use and require PyJWT 2.1.0.

Note:
After merge, buildout.coredev needs to be updated. 
I prepared an separate PR for this: plone/buildout.coredev#735
This is difficult to test with our current Jenkins setup.