### PR TITLE
Do not break path2uid with strange links

### DIFF
--- a/news/1428.bugfix
+++ b/news/1428.bugfix
@@ -1,0 +1,2 @@
+Do not break path2uid with some edge-cases.
+[cekk]

--- a/src/plone/restapi/deserializer/utils.py
+++ b/src/plone/restapi/deserializer/utils.py
@@ -30,9 +30,11 @@ def path2uid(context, link):
     suffix = ""
     while not IUUIDAware.providedBy(obj):
         obj = aq_parent(obj)
+        if obj is None:
+            break
         suffix += "/" + segments.pop()
     # check if obj is wrong because of acquisition
-    if "/".join(obj.getPhysicalPath()) != "/".join(segments):
+    if not obj or "/".join(obj.getPhysicalPath()) != "/".join(segments):
         return link
     href = relative_up * "../" + "resolveuid/" + IUUID(obj)
     if suffix:

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -427,7 +427,7 @@ class TestBlocksDeserializer(unittest.TestCase):
                         {
                             # Pointing to a not created yet object, but matches because acquisition
                             # with another existing parent content with alike-ish path structure
-                            "@id": f"../.."
+                            "@id": "../.."
                         }
                     ],
                 }

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -417,3 +417,23 @@ class TestBlocksDeserializer(unittest.TestCase):
             self.portal.doc1.blocks["123"]["href"][0]["@id"],
             f"../resolveuid/{wrong_uid}",
         )
+
+        # another use-case: pass "../.." as link. Do not change the link.
+        self.deserialize(
+            blocks={
+                "123": {
+                    "@type": "foo",
+                    "href": [
+                        {
+                            # Pointing to a not created yet object, but matches because acquisition
+                            # with another existing parent content with alike-ish path structure
+                            "@id": f"../.."
+                        }
+                    ],
+                }
+            }
+        )
+        self.assertEqual(
+            self.portal.doc1.blocks["123"]["href"][0]["@id"],
+            "../..",
+        )


### PR DESCRIPTION
We had a some strange links in migrated data from a very old Plone. For example "../..".
With these changes, the method does not break and returns the given link.