### PR TITLE
Fix testing matrix to use correct combos of Python and Plone.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.7, 3.6]
-        plone-version: ["6.0", "5.2"]
+        include:
+          - python-version: '3.6'
+            plone-version: '5.2'
+          - python-version: '3.7'
+            plone-version: '5.2'
+          - python-version: '3.8'
+            plone-version: '5.2'
+          - python-version: '3.7'
+            plone-version: '6.0'
+          - python-version: '3.8'
+            plone-version: '6.0'
+          - python-version: '3.9'
+            plone-version: '6.0'
 
     steps:
       # git checkout

--- a/news/1356.bugfix
+++ b/news/1356.bugfix
@@ -1,0 +1,2 @@
+Fix testing matrix to use correct combos of Python and Plone.
+[maurits]

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -14,6 +14,12 @@ Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git
 [instance]
 recipe = plone.recipe.zope2instance
 zodb-temporary-storage = off
+# On March 24 2022, all ES6 stuff was merged.
+# Since then, mockup is no longer a Python package and is not pulled in by CMFPlone
+# The plone.app.widgets pinned in 6.0.0a3 still tries to import it.
+# So temporarily include the egg explicitly, until Plone 6.0.0a4 is out.
+# Alternative would be to add plone.app.widgets to the checkouts.
+eggs += mockup
 
 [versions]
 # we need the new traversal

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -25,6 +25,10 @@ eggs += mockup
 # we need the new traversal
 plone.rest = 2.0.0a3
 
+# We need newer plone.app.testing to fix test setup errors like this:
+# ZODB.POSException.POSKeyError: 'RequestContainer' object has no attribute 'adapters'
+plone.app.testing = 7.0.0a2
+
 black = 21.7b0
 
 # cffi 1.14.3 fails on apple m1


### PR DESCRIPTION
This includes the fixes from my PR #1354.

The previous settings were fine for Plone 5.2, but not for 6.0. They tested unsupported Python 3.6, and were missing the supported Python 3.9.
We could have kept the two lists, but that would mean we need both an exclude (3.6) and an include (3.9). So instead I specify all valid combinations explicitly: for me this looks simpler.
