### PR TITLE
Prevent to create an empty AT content.

### DIFF
--- a/news/1386.bugfix
+++ b/news/1386.bugfix
@@ -1,0 +1,2 @@
+Prevent to create an empty AT content.
+[gbastien]

--- a/src/plone/restapi/deserializer/atcontent.py
+++ b/src/plone/restapi/deserializer/atcontent.py
@@ -52,7 +52,7 @@ class DeserializeFromJson(OrderingMixin, object):
                 mutator(value, **kwargs)
                 modified = True
 
-        if modified:
+        if create or modified:
             errors = self.validate()
             if not validate_all:
                 errors = {f: e for f, e in errors.items() if f in data}

--- a/src/plone/restapi/tests/test_atcontent_deserializer.py
+++ b/src/plone/restapi/tests/test_atcontent_deserializer.py
@@ -160,6 +160,14 @@ class TestATContentDeserializer(unittest.TestCase, OrderingMixin):
         self.deserialize(body='{"layout": "my_new_layout"}')
         self.assertEqual("my_new_layout", self.doc1.getLayout())
 
+    def test_validation_done_when_create(self):
+        self.doc1.setTitle("")
+        self.assertEqual(self.deserialize(body='{}'), self.doc1)
+        with self.assertRaises(BadRequest) as cm:
+            self.deserialize(body='', create=True, validate_all=True)
+        self.assertEqual("Title is required, please correct.",
+                         cm.exception.args[0][1]["message"])
+
 
 class TestValidationRequest(unittest.TestCase):
 


### PR DESCRIPTION
See #1386
Hi,

this is a fix to prevent creating an empty AT content (the way DX deserializer is implemented prevent this).

This is for the 7.x.x branch, could you please review, merge and do a new release?

Thank you!
Gauthier