### PR TITLE
Implement IJSONSummarySerializerMetadata

### DIFF
--- a/news/1250.feature
+++ b/news/1250.feature
@@ -1,2 +1,2 @@
-Return image_field metadata on SummarySerializer for brains
+Implement IJSONSummarySerializerMetadata allowing addons to extend the metadata returned by Summary serializer.
 [ericof]

--- a/news/1250.feature
+++ b/news/1250.feature
@@ -1,0 +1,2 @@
+Return image_field metadata on SummarySerializer for brains
+[ericof]

--- a/src/plone/restapi/interfaces.py
+++ b/src/plone/restapi/interfaces.py
@@ -208,3 +208,19 @@ class IBlockSearchableText(Interface):
 
     def __call__(value):
         """Extract text from the block value. Returns text"""
+
+
+class IJSONSummarySerializerMetadata(Interface):
+    """Configure JSONSummary serializer."""
+
+    def default_metadata():
+        """Returns a set with default metadata to be serialized."""
+
+    def field_accessors():
+        """Returns a dictionary with field accessors to be used during serialization."""
+
+    def non_metadata_attributes():
+        """Returns a set with non metadata attributes."""
+
+    def blocklisted_attributes():
+        """Returns a set with attributes blocked during serialization."""

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -107,4 +107,7 @@
 
   <include package=".controlpanels" />
 
+  <!-- Summary Serializer Metadata -->
+  <utility factory=".summary.JSONSummarySerializerMetadata" name="plone.restapi.summary_serializer_metadata" />
+
 </configure>

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -108,6 +108,9 @@
   <include package=".controlpanels" />
 
   <!-- Summary Serializer Metadata -->
-  <utility factory=".summary.JSONSummarySerializerMetadata" name="plone.restapi.summary_serializer_metadata" />
+  <utility
+      factory=".summary.JSONSummarySerializerMetadata"
+      name="plone.restapi.summary_serializer_metadata"
+      />
 
 </configure>

--- a/src/plone/restapi/serializer/summary.py
+++ b/src/plone/restapi/serializer/summary.py
@@ -53,10 +53,13 @@ def merge_serializer_metadata_utilities_data():
         "blocklisted_attributes": set(),
     }
     utils = getAllUtilitiesRegisteredFor(IJSONSummarySerializerMetadata)
-    for attribute in serializer_metadata.keys():
+    for name in serializer_metadata.keys():
         for util in utils:
-            value = getattr(util, attribute)()
-            serializer_metadata[attribute].update(value)
+            method = getattr(util, name, None)
+            if not method:
+                continue
+            value = method()
+            serializer_metadata[name].update(value)
     return serializer_metadata
 
 


### PR DESCRIPTION
This allows addons to extend the metadata returned by the Summary serializer

To always return **image_field** metadata on summaries, in an addon you will implement a new file called `summary,py` with content
```
from plone.restapi.interfaces import IJSONSummarySerializerMetadata
from zope.interface import implementer


@implementer(IJSONSummarySerializerMetadata)
class JSONSummarySerializerMetadata:
    def default_metadata_fields(self):
        return {
            "image_field",
        }

```

and register it with:
```
<utility factory=".summary.JSONSummarySerializerMetadata" name="plone.volto.summary_serializer_metadata" />
```