### PR TITLE
Avoid `UnboundLocalError` or duplicates in results

### DIFF
--- a/news/1231.bugfix
+++ b/news/1231.bugfix
@@ -1,0 +1,2 @@
+Avoid `UnboundLocalError` or duplicates in results when using `@search` endpoint and a brain is orphan or a `KeyError` occurs during result serialization
+[gbastien]

--- a/news/1231.bugfix
+++ b/news/1231.bugfix
@@ -1,2 +1,2 @@
-Avoid `UnboundLocalError` or duplicates in results when using `@search` endpoint and a brain is orphan or a `KeyError` occurs during result serialization
+Avoid `UnboundLocalError` or duplicates in results when using `@search` endpoint and a brain is orphan or a `KeyError` occurs during result serialization.
 [gbastien]

--- a/src/plone/restapi/serializer/catalog.py
+++ b/src/plone/restapi/serializer/catalog.py
@@ -53,9 +53,9 @@ class LazyCatalogResultSerializer:
                     )
                     continue
 
-                result = getMultiAdapter(
-                    (obj, self.request), ISerializeToJson
-                )(include_items=False)
+                result = getMultiAdapter((obj, self.request), ISerializeToJson)(
+                    include_items=False
+                )
             else:
                 result = getMultiAdapter(
                     (brain, self.request), ISerializeToJsonSummary

--- a/src/plone/restapi/serializer/catalog.py
+++ b/src/plone/restapi/serializer/catalog.py
@@ -41,9 +41,7 @@ class LazyCatalogResultSerializer:
         for brain in batch:
             if fullobjects:
                 try:
-                    result = getMultiAdapter(
-                        (brain.getObject(), self.request), ISerializeToJson
-                    )(include_items=False)
+                    obj = brain.getObject()
                 except KeyError:
                     # Guard in case the brain returned refers to an object that doesn't
                     # exists because it failed to uncatalog itself or the catalog has
@@ -53,6 +51,11 @@ class LazyCatalogResultSerializer:
                             brain.getPath()
                         )
                     )
+                    continue
+
+                result = getMultiAdapter(
+                    (obj, self.request), ISerializeToJson
+                )(include_items=False)
             else:
                 result = getMultiAdapter(
                     (brain, self.request), ISerializeToJsonSummary

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -355,17 +355,14 @@ class TestSearchFunctional(unittest.TestCase):
         transaction.commit()
 
         # query with fullobjects
-        query = {"portal_type": "DXTestDocument",
-                 "fullobjects": True,
-                 "UID": doc_uid}
+        query = {"portal_type": "DXTestDocument", "fullobjects": True, "UID": doc_uid}
         response = self.api_session.get("/@search", params=query)
         self.assertEqual(response.status_code, 200, response.content)
         results = response.json()
         self.assertEqual(len(results["items"]), 0)
 
         # query without fullobjects
-        query = {"portal_type": "DXTestDocument",
-                 "UID": doc_uid}
+        query = {"portal_type": "DXTestDocument", "UID": doc_uid}
         response = self.api_session.get("/@search", params=query)
         self.assertEqual(response.status_code, 200, response.content)
         results = response.json()

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -341,6 +341,36 @@ class TestSearchFunctional(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["items"]), 1)
 
+    def test_search_orphan_brain(self):
+
+        # prevent unindex when deleting self.doc
+        old__unindexObject = self.doc.__class__.unindexObject
+        self.doc.__class__.unindexObject = lambda *args: None
+        self.doc.aq_parent.manage_delObjects([self.doc.getId()])
+        self.doc.__class__.unindexObject = old__unindexObject
+        # doc deleted but still in portal_catalog
+        doc_uid = self.doc.UID()
+        self.assertFalse(self.doc in self.doc.aq_parent)
+        self.assertTrue(self.portal.portal_catalog(UID=doc_uid))
+        transaction.commit()
+
+        # query with fullobjects
+        query = {"portal_type": "DXTestDocument",
+                 "fullobjects": True,
+                 "UID": doc_uid}
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200, response.content)
+        results = response.json()
+        self.assertEqual(len(results["items"]), 0)
+
+        # query without fullobjects
+        query = {"portal_type": "DXTestDocument",
+                 "UID": doc_uid}
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200, response.content)
+        results = response.json()
+        self.assertEqual(len(results["items"]), 1)
+
     # ZCTextIndex
 
     def test_fulltext_search(self):


### PR DESCRIPTION
when using `@search` endpoint and a brain is orphan or a `KeyError` occurs during result serialization

See issue #1231

PS: if this is backported to version working with Zope2, there will need to change as getObject an orphan brain raises KeyError in Zope4 but an AttributeError in Zope2...