### PR TITLE
Customize Subjects field serializer to handle permission

### DIFF
--- a/src/plone/restapi/types/configure.zcml
+++ b/src/plone/restapi/types/configure.zcml
@@ -26,6 +26,10 @@
       />
   <adapter factory=".adapters.SetJsonSchemaProvider" />
   <adapter factory=".adapters.TupleJsonSchemaProvider" />
+  <adapter
+      factory=".adapters.SubjectsFieldJsonSchemaProvider"
+      name="subjects"
+      />
   <adapter factory=".adapters.ChoiceJsonSchemaProvider" />
   <adapter factory=".adapters.ObjectJsonSchemaProvider" />
   <adapter factory=".adapters.DictJsonSchemaProvider" />


### PR DESCRIPTION
With this change, we return "additionalItems" flag based on what is set in Plone control panel (like in the dx widget).

(we need to handle this parameter also in Volto..we will fix it or open a new issue soon)