### PR TITLE
Checkout specific commit of CMFPlone.

### DIFF
--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -7,9 +7,10 @@ find-links = https://dist.plone.org/release/6.0.0a3/
 versions=versions
 auto-checkout =
     Products.CMFPlone
+always-checkout = true
 
 [sources]
-Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git
+Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git rev=1103e16165ede181eec0b1a27b9c5a64e0046172
 
 [instance]
 recipe = plone.recipe.zope2instance


### PR DESCRIPTION
Fixes buildout error for missing plone.base package, from the merged PLIP 3395.

See [failed run](https://github.com/plone/plone.restapi/runs/5856639094?check_suite_focus=true) on plone.restapi master.
