### PR TITLE
Remove all traces of Products.CMFQuickInstaller

### DIFF
--- a/news/1267.bugfix
+++ b/news/1267.bugfix
@@ -1,0 +1,6 @@
+Remove all traces of ``Products.CMFQuickInstaller``.
+It was removed in Plone 5.2.
+BBB code was in ``plone.app.upgrade`` only.
+Plone with Restapi broke if ``plone.app.upgrade` was not available, like when dependening on ``Products.CMFPlone`` only.
+[jensens]
+

--- a/src/plone/restapi/services/addons/addons.py
+++ b/src/plone/restapi/services/addons/addons.py
@@ -2,9 +2,6 @@ from plone.memoize import view
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.interfaces import INonInstallable
-from Products.CMFQuickInstallerTool.interfaces import (
-    INonInstallable as QINonInstallable,
-)
 from Products.GenericSetup import EXTENSION
 from Products.GenericSetup.tool import UNKNOWN
 from zope.component import getAllUtilitiesRegisteredFor
@@ -54,11 +51,7 @@ class Addons:
         return self.is_profile_installed(profile["id"])
 
     def _install_profile_info(self, product_id):
-        """List extension profile infos of a given product.
-
-        From CMFQuickInstallerTool/QuickInstallerTool.py
-        _install_profile_info
-        """
+        """List extension profile infos of a given product."""
         profiles = self.ps.listProfileInfo()
         # We are only interested in extension profiles for the product.
         # TODO Remove the manual Products.* check here. It is still needed.
@@ -140,9 +133,6 @@ class Addons:
     def get_install_profile(self, product_id, allow_hidden=False):
         """Return the default install profile.
 
-        From CMFQuickInstallerTool/QuickInstallerTool.py
-        getInstallProfile
-
         :param product_id: id of product/package
         :type product_id: string
         :param allow_hidden: Allow getting otherwise hidden profile.
@@ -169,9 +159,6 @@ class Addons:
     def is_product_installable(self, product_id, allow_hidden=False):
         """Does a product have an installation profile?
 
-        From CMFQuickInstallerTool/QuickInstallerTool.py
-        isProductInstallable (and the deprecated isProductAvailable)
-
         :param allow_hidden: Allow installing otherwise hidden products.
             In the UI this will be False, but you can set it to True in
             for example a call from plone.app.upgrade where you want to
@@ -188,14 +175,6 @@ class Addons:
                 if gnip is None:
                     continue
                 not_installable.extend(gnip())
-            if product_id in not_installable:
-                return False
-            # BBB.  For backwards compatibility, we try the INonInstallable
-            # from the old QI as well.
-            not_installable = []
-            utils = getAllUtilitiesRegisteredFor(QINonInstallable)
-            for util in utils:
-                not_installable.extend(util.getNonInstallableProducts())
             if product_id in not_installable:
                 return False
 
@@ -240,8 +219,6 @@ class Addons:
     def get_product_version(self, product_id):
         """Return the version of the product (package).
 
-        From CMFQuickInstallerTool/QuickInstallerTool
-        getProductVersion
         That implementation used to fall back to getting the version.txt.
         """
         try:
@@ -258,8 +235,6 @@ class Addons:
 
         If anything errors out then go back to "old way" by returning
         'unknown'.
-
-        From CMFPlone/QuickInstallerTool.py getLatestUpgradeStep
         """
         profile_version = UNKNOWN
         try:
@@ -276,8 +251,6 @@ class Addons:
 
         This is a dict with among others two booleans values, stating if
         an upgrade is required and available.
-
-        From CMFPlone/QuickInstaller.py upgradeInfo
 
         :param product_id: id of product/package
         :type product_id: string
@@ -326,8 +299,6 @@ class Addons:
 
     def install_product(self, product_id, allow_hidden=False):
         """Install a product by name.
-
-        From CMFQuickInstallerTool/QuickInstallerTool.py installProduct
 
         :param product_id: id of product/package
         :type product_id: string
@@ -474,8 +445,7 @@ class Addons:
 
     def get_addons(self, apply_filter=None, product_name=None):
         """
-        100% based on generic setup profiles now. Kinda.
-        For products magic, use the zope quickinstaller I guess.
+        Based on generic setup profiles.
 
         @filter:= 'installed': only products that are installed and not hidden
                   'upgrades': only products with upgrades


### PR DESCRIPTION
For some reason I got an `Products.CMFQuickInstaller` import error in Plone 6. Maybe because its gone? Question is why it worked in past? Did it?

Anyway, this fixes the problem.
