### PR TITLE
Point to the correct repository branch for sphinx-book-theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,7 +172,7 @@ html_theme_options = {
     # "google_analytics_id": "UA-1907133-6",
     "path_to_docs": "docs",
     "repository_url": "https://github.com/plone/plone.restapi",
-    "repository_branch": "plone6docs",
+    "repository_branch": "master",
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,

--- a/news/1346.bugfix
+++ b/news/1346.bugfix
@@ -1,0 +1,1 @@
+Fix the link in the GitHub menu item "suggest edit" to point to master branch. [stevepiercy]


### PR DESCRIPTION
Fix the link in the GitHub menu item "suggest edit" to point to master branch.