### PR TITLE
test(warning): Resolve bulk of warnings from tests

### DIFF
--- a/news/1302.bugfix
+++ b/news/1302.bugfix
@@ -1,0 +1,3 @@
+Resolve the bulk of deprecation and resource leak warnings when running the full test
+suite.
+[rpatterson]

--- a/src/plone/restapi/tests/test_addons.py
+++ b/src/plone/restapi/tests/test_addons.py
@@ -22,7 +22,7 @@ class TestAddons(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -24,7 +24,7 @@ class TestBatchingDXBase(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         self.request = self.portal.REQUEST
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_blocks_searchable_text.py
+++ b/src/plone/restapi/tests/test_blocks_searchable_text.py
@@ -29,7 +29,7 @@ class TestSearchTextInBlocks(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_content_blocks.py
+++ b/src/plone/restapi/tests/test_content_blocks.py
@@ -22,7 +22,7 @@ class TestContentBlocks(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_copymove.py
+++ b/src/plone/restapi/tests/test_copymove.py
@@ -82,7 +82,7 @@ class TestCopyMoveFunctional(unittest.TestCase):
             email="memberuser@example.com", username="memberuser", password="secret"
         )
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -178,7 +178,7 @@ class TestDocumentationBase(unittest.TestCase):
         pushGlobalRegistry(getSite())
         register_static_uuid_utility(prefix="SomeUUID")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -794,7 +794,7 @@ class TestDocumentation(TestDocumentationBase):
         save_request_and_response_for_docs("users", response)
 
     def test_documentation_users_as_anonymous(self):
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, test=self)
         logged_out_api_session.headers.update({"Accept": "application/json"})
 
         response = logged_out_api_session.get("@users")
@@ -819,7 +819,7 @@ class TestDocumentation(TestDocumentationBase):
         )
         transaction.commit()
 
-        standard_api_session = RelativeSession(self.portal_url)
+        standard_api_session = RelativeSession(self.portal_url, test=self)
         standard_api_session.headers.update({"Accept": "application/json"})
         standard_api_session.auth = ("noam", "password")
 
@@ -858,7 +858,7 @@ class TestDocumentation(TestDocumentationBase):
         )
         transaction.commit()
 
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, test=self)
         logged_out_api_session.headers.update({"Accept": "application/json"})
 
         response = logged_out_api_session.get("@users/noam")
@@ -890,7 +890,7 @@ class TestDocumentation(TestDocumentationBase):
 
         transaction.commit()
 
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, test=self)
         logged_out_api_session.headers.update({"Accept": "application/json"})
         logged_out_api_session.auth = ("noam-fake", "secret")
 
@@ -915,7 +915,7 @@ class TestDocumentation(TestDocumentationBase):
         )
         transaction.commit()
 
-        logged_out_api_session = RelativeSession(self.portal_url)
+        logged_out_api_session = RelativeSession(self.portal_url, test=self)
         logged_out_api_session.headers.update({"Accept": "application/json"})
         logged_out_api_session.auth = ("noam", "secret")
         response = logged_out_api_session.get("@users/noam")

--- a/src/plone/restapi/tests/test_error_handling.py
+++ b/src/plone/restapi/tests/test_error_handling.py
@@ -37,7 +37,7 @@ class TestErrorHandling(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_expansion.py
+++ b/src/plone/restapi/tests/test_expansion.py
@@ -115,7 +115,7 @@ class TestExpansionFunctional(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -421,7 +421,7 @@ class TestTranslationExpansionFunctional(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_functional_auth.py
+++ b/src/plone/restapi/tests/test_functional_auth.py
@@ -68,6 +68,7 @@ class TestFunctionalAuth(unittest.TestCase):
         Logging in via the API also grants access to the Zope root ZMI.
         """
         session = requests.Session()
+        self.addCleanup(session.close)
         login_resp = session.post(
             self.portal_url + "/@login",
             headers={"Accept": "application/json"},
@@ -112,6 +113,7 @@ class TestFunctionalAuth(unittest.TestCase):
         Logging in via the Zope root ZMI also grants access to the API.
         """
         session = requests.Session()
+        self.addCleanup(session.close)
         basic_auth_headers = {
             "Authorization": "Basic {}".format(
                 base64.b64encode(
@@ -161,6 +163,7 @@ class TestFunctionalAuth(unittest.TestCase):
         Logging in via the Plone login form also grants access to the API.
         """
         session = requests.Session()
+        self.addCleanup(session.close)
         challenge_resp = session.get(self.private_document_url)
         self.assertEqual(
             challenge_resp.status_code,

--- a/src/plone/restapi/tests/test_locking.py
+++ b/src/plone/restapi/tests/test_locking.py
@@ -25,7 +25,7 @@ class TestLocking(unittest.TestCase):
         ]
         alsoProvides(self.doc, ITTWLockable)
 
-        self.api_session = RelativeSession(self.doc.absolute_url())
+        self.api_session = RelativeSession(self.doc.absolute_url(), test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_permissions.py
+++ b/src/plone/restapi/tests/test_permissions.py
@@ -19,7 +19,7 @@ class TestPermissions(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_registry.py
+++ b/src/plone/restapi/tests/test_registry.py
@@ -23,7 +23,7 @@ class TestRegistry(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_roles.py
+++ b/src/plone/restapi/tests/test_roles.py
@@ -14,7 +14,7 @@ class TestRolesGet(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -39,7 +39,7 @@ class TestSearchFunctional(unittest.TestCase):
         self.request = self.portal.REQUEST
         self.catalog = getToolByName(self.portal, "portal_catalog")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -29,10 +29,10 @@ class TestJsonCompatibleConverters(TestCase):
             + r" \(<(class|type) \'object\'>\) JSON compatible.$"
         )
 
-        with self.assertRaisesRegexp(TypeError, err_regex):
+        with self.assertRaisesRegex(TypeError, err_regex):
             json_compatible(object())
 
-        with self.assertRaisesRegexp(TypeError, err_regex):
+        with self.assertRaisesRegex(TypeError, err_regex):
             json_compatible({"foo": [object()]})
 
     def test_True(self):

--- a/src/plone/restapi/tests/test_services.py
+++ b/src/plone/restapi/tests/test_services.py
@@ -28,7 +28,7 @@ class TestTraversal(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_actions.py
+++ b/src/plone/restapi/tests/test_services_actions.py
@@ -46,11 +46,11 @@ class TestActions(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, test=self)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         self.portal_actions = api.portal.get_tool(name="portal_actions")

--- a/src/plone/restapi/tests/test_services_breadcrumbs.py
+++ b/src/plone/restapi/tests/test_services_breadcrumbs.py
@@ -26,7 +26,7 @@ class TestServicesBreadcrumbs(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -71,7 +71,7 @@ class TestServicesMultilingualBreadcrumbs(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         self.request = self.layer["request"]
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_comments.py
+++ b/src/plone/restapi/tests/test_services_comments.py
@@ -41,12 +41,12 @@ class TestCommentsEndpoint(unittest.TestCase):
         api.user.create(username="jos", password="josjos", email="jos@plone.org")
 
         # Admin session
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
         # User session
-        self.user_session = RelativeSession(self.portal_url)
+        self.user_session = RelativeSession(self.portal_url, test=self)
         self.user_session.headers.update({"Accept": "application/json"})
         self.user_session.auth = ("jos", "jos")
 

--- a/src/plone/restapi/tests/test_services_content.py
+++ b/src/plone/restapi/tests/test_services_content.py
@@ -19,7 +19,7 @@ class TestHistoryVersioning(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_contextnavigation.py
+++ b/src/plone/restapi/tests/test_services_contextnavigation.py
@@ -36,7 +36,7 @@ class TestServicesContextNavigation(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_controlpanel_dexterity_types.py
+++ b/src/plone/restapi/tests/test_services_controlpanel_dexterity_types.py
@@ -18,7 +18,7 @@ class TestDexterityTypesControlpanel(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_controlpanels.py
+++ b/src/plone/restapi/tests/test_services_controlpanels.py
@@ -19,7 +19,7 @@ class TestControlpanelsEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_database.py
+++ b/src/plone/restapi/tests/test_services_database.py
@@ -18,7 +18,7 @@ class TestDatabaseServiceFunctional(unittest.TestCase):
         self.request = self.portal.REQUEST
         self.catalog = getToolByName(self.portal, "portal_catalog")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_email_notification.py
+++ b/src/plone/restapi/tests/test_services_email_notification.py
@@ -28,10 +28,10 @@ class EmailNotificationEndpoint(unittest.TestCase):
         registry["plone.email_from_address"] = "info@plone.org"
         registry["plone.email_from_name"] = "Plone test site"
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, test=self)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         transaction.commit()

--- a/src/plone/restapi/tests/test_services_email_send.py
+++ b/src/plone/restapi/tests/test_services_email_send.py
@@ -28,10 +28,10 @@ class EmailSendEndpoint(unittest.TestCase):
         registry["plone.email_from_address"] = "info@plone.org"
         registry["plone.email_from_name"] = "Plone test site"
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, test=self)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         transaction.commit()

--- a/src/plone/restapi/tests/test_services_groups.py
+++ b/src/plone/restapi/tests/test_services_groups.py
@@ -21,7 +21,7 @@ class TestGroupsEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_history.py
+++ b/src/plone/restapi/tests/test_services_history.py
@@ -23,7 +23,7 @@ class TestHistoryEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -153,7 +153,7 @@ class TestHistoryEndpointEmptyOrInacessibleHistory(unittest.TestCase):
         api.content.transition(self.doc, "publish")
         self.endpoint_url = f"{self.doc.absolute_url()}/@history"
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (TEST_USER_NAME, TEST_USER_PASSWORD)
         # forbid access to `workflowHistory`
@@ -178,7 +178,7 @@ class TestHistoryEndpointTranslatedMessages(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.headers.update({"Accept-Language": "es"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)

--- a/src/plone/restapi/tests/test_services_navigation.py
+++ b/src/plone/restapi/tests/test_services_navigation.py
@@ -23,7 +23,7 @@ class TestServicesNavigation(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_principals.py
+++ b/src/plone/restapi/tests/test_services_principals.py
@@ -21,7 +21,7 @@ class TestPrincipalsEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_querysources.py
+++ b/src/plone/restapi/tests/test_services_querysources.py
@@ -22,7 +22,7 @@ class TestQuerysourcesEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_querystring.py
+++ b/src/plone/restapi/tests/test_services_querystring.py
@@ -18,7 +18,7 @@ class TestQuerystringEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_querystringsearch.py
+++ b/src/plone/restapi/tests/test_services_querystringsearch.py
@@ -19,7 +19,7 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_sources.py
+++ b/src/plone/restapi/tests/test_services_sources.py
@@ -22,7 +22,7 @@ class TestSourcesEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_tiles.py
+++ b/src/plone/restapi/tests/test_services_tiles.py
@@ -41,7 +41,7 @@ class TestServicesTiles(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_services_types.py
+++ b/src/plone/restapi/tests/test_services_types.py
@@ -22,7 +22,7 @@ class TestServicesTypes(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -576,7 +576,7 @@ class TestServicesTypesTranslatedTitles(unittest.TestCase):
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.headers.update({"Accept-Language": "es"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -28,10 +28,10 @@ class TestUsersEndpoint(unittest.TestCase):
 
         self.mailhost = getUtility(IMailHost)
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
-        self.anon_api_session = RelativeSession(self.portal_url)
+        self.anon_api_session = RelativeSession(self.portal_url, test=self)
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         properties = {
@@ -84,7 +84,7 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertEqual("Cambridge, MA", noam.get("location"))
 
     def test_list_users_without_being_manager(self):
-        noam_api_session = RelativeSession(self.portal_url)
+        noam_api_session = RelativeSession(self.portal_url, test=self)
         noam_api_session.headers.update({"Accept": "application/json"})
         noam_api_session.auth = ("noam", "password")
 
@@ -307,7 +307,7 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_get_other_user_info_when_logged_in(self):
-        noam_api_session = RelativeSession(self.portal_url)
+        noam_api_session = RelativeSession(self.portal_url, test=self)
         noam_api_session.headers.update({"Accept": "application/json"})
         noam_api_session.auth = ("noam", "password")
 
@@ -366,7 +366,7 @@ class TestUsersEndpoint(unittest.TestCase):
             },
         )
         transaction.commit()
-        noam_api_session = RelativeSession(self.portal_url)
+        noam_api_session = RelativeSession(self.portal_url, test=self)
         noam_api_session.headers.update({"Accept": "application/json"})
         noam_api_session.auth = ("noam", "password")
 

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -75,7 +75,7 @@ class TestVocabularyEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         provideUtility(

--- a/src/plone/restapi/tests/test_services_workingcopy.py
+++ b/src/plone/restapi/tests/test_services_workingcopy.py
@@ -39,7 +39,7 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertIn("@id", response.json())
 
-        self.assertEquals(
+        self.assertEqual(
             response.json()["@id"],
             f"{self.portal_url}/copy_of_document",
         )
@@ -58,15 +58,15 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["@id"],
             f"{self.portal_url}/copy_of_document",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_name"],
             "admin",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_url"],
             f"{self.portal_url}/author/admin",
         )
@@ -77,19 +77,19 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy_of"]["@id"],
             f"{self.portal_url}/document",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["@id"],
             f"{self.portal_url}/copy_of_document",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_name"],
             "admin",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_url"],
             f"{self.portal_url}/author/admin",
         )
@@ -99,37 +99,37 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
             "/document",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["@id"],
             f"{self.portal_url}/copy_of_document",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_name"],
             "admin",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_url"],
             f"{self.portal_url}/author/admin",
         )
-        self.assertEquals(response.json()["working_copy_of"], None)
+        self.assertEqual(response.json()["working_copy_of"], None)
 
         # Serialization on the working copy object
         response = self.api_session.get(
             "/copy_of_document",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy_of"]["@id"],
             f"{self.portal_url}/document",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["@id"],
             f"{self.portal_url}/copy_of_document",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_name"],
             "admin",
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy"]["creator_url"],
             f"{self.portal_url}/author/admin",
         )
@@ -141,7 +141,7 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        self.assertEquals(
+        self.assertEqual(
             response.json()["working_copy_of"],
             None,
         )
@@ -206,7 +206,7 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
             "/document",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(response.json()["title"], "I just changed the title")
+        self.assertEqual(response.json()["title"], "I just changed the title")
 
     def test_workingcopy_patch_on_the_working_copy(self):
         # We create the working copy
@@ -230,4 +230,4 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
             "/document",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(response.json()["title"], "I just changed the title")
+        self.assertEqual(response.json()["title"], "I just changed the title")

--- a/src/plone/restapi/tests/test_services_workingcopy.py
+++ b/src/plone/restapi/tests/test_services_workingcopy.py
@@ -19,7 +19,7 @@ class TestWorkingCopyEndpoint(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 

--- a/src/plone/restapi/tests/test_site_serializer.py
+++ b/src/plone/restapi/tests/test_site_serializer.py
@@ -69,7 +69,7 @@ class TestSiteSerializationFunctional(unittest.TestCase):
         self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        self.api_session = RelativeSession(f"{self.portal_url}/++api++")
+        self.api_session = RelativeSession(f"{self.portal_url}/++api++", test=self)
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
     def tearDown(self):

--- a/src/plone/restapi/tests/test_system.py
+++ b/src/plone/restapi/tests/test_system.py
@@ -23,7 +23,7 @@ class TestSystemFunctional(unittest.TestCase):
         self.request = self.portal.REQUEST
         self.catalog = getToolByName(self.portal, "portal_catalog")
 
-        self.api_session = RelativeSession(self.portal_url)
+        self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         overview_control_panel = OverviewControlPanel(self.portal, self.request)

--- a/src/plone/restapi/tests/test_tus.py
+++ b/src/plone/restapi/tests/test_tus.py
@@ -65,7 +65,7 @@ class TestTUS(unittest.TestCase):
         self.upload_url = f"{self.folder.absolute_url()}/@tus-upload"
         transaction.commit()
 
-        self.api_session = RelativeSession(self.portal.absolute_url())
+        self.api_session = RelativeSession(self.portal.absolute_url(), test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
@@ -576,7 +576,7 @@ class TestTUSUploadWithCORS(unittest.TestCase):
             CORSTestPolicy, adapts=(Interface, IBrowserRequest), provides=ICORSPolicy
         )
         self.portal = self.layer["portal"]
-        self.api_session = RelativeSession(self.portal.absolute_url())
+        self.api_session = RelativeSession(self.portal.absolute_url(), test=self)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         self.upload_url = f"{self.portal.absolute_url()}/@tus-upload"


### PR DESCRIPTION
Resolve all the deprecation warnings that originate in this package's code that are
exposed by running the tests.  Also, fix or workaround `ResourceWarning: unclosed
<socket.socket ...>` warnings when running the tests.

With these changes, the bulk of warnings output while running the tests have been
removed.  This means there's a *lot* less to ignore in the test output and we should not
be training ourselves to ignore test output.