### PR TITLE
Further normalise http-examples, and no port hardcoding

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -72,7 +72,6 @@ initialization =
     # necessary to explicitly call time.tzset().
     import time
     time.tzset()
-    os.environ['ZSERVER_PORT'] = '55001'
 defaults = ['-s', 'plone.restapi', '--auto-color', '--auto-progress']
 
 [test-coverage]

--- a/news/1226.bugfix
+++ b/news/1226.bugfix
@@ -1,0 +1,3 @@
+Normalize unstable generated behavior names in http-examples output.
+No longer hardcode port 55001 for the tests.
+[maurits]

--- a/src/plone/restapi/tests/http-examples/types_document.resp
+++ b/src/plone/restapi/tests/http-examples/types_document.resp
@@ -97,7 +97,7 @@ Content-Type: application/json+schema
             }
         },
         "author_email": {
-            "behavior": "plone.dexterity.schema.generated.plone_0_Document",
+            "behavior": "plone.dexterity.schema.generated.plone_5_1234567890_2_123456_0_Document",
             "description": "Email of the author",
             "factory": "Email",
             "title": "Author email",

--- a/src/plone/restapi/tests/http-examples/types_document_get_field.resp
+++ b/src/plone/restapi/tests/http-examples/types_document_get_field.resp
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "behavior": "plone.dexterity.schema.generated.plone_0_Document",
+    "behavior": "plone.dexterity.schema.generated.plone_5_1234567890_2_123456_0_Document",
     "description": "Email of the author",
     "factory": "Email",
     "title": "Author email",

--- a/src/plone/restapi/tests/http-examples/types_document_post_field.resp
+++ b/src/plone/restapi/tests/http-examples/types_document_post_field.resp
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Content-Type: application/json
 
 {
-    "behavior": "plone.dexterity.schema.generated.plone_0_Document",
+    "behavior": "plone.dexterity.schema.generated.plone_5_1234567890_2_123456_0_Document",
     "description": "Email of the author",
     "factory": "Email",
     "title": "Author email",

--- a/src/plone/restapi/tests/http-examples/types_document_put.req
+++ b/src/plone/restapi/tests/http-examples/types_document_put.req
@@ -54,7 +54,7 @@ Content-Type: application/json
             }
         },
         "author_email": {
-            "behavior": "plone.dexterity.schema.generated.plone_0_Document",
+            "behavior": "plone.dexterity.schema.generated.plone_5_1234567890_2_123456_0_Document",
             "description": "Email of the author",
             "factory": "Email",
             "title": "Author email",

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -516,11 +516,15 @@ class TestDocumentation(TestDocumentationBase):
         )
         # With plone.dexterity 2.10+ we get an unstable behavior name like this:
         # plone.dexterity.schema.generated.plone_5_1630611587_2_523689_0_Document
-        # Replace it.
+        # In older versions, we got this:
+        # plone.dexterity.schema.generated.plone_0_Document
+        # Normalize this to look like the new name
         document_schema_re = re.compile(
-            r"^plone.dexterity.schema.generated.plone_.*_Document$"
+            r"^plone.dexterity.schema.generated.plone_5_\d*_2_\d*_0_Document$"
         )
-        stable_behavior = "plone.dexterity.schema.generated.plone_0_Document"
+        stable_behavior = (
+            "plone.dexterity.schema.generated.plone_5_1234567890_2_123456_0_Document"
+        )
         json_response = response.json()
         response_text_override = ""
         behavior = json_response.get("behavior")


### PR DESCRIPTION
This is for master what I already [did on 7.x.x](https://github.com/plone/plone.restapi/pull/1218#pullrequestreview-754383233).