### PR TITLE
document the version pins needed to install plone.restapi 7.x in a Pl…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,43 @@ Install plone.restapi by adding it to your buildout::
 
 and then running ``bin/buildout``
 
+When installing plone.restapi version 7.x.x in Plone 4 you may need to add the following version pins to your buildout::
+  
+    [versions]
+    PyJWT = 1.7.1
+
+    six = 1.11.0
+    attrs = 21.2.0
+    plone.rest = 1.6.2
+    plone.schema = 1.3.0
+    # Last pyrsistent version that is python 2 compatible:
+    pyrsistent = 0.15.7
+
+    # Required by:
+    # jsonschema==3.2.0
+    functools32 = 3.2.3.post2
+
+    # Required by:
+    # plone.schema==1.3.0
+    jsonschema = 3.2.0
+
+    # Required by:
+    # importlib-metadata==1.3.0
+    pathlib2 = 2.3.5
+
+    # Required by:
+    # pathlib2==2.3.5
+    scandir = 1.10.0
+
+    # plone.app.contenttypes > 1.0
+    plone.app.contenttypes = 1.1.9
+
+    importlib-metadata = 2.1.3
+    zipp = 1.2.0
+    configparser = 4.0.2
+    contextlib2 = 0.6.0.post1
+
+
 
 Contribute
 ==========


### PR DESCRIPTION
…one 4.3 buildout

Fixes #1150

I have been bitten by this today (again), and I have documented the list of version pins needed to successfully run a Plone 4.3.x buildout with plone.restapi 7.x.x. 