### PR TITLE
7.x.x - Return non-batched vocabularies given a query param b_size=-1 (#1265)

### DIFF
--- a/docs/source/vocabularies.rst
+++ b/docs/source/vocabularies.rst
@@ -83,6 +83,8 @@ The token is what should be sent to the server to address that term.
 .. literalinclude:: ../../src/plone/restapi/tests/http-examples/vocabularies_get.resp
    :language: http
 
+By default, the vocabularies are batched. However, you can pass ``b_size=-1`` parameter to force the endpoint to return all the terms, not batched response.
+
 Filter Vocabularies
 ^^^^^^^^^^^^^^^^^^^
 

--- a/news/1264.feature
+++ b/news/1264.feature
@@ -1,0 +1,2 @@
+Return non-batched vocabularies given a query param ``b_size=-1``
+[sneridagh]

--- a/src/plone/restapi/serializer/vocabularies.py
+++ b/src/plone/restapi/serializer/vocabularies.py
@@ -30,6 +30,7 @@ class SerializeVocabLikeToJson(object):
         vocabulary = self.context
         title = safe_unicode(self.request.form.get("title", ""))
         token = self.request.form.get("token", "")
+        b_size = self.request.form.get("b_size", "")
 
         terms = []
         for term in vocabulary:
@@ -52,9 +53,19 @@ class SerializeVocabLikeToJson(object):
                     continue
                 terms.append(term)
 
+        serialized_terms = []
+
+        # Do not batch parameter is set
+        if b_size == "-1":
+            for term in terms:
+                serializer = getMultiAdapter(
+                    (term, self.request), interface=ISerializeToJson
+                )
+                serialized_terms.append(serializer())
+            return {"@id": vocabulary_id, "items": serialized_terms}
+
         batch = HypermediaBatch(self.request, terms)
 
-        serialized_terms = []
         for term in batch:
             serializer = getMultiAdapter(
                 (term, self.request), interface=ISerializeToJson

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -39,7 +39,10 @@ def test_vocabulary_factory(context):
 
 
 TEST_BIG_VOCABULARY = SimpleVocabulary(
-    [SimpleTerm(a, token=f"token{a}", title=f"Title {a}") for a in range(100)]
+    [
+        SimpleTerm(a, token="token{a}".format(a=a), title="Title {a}".format(a=a))
+        for a in range(100)
+    ]
 )
 
 

--- a/src/plone/restapi/tests/test_services_vocabularies.py
+++ b/src/plone/restapi/tests/test_services_vocabularies.py
@@ -38,6 +38,15 @@ def test_vocabulary_factory(context):
     return TEST_VOCABULARY
 
 
+TEST_BIG_VOCABULARY = SimpleVocabulary(
+    [SimpleTerm(a, token=f"token{a}", title=f"Title {a}") for a in range(100)]
+)
+
+
+def test_big_vocabulary_factory(context):
+    return TEST_BIG_VOCABULARY
+
+
 def test_context_vocabulary_factory(context):
     return SimpleVocabulary(
         [
@@ -293,6 +302,20 @@ class TestVocabularyEndpoint(unittest.TestCase):
                 u"items_total": 2,
             },
         )
+
+    def test_big_vocabulary_not_batched(self):
+        provideUtility(
+            test_big_vocabulary_factory,
+            provides=IVocabularyFactory,
+            name="plone.restapi.tests.test_big_vocabulary",
+        )
+        response = self.api_session.get(
+            "/@vocabularies/plone.restapi.tests.test_big_vocabulary?b_size=-1"
+        )
+
+        self.assertEqual(200, response.status_code)
+        response = response.json()
+        self.assertEqual(len(response["items"]), 100)
 
     def tearDown(self):
         self.api_session.close()


### PR DESCRIPTION
* Return non-batched vocabularies given a query param not_batched

* Change parameter name to b_size=-1

* Amend changelogg