### PR TITLE
Lower restriction of vocabularies endpoint

### DIFF
--- a/news/1258.bugfix
+++ b/news/1258.bugfix
@@ -1,0 +1,1 @@
+Adjust restrictions of vocabularies endpoint [ksuess]

--- a/src/plone/restapi/services/vocabularies/configure.zcml
+++ b/src/plone/restapi/services/vocabularies/configure.zcml
@@ -8,7 +8,7 @@
       accept="application/json"
       factory=".get.VocabulariesGet"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
-      permission="plone.restapi.vocabularies"
+      permission="zope2.View"
       name="@vocabularies"
       />
 
@@ -17,7 +17,7 @@
       accept="application/json"
       factory=".get.VocabulariesGet"
       for="Products.CMFCore.interfaces.IContentish"
-      permission="plone.restapi.vocabularies"
+      permission="zope2.View"
       name="@vocabularies"
       />
 

--- a/src/plone/restapi/services/vocabularies/get.py
+++ b/src/plone/restapi/services/vocabularies/get.py
@@ -1,12 +1,8 @@
 from AccessControl import getSecurityManager
 
 
-try:
-    from plone.app.vocabularies.security import DEFAULT_PERMISSION
-    from plone.app.vocabularies.security import PERMISSIONS
-except ImportError:
-    from plone.app.content.browser.vocabulary import DEFAULT_PERMISSION
-    from plone.app.content.browser.vocabulary import PERMISSIONS
+from plone.app.content.browser.vocabulary import DEFAULT_PERMISSION
+from plone.app.content.browser.vocabulary import PERMISSIONS
 
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service

--- a/src/plone/restapi/services/vocabularies/get.py
+++ b/src/plone/restapi/services/vocabularies/get.py
@@ -2,13 +2,11 @@ from AccessControl import getSecurityManager
 
 
 try:
-    from plone.app.vocabularies import DEFAULT_PERMISSION
-    from plone.app.vocabularies import PERMISSIONS
+    from plone.app.vocabularies.security import DEFAULT_PERMISSION
+    from plone.app.vocabularies.security import PERMISSIONS
 except ImportError:
-    from plone.app.content.browser.vocabulary import (
-        DEFAULT_PERMISSION,
-        PERMISSIONS,
-    )
+    from plone.app.content.browser.vocabulary import DEFAULT_PERMISSION
+    from plone.app.content.browser.vocabulary import PERMISSIONS
 
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service

--- a/src/plone/restapi/services/vocabularies/get.py
+++ b/src/plone/restapi/services/vocabularies/get.py
@@ -35,20 +35,19 @@ class VocabulariesGet(Service):
         return {"error": {"type": type, "message": message}}
 
     def _has_permission_to_access_vocabulary(self, vocabulary_name):
-        """Check if user is authorized to access built-in vocabulary
+        """Check if user is authorized to access the vocabulary.
 
-        default permission for all vocabularies, built-in and others, was
-          <permission
-            id="plone.restapi.vocabularies"
-            title="plone.restapi: Access Plone vocabularies"
-            />
+        The endpoint using this method is supposed to have no further protection (`zope.2Public` permission).
+        A vocabulary with no further protection follows the `plone.app.vocabularies.DEFAULT_PERMISSION` (usually `zope2.View`).
+        For further protection the dictionary `plone.app.vocabularies.PERMISSION` is used.
+        It is a mapping from vocabulary name to permission.
+        If a vocabulary is mapped there, the permission from the map is taken.
+        Thus vocabularies can be protected stronger or weaker than the default.
         """
-        if vocabulary_name in PERMISSIONS:
-            sm = getSecurityManager()
-            return sm.checkPermission(
-                PERMISSIONS.get(vocabulary_name, DEFAULT_PERMISSION), self.context
-            )
-        return True
+        sm = getSecurityManager()
+        return sm.checkPermission(
+            PERMISSIONS.get(vocabulary_name, DEFAULT_PERMISSION), self.context
+        )
 
     def reply(self):
         # return list of all vocabularies

--- a/src/plone/restapi/services/vocabularies/get.py
+++ b/src/plone/restapi/services/vocabularies/get.py
@@ -1,16 +1,21 @@
 from AccessControl import getSecurityManager
+
+
 try:
-    from plone.app.vocabularies import DEFAULT_PERMISSION, DEFAULT_PERMISSION_SECURE, PERMISSIONS
+    from plone.app.vocabularies import DEFAULT_PERMISSION
+    from plone.app.vocabularies import PERMISSIONS
 except ImportError:
-    from plone.app.content.browser.vocabulary import DEFAULT_PERMISSION, DEFAULT_PERMISSION_SECURE, PERMISSIONS
-from plone.app.z3cform.interfaces import IFieldPermissionChecker
+    from plone.app.content.browser.vocabulary import (
+        DEFAULT_PERMISSION,
+        PERMISSIONS,
+    )
+
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from zope.component import ComponentLookupError
 from zope.component import getMultiAdapter
 from zope.component import getUtilitiesFor
 from zope.component import getUtility
-from zope.component import queryAdapter
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 from zope.schema.interfaces import IVocabularyFactory
@@ -69,16 +74,14 @@ class VocabulariesGet(Service):
                 (
                     f"You are not authorized to access "
                     f"the vocabulary '{vocabulary_name}'."
-                )
+                ),
             )
 
         try:
             factory = getUtility(IVocabularyFactory, name=vocabulary_name)
         except ComponentLookupError:
             return self._error(
-                404,
-                "Not Found",
-                f"The vocabulary '{vocabulary_name}' does not exist"
+                404, "Not Found", f"The vocabulary '{vocabulary_name}' does not exist"
             )
 
         vocabulary = factory(self.context)

--- a/src/plone/restapi/services/vocabularies/get.py
+++ b/src/plone/restapi/services/vocabularies/get.py
@@ -37,12 +37,12 @@ class VocabulariesGet(Service):
     def _has_permission_to_access_vocabulary(self, vocabulary_name):
         """Check if user is authorized to access the vocabulary.
 
-        The endpoint using this method is supposed to have no further protection (`zope.2Public` permission).
+        The endpoint using this method is supposed to have no further protection (`zope.View` permission).
         A vocabulary with no further protection follows the `plone.app.vocabularies.DEFAULT_PERMISSION` (usually `zope2.View`).
         For further protection the dictionary `plone.app.vocabularies.PERMISSION` is used.
         It is a mapping from vocabulary name to permission.
         If a vocabulary is mapped there, the permission from the map is taken.
-        Thus vocabularies can be protected stronger or weaker than the default.
+        Thus vocabularies can be protected stronger than the default.
         """
         sm = getSecurityManager()
         return sm.checkPermission(

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -114,7 +114,7 @@ class TestVocabularyEndpoint(unittest.TestCase):
 
     def test_get_builtin_vocabulary(self):
         """Check if built-in vocabularies are protected.
-        
+
         See plone.app.vocabularies.PERMISSIONS
         """
         self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -3,6 +3,8 @@ from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
 from zope.component import getGlobalSiteManager
@@ -109,6 +111,38 @@ class TestVocabularyEndpoint(unittest.TestCase):
                 "items_total": 7,
             },
         )
+
+    def test_get_builtin_vocabulary(self):
+        """Check if built-in vocabularies are protected.
+        
+        See plone.app.vocabularies.PERMISSIONS
+        """
+        self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)
+
+        # test editor
+        setRoles(self.portal, TEST_USER_ID, ["Member", "Contributor", "Editor"])
+        transaction.commit()
+        response = self.api_session.get(
+            "/@vocabularies/plone.app.vocabularies.Keywords"
+        )
+        self.assertEqual(200, response.status_code)
+        response = response.json()
+        self.assertEqual(
+            response,
+            {
+                "@id": self.portal_url
+                + "/@vocabularies/plone.app.vocabularies.Keywords",  # noqa
+                "items": [],
+                "items_total": 0,
+            },
+        )
+        # test Anonymous
+        setRoles(self.portal, TEST_USER_ID, ["Anonymous"])
+        transaction.commit()
+        response = self.api_session.get(
+            "/@vocabularies/plone.app.vocabularies.Keywords"
+        )
+        self.assertEqual(403, response.status_code)
 
     def test_get_vocabulary_batched(self):
         response = self.api_session.get(


### PR DESCRIPTION
- No check of field permissions: that's not the responsibility of the vocabulary, but of the schema.