### PR TITLE
Temporarily include mockup egg on Plone 6.

### DIFF
--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -14,6 +14,12 @@ Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git
 [instance]
 recipe = plone.recipe.zope2instance
 zodb-temporary-storage = off
+# On March 24 2022, all ES6 stuff was merged.
+# Since then, mockup is no longer a Python package and is not pulled in by CMFPlone
+# The plone.app.widgets pinned in 6.0.0a3 still tries to import it.
+# So temporarily include the egg explicitly, until Plone 6.0.0a4 is out.
+# Alternative would be to add plone.app.widgets to the checkouts.
+eggs += mockup
 
 [versions]
 # we need the new traversal

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -25,6 +25,10 @@ eggs += mockup
 # we need the new traversal
 plone.rest = 2.0.0a3
 
+# We need newer plone.app.testing to fix test setup errors like this:
+# ZODB.POSException.POSKeyError: 'RequestContainer' object has no attribute 'adapters'
+plone.app.testing = 7.0.0a2
+
 black = 21.7b0
 
 # cffi 1.14.3 fails on apple m1


### PR DESCRIPTION
Otherwise the buildout fails since the ES6 merges yesterday.
See [this GHA run](https://github.com/plone/plone.restapi/runs/5687219593?check_suite_focus=true#step:11:203).