### PR TITLE
Add check for protected vocabulary in endpoint 'vocabularies'.

### DIFF
--- a/news/1286.feature
+++ b/news/1286.feature
@@ -1,0 +1,1 @@
+Add check for protected vocabulary ind endpoint 'vocabularies' [ksuess]

--- a/src/plone/restapi/services/vocabularies/get.py
+++ b/src/plone/restapi/services/vocabularies/get.py
@@ -92,7 +92,7 @@ class VocabulariesGet(Service):
 
         factory = ProxyFactory(factory)
         checker = getChecker(factory)
-        permission = dict(checker.get_permissions.items()).get('__call__')
+        permission = dict(checker.get_permissions.items()).get("__call__")
         if permission and not permission == CheckerPublic:
             sm = getSecurityManager()
             if not sm.checkPermission(permission, self.context):

--- a/src/plone/restapi/testing.zcml
+++ b/src/plone/restapi/testing.zcml
@@ -12,6 +12,13 @@
       component=".tests.dxtypes.vocabularyRequireingContextFactory"
       />
 
+  <utility
+      provides="zope.schema.interfaces.IVocabularyFactory"
+      name="plone.restapi.testing.protected_vocabulary"
+      component=".tests.test_services_vocabularies.test_vocabulary_factory"
+      permission="cmf.ManagePortal"
+      />
+
   <include
       package="plone.behavior"
       file="meta.zcml"

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -159,11 +159,13 @@ class TestVocabularyEndpoint(unittest.TestCase):
         response = response.json()
         self.assertEqual(
             response,
-            {'error': {
-                'message': 
-                    'You are not authorized to access the vocabulary '
+            {
+                "error": {
+                    "message": "You are not authorized to access the vocabulary "
                     "'plone.restapi.testing.protected_vocabulary'.",
-                'type': 'Forbidden'}},
+                    "type": "Forbidden",
+                }
+            },
         )
 
         # Test Manager.

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -146,6 +146,34 @@ class TestVocabularyEndpoint(unittest.TestCase):
         )
         self.assertEqual(401, response.status_code)
 
+    def test_get_protected_vocabulary(self):
+        self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)
+
+        # Test Editor.
+        setRoles(self.portal, TEST_USER_ID, ["Member", "Contributor", "Editor"])
+        transaction.commit()
+        response = self.api_session.get(
+            "/@vocabularies/plone.restapi.testing.protected_vocabulary"
+        )
+        self.assertEqual(403, response.status_code)
+        response = response.json()
+        self.assertEqual(
+            response,
+            {'error': {
+                'message': 
+                    'You are not authorized to access the vocabulary '
+                    "'plone.restapi.testing.protected_vocabulary'.",
+                'type': 'Forbidden'}},
+        )
+
+        # Test Manager.
+        setRoles(self.portal, TEST_USER_ID, ["Member", "Manager"])
+        transaction.commit()
+        response = self.api_session.get(
+            "/@vocabularies/plone.restapi.testing.protected_vocabulary"
+        )
+        self.assertEqual(200, response.status_code)
+
     def test_get_vocabulary_batched(self):
         response = self.api_session.get(
             "/@vocabularies/plone.restapi.tests.test_vocabulary?b_size=1"


### PR DESCRIPTION
Fix [1286](https://github.com/plone/plone.restapi/issues/1286)