### PR TITLE
Be permissive when testing the schema of the querystring endpoint

### DIFF
--- a/news/1307.feature
+++ b/news/1307.feature
@@ -1,0 +1,1 @@
+Be permissive when testing the schema of the querystring endpoint [reebalazs]

--- a/src/plone/restapi/tests/test_services_querystring.py
+++ b/src/plone/restapi/tests/test_services_querystring.py
@@ -64,7 +64,14 @@ class TestQuerystringEndpoint(unittest.TestCase):
             "values": {},
             "vocabulary": None,
         }
-        self.assertEqual(expected_field_config, idx)
+        # Be permissive with the check and only check the existing
+        # attributes. (This gives plone.app.querystring to extend its schema
+        # when that becomes necessary, while making sure that all code depending
+        # on any existing attributes continues to work.)
+        filtered_idx = {}
+        for key in expected_field_config:
+            filtered_idx[key] = idx.get(key, "NOT-FOUND")
+        self.assertEqual(expected_field_config, filtered_idx)
 
     def test_endpoint_inlines_vocabularies(self):
         response = self.api_session.get("/@querystring")


### PR DESCRIPTION
Allow any additional property to be defined by plone.app.querystring,
otherwise no properties can ever be added. The change also makes sure
that all code depending on any existing attributes continues to work.
This is needed in favor of
https://github.com/plone/plone.app.querystring/pull/104 .