### PR TITLE
Test-only fix: normalize white space in html in some tests.

### DIFF
--- a/news/49.bugfix
+++ b/news/49.bugfix
@@ -1,0 +1,3 @@
+Test-only fix: normalize white space in html in some tests.
+Needed to not fail with newer plone.outputfilters.
+[maurits]

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -342,3 +342,19 @@ def register_static_uuid_utility(prefix):
     prefix = re.sub(r"[^a-zA-Z0-9\-_]", "", prefix)
     generator = StaticUUIDGenerator(prefix)
     getGlobalSiteManager().registerUtility(component=generator)
+
+
+def normalize_html(value):
+    # Strip all white spaces of every line, then join on one line.
+    # But try to avoid getting 'Go to<a href' instead of 'Go to <a href'.
+    lines = []
+    for line in value.splitlines():
+        line = line.strip()
+        if (
+            line.startswith("<")
+            and not line.startswith("</")
+            and not line.startswith("<br")
+        ):
+            line = " " + line
+        lines.append(line)
+    return "".join(lines).strip()

--- a/src/plone/restapi/tests/test_comments.py
+++ b/src/plone/restapi/tests/test_comments.py
@@ -7,6 +7,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.registry.interfaces import IRegistry
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.testing import normalize_html
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from Products.CMFCore.utils import getToolByName
 from Products.PlonePAS.tests import dummy
@@ -166,7 +167,7 @@ class TestCommentsSerializers(TestCase):
         self.assertEqual(
             'Go to <a href="https://www.plone.org" '
             + 'rel="nofollow">https://www.plone.org</a>',
-            serializer()["text"]["data"],
+            normalize_html(serializer()["text"]["data"]),
         )
         # serializer should return mimetype = text/html
         self.assertEqual("text/html", serializer()["text"]["mime-type"])
@@ -189,7 +190,7 @@ class TestCommentsSerializers(TestCase):
         # serializer should return HTML
         self.assertEqual(
             'Go to <a href="https://www.plone.org">Plone</a>',
-            serializer()["text"]["data"],
+            normalize_html(serializer()["text"]["data"]),
         )
         # serializer should return mimetype = text/html
         self.assertEqual("text/html", serializer()["text"]["mime-type"])

--- a/src/plone/restapi/tests/test_content_post.py
+++ b/src/plone/restapi/tests/test_content_post.py
@@ -6,6 +6,7 @@ from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
+from plone.restapi.testing import normalize_html
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from Products.CMFCore.utils import getToolByName
 from zope.component import getGlobalSiteManager
@@ -231,7 +232,10 @@ class TestFolderCreate(unittest.TestCase):
         self.assertEqual(
             "<p>example with '</p>", self.portal.folder1.mydocument2.text.raw
         )
-        self.assertEqual("<p>example with '</p>", response.json()["text"]["data"])
+        self.assertEqual(
+            "<p>example with '</p>",
+            normalize_html(response.json()["text"]["data"]),
+        )
 
     def test_post_with_uid_with_manage_portal_permission(self):
         response = requests.post(


### PR DESCRIPTION
Needed to not fail with newer plone.outputfilters.
Similar to the fix in https://github.com/plone/plone.app.discussion/pull/202, see explanation there.