### PR TITLE
Updated tests to not fail when the Plone Site root is dexterity.

### DIFF
--- a/news/2454.bugfix
+++ b/news/2454.bugfix
@@ -1,0 +1,2 @@
+Updated tests to not fail when the Plone Site root is dexterity.
+[jaroel]

--- a/src/plone/restapi/tests/test_services_controlpanel_dexterity_types.py
+++ b/src/plone/restapi/tests/test_services_controlpanel_dexterity_types.py
@@ -45,6 +45,7 @@ class TestDexterityTypesControlpanel(unittest.TestCase):
                 for x in self.api_session.get("/@controlpanels/dexterity-types")
                 .json()
                 .get("items")
+                if x.get("id") != "Plone Site"
             ],
         )
 
@@ -115,5 +116,6 @@ class TestDexterityTypesControlpanel(unittest.TestCase):
                 for x in self.api_session.get("/@controlpanels/dexterity-types")
                 .json()
                 .get("items")
+                if x.get("id") != "Plone Site"
             ],
         )


### PR DESCRIPTION
This is what is left over from https://github.com/plone/plone.restapi/pull/1200