### PR TITLE
Add Users and Groups controlpanels to default registry

### DIFF
--- a/news/1463.feature
+++ b/news/1463.feature
@@ -1,0 +1,1 @@
+add users and groups controlpanel to registry. [nileshgulia1]

--- a/src/plone/restapi/controlpanels/registry.py
+++ b/src/plone/restapi/controlpanels/registry.py
@@ -113,3 +113,21 @@ class UserGroupControlpanel(RegistryConfigletPanel):
     configlet_category_id = "plone-users-and-groups"
     group = "Users and Groups"
     title = "User and Group Settings"
+
+
+@adapter(Interface, Interface)
+class UsersControlpanel(RegistryConfigletPanel):
+    schema = IUserGroupsSettingsSchema
+    configlet_id = "UsersSettings"
+    configlet_category_id = "plone-users-and-groups"
+    group = "Users and Groups"
+    title = "Users"
+
+
+@adapter(Interface, Interface)
+class GroupsControlpanel(RegistryConfigletPanel):
+    schema = IUserGroupsSettingsSchema
+    configlet_id = "GroupsSettings"
+    configlet_category_id = "plone-users-and-groups"
+    group = "Users and Groups"
+    title = "Groups"

--- a/src/plone/restapi/services/controlpanels/configure.zcml
+++ b/src/plone/restapi/services/controlpanels/configure.zcml
@@ -123,6 +123,18 @@
         name="usergroup"
         />
 
+    <adapter
+        factory="plone.restapi.controlpanels.registry.UsersControlpanel"
+        name="users"
+        />
+
+    <adapter
+        factory="plone.restapi.controlpanels.registry.GroupsControlpanel"
+        name="groups"
+        />
+
+
+
   </configure>
 
 </configure>


### PR DESCRIPTION
I just noticed we still don't have "users" controlpanel in the default registry. I need this to have the schema for `many_users` and `many_groups`.