### PR TITLE
Tests: make RelativeSession transaction aware. [7.x.x]

### DIFF
--- a/news/1018.bugfix
+++ b/news/1018.bugfix
@@ -1,0 +1,3 @@
+Tests: make RelativeSession transaction aware.
+This should fix some random test failures.
+[maurits]

--- a/src/plone/restapi/tests/test_addons.py
+++ b/src/plone/restapi/tests/test_addons.py
@@ -36,7 +36,7 @@ class TestAddons(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -346,6 +346,7 @@ class TestAABatchingArchetypes(unittest.TestCase):
     def setUp(self):
         if not HAS_AT:
             raise unittest.SkipTest("Skip tests if Archetypes is not present")
+        self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -30,7 +30,7 @@ class TestBatchingDXBase(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         self.request = self.portal.REQUEST
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -350,7 +350,7 @@ class TestAABatchingArchetypes(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
 
         setRoles(self.portal, TEST_USER_ID, ["Member", "Contributor"])
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -393,7 +393,7 @@ class TestBatchingArchetypes(unittest.TestCase):
 
         setRoles(self.portal, TEST_USER_ID, ["Member", "Contributor"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_blocks_searchable_text.py
+++ b/src/plone/restapi/tests/test_blocks_searchable_text.py
@@ -30,7 +30,7 @@ class TestSearchTextInBlocks(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_content_blocks.py
+++ b/src/plone/restapi/tests/test_content_blocks.py
@@ -23,7 +23,7 @@ class TestContentBlocks(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_copymove.py
+++ b/src/plone/restapi/tests/test_copymove.py
@@ -83,7 +83,7 @@ class TestCopyMoveFunctional(unittest.TestCase):
             email="memberuser@example.com", username="memberuser", password="secret"
         )
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -196,7 +196,7 @@ class TestDocumentationBase(unittest.TestCase):
         pushGlobalRegistry(getSite())
         register_static_uuid_utility(prefix="SomeUUID")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -816,7 +816,7 @@ class TestDocumentation(TestDocumentationBase):
         save_request_and_response_for_docs("users", response)
 
     def test_documentation_users_as_anonymous(self):
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, self.app)
         logged_out_api_session.headers.update({"Accept": "application/json"})
 
         response = logged_out_api_session.get("@users")
@@ -841,7 +841,7 @@ class TestDocumentation(TestDocumentationBase):
         )
         transaction.commit()
 
-        standard_api_session = RelativeSession(self.portal_url)
+        standard_api_session = RelativeSession(self.portal_url, self.app)
         standard_api_session.headers.update({"Accept": "application/json"})
         standard_api_session.auth = ("noam", "password")
 
@@ -880,7 +880,7 @@ class TestDocumentation(TestDocumentationBase):
         )
         transaction.commit()
 
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, self.app)
         logged_out_api_session.headers.update({"Accept": "application/json"})
 
         response = logged_out_api_session.get("@users/noam")
@@ -912,7 +912,7 @@ class TestDocumentation(TestDocumentationBase):
 
         transaction.commit()
 
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, self.app)
         logged_out_api_session.headers.update({"Accept": "application/json"})
         logged_out_api_session.auth = ("noam-fake", "secret")
 
@@ -937,7 +937,7 @@ class TestDocumentation(TestDocumentationBase):
         )
         transaction.commit()
 
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, self.app)
         logged_out_api_session.headers.update({"Accept": "application/json"})
         logged_out_api_session.auth = ("noam", "secret")
         response = logged_out_api_session.get("@users/noam")

--- a/src/plone/restapi/tests/test_error_handling.py
+++ b/src/plone/restapi/tests/test_error_handling.py
@@ -39,7 +39,7 @@ class TestErrorHandling(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_expansion.py
+++ b/src/plone/restapi/tests/test_expansion.py
@@ -119,7 +119,7 @@ class TestExpansionFunctional(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -362,7 +362,7 @@ class TestTranslationExpansionFunctional(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_locking.py
+++ b/src/plone/restapi/tests/test_locking.py
@@ -18,6 +18,7 @@ class TestLocking(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
+        self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.request = self.layer["request"]
         login(self.portal, SITE_OWNER_NAME)
@@ -26,7 +27,7 @@ class TestLocking(unittest.TestCase):
         ]
         alsoProvides(self.doc, ITTWLockable)
 
-        self.api_session = RelativeSession(self.doc.absolute_url())
+        self.api_session = RelativeSession(self.doc.absolute_url(), self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_permissions.py
+++ b/src/plone/restapi/tests/test_permissions.py
@@ -20,7 +20,7 @@ class TestPermissions(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_registry.py
+++ b/src/plone/restapi/tests/test_registry.py
@@ -25,7 +25,7 @@ class TestRegistry(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_roles.py
+++ b/src/plone/restapi/tests/test_roles.py
@@ -12,10 +12,11 @@ class TestRolesGet(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
+        self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -44,7 +44,7 @@ class TestSearchFunctional(unittest.TestCase):
         self.request = self.portal.REQUEST
         self.catalog = getToolByName(self.portal, "portal_catalog")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -805,7 +805,7 @@ class TestSearchATFunctional(unittest.TestCase):
         self.request = self.portal.REQUEST
         self.catalog = getToolByName(self.portal, "portal_catalog")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services.py
+++ b/src/plone/restapi/tests/test_services.py
@@ -29,7 +29,7 @@ class TestTraversal(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_actions.py
+++ b/src/plone/restapi/tests/test_services_actions.py
@@ -47,11 +47,11 @@ class TestActions(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, self.app)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         self.portal_actions = api.portal.get_tool(name="portal_actions")

--- a/src/plone/restapi/tests/test_services_breadcrumbs.py
+++ b/src/plone/restapi/tests/test_services_breadcrumbs.py
@@ -30,7 +30,7 @@ class TestServicesBreadcrumbs(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -76,11 +76,12 @@ class TestServicesMultilingualBreadcrumbs(unittest.TestCase):
     layer = PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 
     def setUp(self):
+        self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
         self.request = self.layer["request"]
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_comments.py
+++ b/src/plone/restapi/tests/test_services_comments.py
@@ -42,12 +42,12 @@ class TestCommentsEndpoint(unittest.TestCase):
         api.user.create(username="jos", password="josjos", email="jos@plone.org")
 
         # Admin session
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
         # User session
-        self.user_session = RelativeSession(self.portal_url)
+        self.user_session = RelativeSession(self.portal_url, self.app)
         self.user_session.headers.update({"Accept": "application/json"})
         self.user_session.auth = ("jos", "jos")
 

--- a/src/plone/restapi/tests/test_services_content.py
+++ b/src/plone/restapi/tests/test_services_content.py
@@ -20,7 +20,7 @@ class TestHistoryVersioning(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_contextnavigation.py
+++ b/src/plone/restapi/tests/test_services_contextnavigation.py
@@ -38,7 +38,7 @@ class TestServicesContextNavigation(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_controlpanel_dexterity_types.py
+++ b/src/plone/restapi/tests/test_services_controlpanel_dexterity_types.py
@@ -19,7 +19,7 @@ class TestDexterityTypesControlpanel(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_controlpanels.py
+++ b/src/plone/restapi/tests/test_services_controlpanels.py
@@ -29,7 +29,7 @@ class TestControlpanelsEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_database.py
+++ b/src/plone/restapi/tests/test_services_database.py
@@ -19,7 +19,7 @@ class TestDatabaseServiceFunctional(unittest.TestCase):
         self.request = self.portal.REQUEST
         self.catalog = getToolByName(self.portal, "portal_catalog")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_email_notification.py
+++ b/src/plone/restapi/tests/test_services_email_notification.py
@@ -40,10 +40,10 @@ class EmailNotificationEndpoint(unittest.TestCase):
         registry["plone.email_from_address"] = "info@plone.org"
         registry["plone.email_from_name"] = u"Plone test site"
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, self.app)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         transaction.commit()

--- a/src/plone/restapi/tests/test_services_email_send.py
+++ b/src/plone/restapi/tests/test_services_email_send.py
@@ -38,10 +38,10 @@ class EmailSendEndpoint(unittest.TestCase):
         registry["plone.email_from_address"] = "info@plone.org"
         registry["plone.email_from_name"] = u"Plone test site"
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, self.app)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         transaction.commit()

--- a/src/plone/restapi/tests/test_services_groups.py
+++ b/src/plone/restapi/tests/test_services_groups.py
@@ -22,7 +22,7 @@ class TestGroupsEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_history.py
+++ b/src/plone/restapi/tests/test_services_history.py
@@ -25,7 +25,7 @@ class TestHistoryEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -141,6 +141,7 @@ class TestHistoryEndpointEmptyOrInacessibleHistory(unittest.TestCase):
         )
 
     def setUp(self):
+        self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 
@@ -157,7 +158,7 @@ class TestHistoryEndpointEmptyOrInacessibleHistory(unittest.TestCase):
         api.content.transition(self.doc, "publish")
         self.endpoint_url = "{}/@history".format(self.doc.absolute_url())
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)
         # forbid access to `workflowHistory`
@@ -182,7 +183,7 @@ class TestHistoryEndpointTranslatedMessages(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.headers.update({"Accept-Language": "es"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)

--- a/src/plone/restapi/tests/test_services_navigation.py
+++ b/src/plone/restapi/tests/test_services_navigation.py
@@ -29,7 +29,7 @@ class TestServicesNavigation(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_principals.py
+++ b/src/plone/restapi/tests/test_services_principals.py
@@ -22,7 +22,7 @@ class TestPrincipalsEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_querysources.py
+++ b/src/plone/restapi/tests/test_services_querysources.py
@@ -23,7 +23,7 @@ class TestQuerysourcesEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_querystring.py
+++ b/src/plone/restapi/tests/test_services_querystring.py
@@ -19,7 +19,7 @@ class TestQuerystringEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_querystringsearch.py
+++ b/src/plone/restapi/tests/test_services_querystringsearch.py
@@ -28,7 +28,7 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_sources.py
+++ b/src/plone/restapi/tests/test_services_sources.py
@@ -23,7 +23,7 @@ class TestSourcesEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_tiles.py
+++ b/src/plone/restapi/tests/test_services_tiles.py
@@ -42,7 +42,7 @@ class TestServicesTiles(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_types.py
+++ b/src/plone/restapi/tests/test_services_types.py
@@ -21,7 +21,7 @@ class TestServicesTypes(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -559,7 +559,7 @@ class TestServicesTypesTranslatedTitles(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.headers.update({"Accept-Language": "es"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -34,10 +34,10 @@ class TestUsersEndpoint(unittest.TestCase):
 
         self.mailhost = getUtility(IMailHost)
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, self.app)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         properties = {
@@ -90,7 +90,7 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertEqual("Cambridge, MA", noam.get("location"))
 
     def test_list_users_without_being_manager(self):
-        noam_api_session = RelativeSession(self.portal_url)
+        noam_api_session = RelativeSession(self.portal_url, self.app)
         noam_api_session.headers.update({"Accept": "application/json"})
         noam_api_session.auth = ("noam", "password")
 
@@ -313,7 +313,7 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_get_other_user_info_when_logged_in(self):
-        noam_api_session = RelativeSession(self.portal_url)
+        noam_api_session = RelativeSession(self.portal_url, self.app)
         noam_api_session.headers.update({"Accept": "application/json"})
         noam_api_session.auth = ("noam", "password")
 
@@ -372,7 +372,7 @@ class TestUsersEndpoint(unittest.TestCase):
             },
         )
         transaction.commit()
-        noam_api_session = RelativeSession(self.portal_url)
+        noam_api_session = RelativeSession(self.portal_url, self.app)
         noam_api_session.headers.update({"Accept": "application/json"})
         noam_api_session.auth = ("noam", "password")
 

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -59,7 +59,7 @@ class TestVocabularyEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         provideUtility(

--- a/src/plone/restapi/tests/test_system.py
+++ b/src/plone/restapi/tests/test_system.py
@@ -24,7 +24,7 @@ class TestSystemFunctional(unittest.TestCase):
         self.request = self.portal.REQUEST
         self.catalog = getToolByName(self.portal, "portal_catalog")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         overview_control_panel = OverviewControlPanel(self.portal, self.request)

--- a/src/plone/restapi/tests/test_tus.py
+++ b/src/plone/restapi/tests/test_tus.py
@@ -64,6 +64,7 @@ class TestTUS(unittest.TestCase):
     def setUp(self):
         self.app = self.layer["app"]
         self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
         login(self.portal, SITE_OWNER_NAME)
 
         self.folder = api.content.create(
@@ -72,7 +73,7 @@ class TestTUS(unittest.TestCase):
         self.upload_url = "{}/@tus-upload".format(self.folder.absolute_url())
         transaction.commit()
 
-        self.api_session = RelativeSession(self.portal.absolute_url())
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -582,8 +583,10 @@ class TestTUSUploadWithCORS(unittest.TestCase):
         provideAdapter(
             CORSTestPolicy, adapts=(Interface, IBrowserRequest), provides=ICORSPolicy
         )
+        self.app = self.layer["app"]
         self.portal = self.layer["portal"]
-        self.api_session = RelativeSession(self.portal.absolute_url())
+        self.portal_url = self.portal.absolute_url()
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         self.upload_url = "{}/@tus-upload".format(self.portal.absolute_url())
@@ -748,7 +751,9 @@ class TestTUSWithAT(unittest.TestCase):
     def setUp(self):
         if not HAS_AT:
             raise unittest.SkipTest("Skip tests if Archetypes is not present")
+        self.app = self.layer["app"]
         self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         login(self.portal, TEST_USER_NAME)
 
@@ -758,7 +763,7 @@ class TestTUSWithAT(unittest.TestCase):
         self.upload_url = "{}/@tus-upload".format(self.folder.absolute_url())
         transaction.commit()
 
-        self.api_session = RelativeSession(self.portal.absolute_url())
+        self.api_session = RelativeSession(self.portal_url, self.app)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)
 


### PR DESCRIPTION
This should fix some random test failures.
This fixes https://github.com/plone/plone.restapi/issues/1018
Summary of my latest comments there:

- In a functional test layer using zope.testbrowser, a request that changes something in Plone leads to a transaction commit.
- plone.restapi uses RelativeSession instead, and this missed such an integration: changes did not really end up in the database.

It somehow mostly worked so far, but to me that seems luck.

Once approved, I can forward port to master.