### PR TITLE
Checkout Products.CMFPlone to have a green GHA build again

### DIFF
--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -1,10 +1,15 @@
 [buildout]
+extensions = mr.developer
 extends =
     https://dist.plone.org/release/6.0-dev/versions.cfg
     base.cfg
 find-links = https://dist.plone.org/release/6.0-dev/
 versions=versions
+auto-checkout =
+    Products.CMFPlone
 
+[sources]
+Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git
 
 [instance]
 recipe = plone.recipe.zope2instance


### PR DESCRIPTION
This fixes the build like it is defined now, but I think that the GHA workflows should be revisited.

Fixes #1254