### PR TITLE
fix: plone.restapi must work with dependency on only Products.CMFPlone

### DIFF
--- a/news/1461.bugfix
+++ b/news/1461.bugfix
@@ -1,0 +1,2 @@
+Do not hard depend on `plone.app.iterate`. It is not an direct core package and might not be available.
+[jensens]

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -15,7 +15,6 @@ from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.expansion import expandable_elements
 from plone.restapi.serializer.nextprev import NextPrevious
-from plone.restapi.serializer.working_copy import WorkingCopyInfo
 from plone.restapi.services.locking import lock_info
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.supermodel.utils import mergedTaggedValueDict
@@ -29,6 +28,13 @@ from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema import getFields
 from zope.security.interfaces import IPermission
+
+try:
+    # plone.app.iterate is by intend not part of Products.CMFPlone dependencies
+    # so we can not rely on having it
+    from plone.restapi.serializer.working_copy import WorkingCopyInfo
+except ImportError:
+    WorkingCopyInfo = None
 
 
 @implementer(ISerializeToJson)
@@ -77,8 +83,11 @@ class SerializeToJson:
         )
 
         # Insert working copy information
-        baseline, working_copy = WorkingCopyInfo(self.context).get_working_copy_info()
-        result.update({"working_copy": working_copy, "working_copy_of": baseline})
+        if WorkingCopyInfo is not None:
+            baseline, working_copy = WorkingCopyInfo(
+                self.context
+            ).get_working_copy_info()
+            result.update({"working_copy": working_copy, "working_copy_of": baseline})
 
         # Insert locking information
         result.update({"lock": lock_info(obj)})

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -38,7 +38,7 @@
   <include package=".workflow" />
   <include
       package=".workingcopy"
-      zcml:condition="have plone-5"
+      zcml:condition="installed plone.app.iterate"
       />
   <include
       package=".multilingual"


### PR DESCRIPTION
Currently restapi depends on `plone.app.iterate`. 
The assumption, that it is always there, is wrong: it is an (internal) addon, only installed when dependening on 'Plone'.