### PR TITLE
Return non-batched vocabularies given a query param b_size=-1

### DIFF
--- a/docs/source/vocabularies.rst
+++ b/docs/source/vocabularies.rst
@@ -83,7 +83,7 @@ The token is what should be sent to the server to address that term.
 .. literalinclude:: ../../src/plone/restapi/tests/http-examples/vocabularies_get.resp
    :language: http
 
-By default, the vocabularies are batched. However, you can pass a ``not_batched`` parameter to force the endpoint to return all the terms.
+By default, the vocabularies are batched. However, you can pass ``b_size=-1`` parameter to force the endpoint to return all the terms, not batched response.
 
 Filter Vocabularies
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/source/vocabularies.rst
+++ b/docs/source/vocabularies.rst
@@ -83,6 +83,8 @@ The token is what should be sent to the server to address that term.
 .. literalinclude:: ../../src/plone/restapi/tests/http-examples/vocabularies_get.resp
    :language: http
 
+By default, the vocabularies are batched. However, you can pass a ``not_batched`` parameter to force the endpoint to return all the terms.
+
 Filter Vocabularies
 ^^^^^^^^^^^^^^^^^^^
 

--- a/news/1264.feature
+++ b/news/1264.feature
@@ -1,2 +1,2 @@
-Return non-batched vocabularies given a query param ``not_batched``
+Return non-batched vocabularies given a query param ``b_size=-1``
 [sneridagh]

--- a/news/1264.feature
+++ b/news/1264.feature
@@ -1,0 +1,2 @@
+Return non-batched vocabularies given a query param ``not_batched``
+[sneridagh]

--- a/src/plone/restapi/serializer/vocabularies.py
+++ b/src/plone/restapi/serializer/vocabularies.py
@@ -27,7 +27,7 @@ class SerializeVocabLikeToJson:
         vocabulary = self.context
         title = safe_unicode(self.request.form.get("title", ""))
         token = self.request.form.get("token", "")
-        not_batched = self.request.form.get("not_batched", "")
+        b_size = self.request.form.get("b_size", "")
 
         terms = []
         for term in vocabulary:
@@ -55,7 +55,8 @@ class SerializeVocabLikeToJson:
 
         serialized_terms = []
 
-        if not_batched:
+        # Do not batch parameter is set
+        if b_size == "-1":
             for term in terms:
                 serializer = getMultiAdapter(
                     (term, self.request), interface=ISerializeToJson

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -43,6 +43,15 @@ def test_vocabulary_factory(context):
     return TEST_VOCABULARY
 
 
+TEST_BIG_VOCABULARY = SimpleVocabulary(
+    [SimpleTerm(a, token=f"token{a}", title=f"Title {a}") for a in range(100)]
+)
+
+
+def test_big_vocabulary_factory(context):
+    return TEST_BIG_VOCABULARY
+
+
 def test_context_vocabulary_factory(context):
     return SimpleVocabulary(
         [
@@ -330,6 +339,20 @@ class TestVocabularyEndpoint(unittest.TestCase):
                 "items_total": 2,
             },
         )
+
+    def test_big_vocabulary_not_batched(self):
+        provideUtility(
+            test_big_vocabulary_factory,
+            provides=IVocabularyFactory,
+            name="plone.restapi.tests.test_big_vocabulary",
+        )
+        response = self.api_session.get(
+            "/@vocabularies/plone.restapi.tests.test_big_vocabulary?not_batched=1"
+        )
+
+        self.assertEqual(200, response.status_code)
+        response = response.json()
+        self.assertEqual(len(response["items"]), 100)
 
     def tearDown(self):
         self.api_session.close()

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -347,7 +347,7 @@ class TestVocabularyEndpoint(unittest.TestCase):
             name="plone.restapi.tests.test_big_vocabulary",
         )
         response = self.api_session.get(
-            "/@vocabularies/plone.restapi.tests.test_big_vocabulary?not_batched=1"
+            "/@vocabularies/plone.restapi.tests.test_big_vocabulary?b_size=-1"
         )
 
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
To provide a better support to the new select widget capabilities, we need to get the full thing, no batches.