### PR TITLE
Tests: patch unique url for scale in old or new way.

### DIFF
--- a/news/57.bugfix
+++ b/news/57.bugfix
@@ -1,0 +1,3 @@
+Tests: patch unique url for scale in old or new way.
+This is only in serializer tests for images.
+[maurits]

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -1,6 +1,5 @@
 from base64 import b64encode
 from datetime import datetime
-from unittest.mock import patch
 from pkg_resources import resource_filename
 from plone import api
 from plone.app.discussion.interfaces import IConversation
@@ -25,6 +24,7 @@ from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_ITERATE_FUNCTIONAL_TESTING
 from plone.restapi.testing import register_static_uuid_utility
 from plone.restapi.testing import RelativeSession
+from plone.restapi.tests.helpers import patch_scale_uuid
 from plone.restapi.tests.statictime import StaticTime
 from plone.scale import storage
 from plone.testing.z2 import Browser
@@ -301,7 +301,8 @@ class TestDocumentation(TestDocumentationBase):
         self.portal.newsitem.image_caption = "This is an image caption."
         transaction.commit()
 
-        with patch.object(storage, "uuid4", return_value="uuid1"):
+        scale_url_uuid = "uuid1"
+        with patch_scale_uuid(scale_url_uuid):
             response = self.api_session.get(self.portal.newsitem.absolute_url())
             save_request_and_response_for_docs("newsitem", response)
 
@@ -349,7 +350,8 @@ class TestDocumentation(TestDocumentationBase):
             data=image_data, contentType="image/png", filename="image.png"
         )
         transaction.commit()
-        with patch.object(storage, "uuid4", return_value="uuid1"):
+        scale_url_uuid = "uuid1"
+        with patch_scale_uuid(scale_url_uuid):
             response = self.api_session.get(self.portal.image.absolute_url())
             save_request_and_response_for_docs("image", response)
 

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -26,7 +26,6 @@ from plone.restapi.testing import register_static_uuid_utility
 from plone.restapi.testing import RelativeSession
 from plone.restapi.tests.helpers import patch_scale_uuid
 from plone.restapi.tests.statictime import StaticTime
-from plone.scale import storage
 from plone.testing.z2 import Browser
 from zope.component import createObject
 from zope.component import getUtility

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -13,10 +13,9 @@ from plone.namedfile.file import NamedImage
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.serializer.dxfields import DefaultFieldSerializer
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
-from plone.scale import storage
+from plone.restapi.tests.helpers import patch_scale_uuid
 from plone.uuid.interfaces import IUUID
 from unittest import TestCase
-from unittest.mock import patch
 from z3c.form.interfaces import IDataManager
 from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
@@ -387,7 +386,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
         with open(image_file, "rb") as f:
             image_data = f.read()
         fn = "test_namedimage_field"
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
+        scale_url_uuid = "uuid_1"
+        with patch_scale_uuid(scale_url_uuid):
             value = self.serialize(
                 fn,
                 NamedImage(
@@ -396,7 +396,6 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
             self.assertTrue(isinstance(value, dict), "Not a <dict>")
 
-            scale_url_uuid = "uuid_1"
             obj_url = self.doc1.absolute_url()
 
             # Original image is still a "scale"
@@ -483,7 +482,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
         is returned as is and we need to check it, but the scales should be empty"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedimage_field"
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
+        scale_url_uuid = "uuid_1"
+        with patch_scale_uuid(scale_url_uuid):
             value = self.serialize(
                 fn,
                 NamedImage(
@@ -492,7 +492,6 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
 
         obj_url = self.doc1.absolute_url()
-        scale_url_uuid = "uuid_1"
         self.assertEqual(
             {
                 "content-type": "image/gif",
@@ -514,7 +513,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
         with open(image_file, "rb") as f:
             image_data = f.read()
         fn = "test_namedblobimage_field"
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
+        scale_url_uuid = "uuid_1"
+        with patch_scale_uuid(scale_url_uuid):
             value = self.serialize(
                 fn,
                 NamedBlobImage(
@@ -523,7 +523,6 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
             self.assertTrue(isinstance(value, dict), "Not a <dict>")
 
-            scale_url_uuid = "uuid_1"
             obj_url = self.doc1.absolute_url()
 
             # Original image is still a "scale"
@@ -610,7 +609,8 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
         is returned as is and we need to check it, but the scales should be empty"""
         image_data = b"INVALID IMAGE DATA"
         fn = "test_namedblobimage_field"
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
+        scale_url_uuid = "uuid_1"
+        with patch_scale_uuid(scale_url_uuid):
             value = self.serialize(
                 fn,
                 NamedBlobImage(
@@ -619,7 +619,6 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
 
         obj_url = self.doc1.absolute_url()
-        scale_url_uuid = "uuid_1"
         self.assertEqual(
             {
                 "content-type": "image/gif",

--- a/src/plone/restapi/tests/test_serializer.py
+++ b/src/plone/restapi/tests/test_serializer.py
@@ -7,9 +7,8 @@ from plone.namedfile.file import NamedBlobImage
 from plone.namedfile.file import NamedFile
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
-from plone.scale import storage
+from plone.restapi.tests.helpers import patch_scale_uuid
 from Products.CMFCore.utils import getToolByName
-from unittest.mock import patch
 from zope.component import getMultiAdapter
 
 import json
@@ -261,9 +260,9 @@ class TestSerializeToJsonAdapter(unittest.TestCase):
 
         self.maxDiff = 99999
 
-        with patch.object(storage, "uuid4", return_value="uuid_1"):
+        scale_url_uuid = "uuid_1"
+        with patch_scale_uuid(scale_url_uuid):
             obj_url = self.portal.image1.absolute_url()
-            scale_url_uuid = "uuid_1"
             download_url = f"{obj_url}/@@images/{scale_url_uuid}.png"
             scales = {
                 "listing": {"download": download_url, "width": 16, "height": 4},

--- a/src/plone/restapi/tests/test_services.py
+++ b/src/plone/restapi/tests/test_services.py
@@ -8,7 +8,6 @@ from plone.namedfile.file import NamedBlobImage
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
 from plone.restapi.tests.helpers import patch_scale_uuid
-from plone.scale import storage
 from z3c.relationfield import RelationValue
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds

--- a/src/plone/restapi/tests/test_services.py
+++ b/src/plone/restapi/tests/test_services.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -8,6 +7,7 @@ from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
+from plone.restapi.tests.helpers import patch_scale_uuid
 from plone.scale import storage
 from z3c.relationfield import RelationValue
 from zope.component import getUtility
@@ -87,7 +87,8 @@ class TestTraversal(unittest.TestCase):
         self.portal.news1.image_caption = "This is an image caption."
         transaction.commit()
 
-        with patch.object(storage, "uuid4", return_value="uuid1"):
+        scale_url_uuid = "uuid1"
+        with patch_scale_uuid(scale_url_uuid):
             response = self.api_session.get(self.portal.news1.absolute_url())
 
             self.assertEqual(response.status_code, 200)
@@ -112,7 +113,7 @@ class TestTraversal(unittest.TestCase):
                 "This is an image caption.", response.json()["image_caption"]
             )
             self.assertDictContainsSubset(
-                {"download": self.portal_url + "/news1/@@images/uuid1.png"},  # noqa
+                {"download": self.portal_url + f"/news1/@@images/{scale_url_uuid}.png"},
                 response.json()["image"],
             )
 


### PR DESCRIPTION
This is only in serializer tests for images.

uuid4 is only used until plone.scale 6.0.0a4.
https://github.com/plone/plone.scale/pull/57 introduces a new way.

We also patch the _modified_since method to always return True.
Otherwise you may get info from a different scale back, precisely because we give all scales the same "unique" id,
which then is of course no longer unique, making the logic unstable.
This is needed for the newer plone.scale versions, but should be perfectly fine for the older ones.

The `plone.scale` PR allows us to get the urls without really generating the actual scales and store them in blobs. But this PR does **not** use it yet. Happy to do that, but that can be done slightly later, like after there is a new plone.scale release. With the current PR the tests are at least prepared. They were failing in Jenkins with checkouts of plone.scale and plone.namedfile.