### PR TITLE
Upgrade CI to Plone 6.0.0a4

### DIFF
--- a/.github/workflows/plone6.yml
+++ b/.github/workflows/plone6.yml
@@ -1,4 +1,4 @@
-name: Tests Plone 5
+name: Tests Plone 6
 on: [push]
 jobs:
   build:
@@ -6,8 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        plone-version: ['5.2']
-        python-version: ['3.6' '3.7', '3.8']
+        plone-version: ['6.0']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
       # git checkout
@@ -27,11 +27,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      # python install
-      - run: pip install virtualenv
-      - run: pip install wheel
+      # pip install
       - name: pip install
-        run: pip install -r requirements.txt -r requirements-docs.txt
+        run: pip install -r requirements-60.txt -r requirements-docs.txt
 
       # buildout
       - name: buildout
@@ -43,22 +41,12 @@ jobs:
       - name: code analysis
         run: bin/code-analysis
 
-      # build sphinx
-      - name: sphinx
-#        run: if [ "${{ matrix.plone-version }}" == "5.2" ] && [ ${{ matrix.python-version }} == '3.7' ]; then bin/sphinxbuilder; fi
-        run: if [ "${{ matrix.plone-version }}" == "5.2" ] && [ ${{ matrix.python-version }} == '3.7' ]; then make docs-html; fi
-
       # test
       - name: test
         run: bin/test
 
+      # Commented out a few actions that should not currently be run on Plone 6.
+      # Kept a note here, so we do not forget about them when we drop Plone 5 support.
+      # build sphinx
       # test no uncommited changes
-      - name: test no uncommited changes
-        run: bin/test-no-uncommitted-doc-changes
-        env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
-          PLONE_VERSION: ${{ matrix.plone-version }}
-
       # test sphinx warnings
-#      - name: sphinx
-#        run: if [ "${{ matrix.plone-version }}" == "5.2" ] && [ ${{ matrix.python-version }} == '3.7' ]; then bin/test-no-sphinx-warnings; fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         plone-version: ['5.2']
-        python-version: ['3.6' '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8']
 
     steps:
       # git checkout

--- a/Makefile
+++ b/Makefile
@@ -65,15 +65,15 @@ build-plone-5.2-performance: .installed.cfg  ## Build Plone 5.2
 	bin/buildout -c plone-5.2.x-performance.cfg
 
 .PHONY: Build Plone 6.0
-build-plone-6.0: .installed.cfg  ## Build Plone 6.0
+build-plone-6.0: bin/buildout *.cfg  ## Build Plone 6.0
 	bin/pip install --upgrade pip
-	bin/pip install -r requirements.txt
+	bin/pip install -r requirements-60.txt
 	bin/buildout -c plone-6.0.x.cfg
 
 .PHONY: Build Plone 6.0 Performance
-build-plone-6.0-performance: .installed.cfg  ## Build Plone 6.0
+build-plone-6.0-performance: bin/buildout *.cfg  ## Build Plone 6.0
 	bin/pip install --upgrade pip
-	bin/pip install -r requirements.txt
+	bin/pip install -r requirements-60.txt
 	bin/buildout -c plone-6.0.x-performance.cfg
 
 .PHONY: Test

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -24,10 +24,3 @@ eggs += mockup
 
 [versions]
 black = 21.7b0
-
-# cffi 1.14.3 fails on apple m1
-# cffi 1.14.4 fails with "ModuleNotFoundError: No module named '_cffi_backend'"
-cffi = 1.14.6
-
-# Error: The requirement ('importlib-metadata<4.3') is not allowed by your [versions] constraint (4.5.0)
-importlib-metadata = 4.2.0

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -9,6 +9,11 @@ auto-checkout =
 #    Products.CMFPlone
 always-checkout = true
 
+[buildout:python37]
+parts =
+    test
+    code-analysis
+
 [sources]
 Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git rev=1103e16165ede181eec0b1a27b9c5a64e0046172
 

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -1,12 +1,12 @@
 [buildout]
 extensions = mr.developer
 extends =
-    https://dist.plone.org/release/6.0.0a3/versions.cfg
+    https://dist.plone.org/release/6.0.0a4/versions.cfg
     base.cfg
-find-links = https://dist.plone.org/release/6.0.0a3/
+find-links = https://dist.plone.org/release/6.0.0a4/
 versions=versions
 auto-checkout =
-    Products.CMFPlone
+#    Products.CMFPlone
 always-checkout = true
 
 [sources]
@@ -23,13 +23,6 @@ zodb-temporary-storage = off
 eggs += mockup
 
 [versions]
-# we need the new traversal
-plone.rest = 2.0.0a3
-
-# We need newer plone.app.testing to fix test setup errors like this:
-# ZODB.POSException.POSKeyError: 'RequestContainer' object has no attribute 'adapters'
-plone.app.testing = 7.0.0a2
-
 black = 21.7b0
 
 # cffi 1.14.3 fails on apple m1

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -24,3 +24,8 @@ eggs += mockup
 
 [versions]
 black = 21.7b0
+
+[versions:python37]
+# Requirement of flake8>=2.4.0: importlib-metadata<4.3
+# Error: The requirement ('importlib-metadata<4.3') is not allowed by your [versions] constraint (4.11.2)
+importlib-metadata = 4.2.0

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -15,12 +15,6 @@ Products.CMFPlone = git https://github.com/plone/Products.CMFPlone.git rev=1103e
 [instance]
 recipe = plone.recipe.zope2instance
 zodb-temporary-storage = off
-# On March 24 2022, all ES6 stuff was merged.
-# Since then, mockup is no longer a Python package and is not pulled in by CMFPlone
-# The plone.app.widgets pinned in 6.0.0a3 still tries to import it.
-# So temporarily include the egg explicitly, until Plone 6.0.0a4 is out.
-# Alternative would be to add plone.app.widgets to the checkouts.
-eggs += mockup
 
 [versions]
 black = 21.7b0

--- a/requirements-60.txt
+++ b/requirements-60.txt
@@ -1,0 +1,12 @@
+# from https://dist.plone.org/release/6.0.0a4/requirements.txt
+setuptools==62.0.0
+zc.buildout==3.0.0rc3
+pip==22.0.4
+wheel==0.37.1
+
+# Windows specific down here (has to be installed here, fails in buildout)
+# Dependency of zope.sendmail:
+pywin32 ; platform_system == 'Windows'
+
+# SSL Certs on windows, because Python is missing them otherwise:
+certifi ; platform_system == 'Windows'


### PR DESCRIPTION
This takes the first commit of PR #1360 and then fixes the test setup by splitting a new `plone6.yml` off from the largely unchanged `tests.yml` which is then still used for Plone 5.