### PR TITLE
Fix random failures in tests

### DIFF
--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -385,8 +385,10 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
         self.request.form["include_items"] = True
         serialized = self.serialize(self.portal.collection1)
         items = serialized.get("items")
-        self.assertEqual(items[0]["title"], self.portal.doc1.Title())
-        self.assertEqual(items[1]["title"], self.portal.doc2.Title())
+        self.assertEqual(
+            sorted([item["title"] for item in items]),
+            [self.portal.doc1.Title(), self.portal.doc2.Title()],
+        )
         self.assertEqual(serialized.get("items_total"), 2)
 
     def test_serialize_returns_site_root_common(self):

--- a/src/plone/restapi/tests/test_services_querystringsearch.py
+++ b/src/plone/restapi/tests/test_services_querystringsearch.py
@@ -130,6 +130,7 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
                     }
                 ],
                 "b_size": 5,
+                "sort_on": "sortable_title",
             },
         )
 
@@ -153,6 +154,7 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
                 ],
                 "b_size": 5,
                 "b_start": 5,
+                "sort_on": "sortable_title",
             },
         )
 


### PR DESCRIPTION
**test_serialize_to_json_collection_include_items:**

When we don't have the `sort_on` parameter, it's not guaranteed that the search result will always come in the same order. This was causing the test to fail randomly. So we sort the titles before comparing the result.

This fixes the error:

```
AssertionError: 'Document 2' != 'Document 1'
```

See: https://jenkins.plone.org/job/pull-request-6.0-3.9/561

**test_querystringsearch_complex:**

We add the `sort_on` parameter to ensure that the result always comes in the same order.

This fixes the error:

AssertionError: 'Test Document 8' != 'Test Document 4'

See: https://github.com/plone/plone.restapi/runs/4288557515?check_suite_focus=true