### PR TITLE
Do not break if publish recursive folder children that are already published

### DIFF
--- a/news/1291.bugfix
+++ b/news/1291.bugfix
@@ -1,0 +1,1 @@
+Do not break in recursive transition when children already are in destination state. [cekk]

--- a/src/plone/restapi/tests/test_workflow.py
+++ b/src/plone/restapi/tests/test_workflow.py
@@ -256,12 +256,14 @@ class TestWorkflowTransition(TestCase):
         """
         folder = self.portal[self.portal.invokeFactory("Folder", id="folder")]
         subfolder1 = folder[folder.invokeFactory("Folder", id="subfolder-1")]
+        document = subfolder1[subfolder1.invokeFactory("Document", id="document")]
         subfolder2 = folder[folder.invokeFactory("Folder", id="subfolder-2")]
         self.wftool.doActionFor(subfolder1, "publish")
 
         self.assertEqual(
             "published", self.wftool.getInfoFor(subfolder1, "review_state")
         )
+        self.assertEqual("private", self.wftool.getInfoFor(document, "review_state"))
 
         # now try to publish folder and all children
         self.request["BODY"] = '{"comment": "A comment", "include_children": true}'
@@ -275,3 +277,4 @@ class TestWorkflowTransition(TestCase):
         self.assertEqual(
             "published", self.wftool.getInfoFor(subfolder2, "review_state")
         )
+        self.assertEqual("published", self.wftool.getInfoFor(document, "review_state"))


### PR DESCRIPTION
The problem is that if we have a private folder (A) with some children (AA AB AC) and one of these is already published (AB), the endpoint call returns a 400 because AB can't apply "publish" transition. The publication process will fail with some folders published (the ones before the published one) and other not (the ones after).

With this pr i will check if the current obj state is the same of the transition's destination and skip the exception. Otherwise, raise the error.
