### PR TITLE
Fix tests that involving dates in Python 3.8 on machines that don't use TZ=UTC

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -66,6 +66,10 @@ recipe = zc.recipe.testrunner
 eggs = ${instance:eggs}
 initialization =
     os.environ['TZ'] = 'UTC'
+    # In Python 3.8+, for the TZ environment variable to be used, it's 
+    # necessary to explicitly call time.tzset().
+    import time
+    time.tzset()
     os.environ['ZSERVER_PORT'] = '55001'
 defaults = ['-s', 'plone.restapi', '--auto-color', '--auto-progress']
 


### PR DESCRIPTION
In Python 3.8, for the TZ environment variable to be recognized, you
need to call time.tzset()

Ref: https://github.com/plone/buildout.coredev/pull/701

This is a backport of #1195 to branch 7.x.x