### PR TITLE
Improve error status code in new vocabularies endpoint refactor

### DIFF
--- a/news/1284.bugfix
+++ b/news/1284.bugfix
@@ -1,0 +1,2 @@
+Improve error status code in vocabularies endpoint refactor
+[sneridagh]

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -139,10 +139,12 @@ class TestVocabularyEndpoint(unittest.TestCase):
         # test Anonymous
         setRoles(self.portal, TEST_USER_ID, ["Anonymous"])
         transaction.commit()
+
+        self.api_session.auth = ()
         response = self.api_session.get(
             "/@vocabularies/plone.app.vocabularies.Keywords"
         )
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(401, response.status_code)
 
     def test_get_vocabulary_batched(self):
         response = self.api_session.get(


### PR DESCRIPTION
Small thing, return 401 also whenever it is sensible.