### PR TITLE
Fixed timestamp calculation in history service on Python 3.10.

### DIFF
--- a/news/1391.bugfix
+++ b/news/1391.bugfix
@@ -1,0 +1,2 @@
+Fixed timestamp calculation in history service on Python 3.10.
+[maurits]

--- a/src/plone/restapi/services/history/get.py
+++ b/src/plone/restapi/services/history/get.py
@@ -71,7 +71,7 @@ class HistoryGet(Service):
             # Versioning entries use a timestamp,
             # workflow ISO formatted string
             if not isinstance(item["time"], str):
-                item["time"] = dt.fromtimestamp(item["time"]).isoformat()
+                item["time"] = dt.fromtimestamp(int(item["time"])).isoformat()
 
             # The create event has an empty 'action', but we like it to say
             # 'Create', alike the transition_title


### PR DESCRIPTION
Fixes https://github.com/plone/plone.restapi/issues/1391