### PR TITLE
Tests: fixed order of roles in http examples.

### DIFF
--- a/news/1327.feature
+++ b/news/1327.feature
@@ -1,1 +1,1 @@
-- Added 'View comments' and 'Reply to item' permission to discussion [@razvanMiu]
+Added 'View comments' and 'Reply to item' permission to discussion [@razvanMiu]

--- a/news/1452.bugfix
+++ b/news/1452.bugfix
@@ -1,0 +1,2 @@
+Sort the roles in the user serializer.
+[maurits]

--- a/src/plone/restapi/serializer/user.py
+++ b/src/plone/restapi/serializer/user.py
@@ -25,7 +25,7 @@ class BaseSerializer:
         roles = user.getRoles()
         # Anonymous and Authenticated are pseudo roles assign automatically
         # to logged-in or logged-out users. They should not be exposed here
-        roles = list(set(roles) - {"Anonymous", "Authenticated"})
+        roles = sorted(list(set(roles) - {"Anonymous", "Authenticated"}))
 
         data = {
             "@id": f"{portal.absolute_url()}/@users/{user.id}",

--- a/src/plone/restapi/tests/http-examples/users_filtered_by_groups.resp
+++ b/src/plone/restapi/tests/http-examples/users_filtered_by_groups.resp
@@ -26,8 +26,8 @@ Content-Type: application/json
         "location": "Cambridge, MA",
         "portrait": null,
         "roles": [
-            "Reviewer",
-            "Member"
+            "Member",
+            "Reviewer"
         ],
         "username": "noam"
     }

--- a/src/plone/restapi/tests/http-examples/users_filtered_by_username.resp
+++ b/src/plone/restapi/tests/http-examples/users_filtered_by_username.resp
@@ -26,8 +26,8 @@ Content-Type: application/json
         "location": "Cambridge, MA",
         "portrait": null,
         "roles": [
-            "Reviewer",
-            "Member"
+            "Member",
+            "Reviewer"
         ],
         "username": "noam"
     }


### PR DESCRIPTION
"test no uncommitted changes" fails, see for example [this run](https://github.com/plone/plone.restapi/runs/6806798950?check_suite_focus=true#step:12:67). No idea why the PR from earlier this week that added this was green.

(Plus tiny fix in an unrelated news snippet so another check is green.)