### PR TITLE
Improve support for `missing_value` and `default` story

### DIFF
--- a/news/1282.bugfix
+++ b/news/1282.bugfix
@@ -1,0 +1,2 @@
+Improve support and meaning for `default` and `missing_value` in serializers/deserializers
+[sneridagh]

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -159,27 +159,22 @@ class DeserializeFromJson(OrderingMixin):
                     if name == "changeNote":
                         continue
                     dm = queryMultiAdapter((self.context, field), IDataManager)
-
                     # Covering here missing_value/default edge cases
-                    if name not in data:
-                        dm = queryMultiAdapter((self.context, field), IDataManager)
-
-                        if (
-                            field.missing_value is not None
-                            and not dm.get()
-                            and not field.required
-                        ):
-                            # If the field is not set in data, it has no value set either,
-                            # and missing_value is defined, it sets the missing value
-                            dm.set(field.missing_value)
-                        if (
-                            field.missing_value is not None
-                            and dm.get() == field.default
-                            and not field.required
-                        ):
-                            # If the field is not set in data, it has a default,
-                            # and missing_value is defined, it sets the missing value
+                    if (
+                        name not in data 
+                        and field.missing_value is not None
+                        and not field.required
+                    ):
+                        # precondition:
+                        # - name was not handled before 
+                        # - not required, otherwise there has to be a value
+                        # - missing_value is defined, so it can be set
+                        dm_value = dm.get()
+                        if not dm_value or dm_value == field.default:
+                            # If theres no value at all
+                            # or if value is the default 
                             # (so it prevails instead of default)
+                            # then it sets the missing value
                             dm.set(field.missing_value)
 
                     bound = field.bind(self.context)

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -161,6 +161,19 @@ class DeserializeFromJson(OrderingMixin):
                     dm = queryMultiAdapter((self.context, field), IDataManager)
                     bound = field.bind(self.context)
                     try:
+                        if name not in data and not dm.get() and not field.required:
+                            # If the field is not set in data, it has no value set either,
+                            # and missing_value is defined, it sets the missing value
+                            dm.set(field.missing_value)
+                        if (
+                            name not in data
+                            and dm.get() == field.default
+                            and not field.required
+                        ):
+                            # If the field is not set in data, it has a default,
+                            # and missing_value is defined, it sets the missing value
+                            # (so it prevails instead of default)
+                            dm.set(field.missing_value)
                         bound.validate(dm.get())
                     except ValidationError as e:
                         errors.append({"message": e.doc(), "field": name, "error": e})

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -161,18 +161,18 @@ class DeserializeFromJson(OrderingMixin):
                     dm = queryMultiAdapter((self.context, field), IDataManager)
                     # Covering here missing_value/default edge cases
                     if (
-                        name not in data 
+                        name not in data
                         and field.missing_value is not None
                         and not field.required
                     ):
                         # precondition:
-                        # - name was not handled before 
+                        # - name was not handled before
                         # - not required, otherwise there has to be a value
                         # - missing_value is defined, so it can be set
                         dm_value = dm.get()
                         if not dm_value or dm_value == field.default:
                             # If theres no value at all
-                            # or if value is the default 
+                            # or if value is the default
                             # (so it prevails instead of default)
                             # then it sets the missing value
                             dm.set(field.missing_value)

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -164,12 +164,16 @@ class DeserializeFromJson(OrderingMixin):
                     if name not in data:
                         dm = queryMultiAdapter((self.context, field), IDataManager)
 
-                        if field.missing_value and not dm.get() and not field.required:
+                        if (
+                            field.missing_value is not None
+                            and not dm.get()
+                            and not field.required
+                        ):
                             # If the field is not set in data, it has no value set either,
                             # and missing_value is defined, it sets the missing value
                             dm.set(field.missing_value)
                         if (
-                            field.missing_value
+                            field.missing_value is not None
                             and dm.get() == field.default
                             and not field.required
                         ):

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -279,6 +279,10 @@ class IDXTestDocumentSchema(model.Schema):
         required=False, missing_value="missing", default="default"
     )
 
+    test_missing_value_field_and_no_default = schema.TextLine(
+        required=False, missing_value="missing"
+    )
+
     test_missing_value_required_field = schema.TextLine(
         required=True, missing_value="missing", default="some value"
     )

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -279,8 +279,8 @@ class IDXTestDocumentSchema(model.Schema):
         required=False, missing_value="missing", default="default"
     )
 
-    test_missing_value_field_and_no_default = schema.TextLine(
-        required=False, missing_value="missing"
+    test_missing_value_field_and_no_default = schema.List(
+        required=False, value_type=schema.Choice(values=[1, 2, 3]), missing_value=[]
     )
 
     test_missing_value_required_field = schema.TextLine(

--- a/src/plone/restapi/tests/test_dxcontent_deserializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_deserializer.py
@@ -186,6 +186,22 @@ class TestDXContentDeserializer(unittest.TestCase, OrderingMixin):
         self.deserialize(body='{"test_missing_value_field": null}')
         self.assertEqual("missing", self.portal.doc1.test_missing_value_field)
 
+    def test_deserializer_sets_missing_value_when_receiving_nothing_at_all(self):
+        # If the field is not set in the request data, it has no value set either,
+        # and missing_value is defined, it sets the missing value
+        self.deserialize(body='{"test_required_field": "My Value"}', validate_all=True)
+        self.assertEqual(
+            "missing", self.portal.doc1.test_missing_value_field_and_no_default
+        )
+
+    def test_deserializer_has_default_and_missing_value_sets_missing_value_when_receiving_nothing_at_all(
+        self,
+    ):
+        # If the field is not set in the request data, it has a default,
+        # and missing_value is defined, it sets the missing value (so it prevails instead of default)
+        self.deserialize(body='{"test_required_field": "My Value"}', validate_all=True)
+        self.assertEqual("missing", self.portal.doc1.test_missing_value_field)
+
     def test_deserializer_sets_missing_value_on_required_field(self):
         """We don't set missing_value if the field is required"""
         self.deserialize(body='{"test_missing_value_required_field": "valid value"}')

--- a/src/plone/restapi/tests/test_dxcontent_deserializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_deserializer.py
@@ -190,9 +190,7 @@ class TestDXContentDeserializer(unittest.TestCase, OrderingMixin):
         # If the field is not set in the request data, it has no value set either,
         # and missing_value is defined, it sets the missing value
         self.deserialize(body='{"test_required_field": "My Value"}', validate_all=True)
-        self.assertEqual(
-            "missing", self.portal.doc1.test_missing_value_field_and_no_default
-        )
+        self.assertEqual([], self.portal.doc1.test_missing_value_field_and_no_default)
 
     def test_deserializer_has_default_and_missing_value_sets_missing_value_when_receiving_nothing_at_all(
         self,

--- a/src/plone/restapi/tests/test_dxcontent_serializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_serializer.py
@@ -150,6 +150,16 @@ class TestDXContentSerializer(unittest.TestCase):
         self.assertIn("test_read_permission_field", obj)
         self.assertEqual("Secret Stuff", obj["test_read_permission_field"])
 
+    def test_serializer_includes_default_value(self):
+        obj = self.serialize()
+        self.assertIn("test_missing_value_field", obj)
+        self.assertEqual("default", obj["test_missing_value_field"])
+
+    def test_serializer_returns_None_if_only_missing_value_is_present(self):
+        obj = self.serialize()
+        self.assertIn("test_missing_value_field_and_no_default", obj)
+        self.assertEqual(None, obj["test_missing_value_field_and_no_default"])
+
     def test_get_layout(self):
         current_layout = self.portal.doc1.getLayout()
         obj = self.serialize()


### PR DESCRIPTION
See #1282 .

Could be a conflictive piece of code, so please triple check this. Tricky thing here is that I guess that `missing_value` is a `zc3.form`/Classic UI thing, and we are transferring those responsibilities to the RESTAPI code here. One could argue that the frontend should take care of that instead than the API.

