### PR TITLE
Use _getsafeMemberId when checking for user portrait

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Bug fixes:
 
 
 - Tests: add names to behaviors.  [maurits] (#169)
+- Sanitise user id when checking for portrait [instification]
 
 
 8.23.0 (2022-06-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Bug fixes:
 
 
 - Tests: add names to behaviors.  [maurits] (#169)
-- Sanitise user id when checking for portrait [instification]
+- Sanitise user id when checking for portrait [instification] (#1261)
 
 
 8.23.0 (2022-06-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,6 @@ Bug fixes:
 
 
 - Tests: add names to behaviors.  [maurits] (#169)
-- Sanitise user id when checking for portrait [instification] (#1261)
 
 
 8.23.0 (2022-06-23)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -37,4 +37,5 @@
 - Elio Schmutz
 - Gauthier Bastien
 - Katja Süss
+- Jon Pentland
   

--- a/news/1466.bugfix
+++ b/news/1466.bugfix
@@ -1,0 +1,1 @@
+Sanitise user id when checking for portrait [instification]

--- a/src/plone/restapi/serializer/user.py
+++ b/src/plone/restapi/serializer/user.py
@@ -38,10 +38,12 @@ class BaseSerializer:
 
         for name in getFieldNames(schema):
             if name == "portrait":
+                membership = getToolByName(portal, 'portal_membership')
                 memberdata = getToolByName(portal, "portal_memberdata")
-                if user.id in memberdata.portraits:
+                safe_id = membership._getSafeMemberId(user.id)
+                if safe_id in memberdata.portraits:
                     value = "{}/portal_memberdata/portraits/{}".format(
-                        portal.absolute_url(), user.id
+                        portal.absolute_url(), safe_id
                     )
                 else:
                     value = None

--- a/src/plone/restapi/serializer/user.py
+++ b/src/plone/restapi/serializer/user.py
@@ -38,7 +38,7 @@ class BaseSerializer:
 
         for name in getFieldNames(schema):
             if name == "portrait":
-                membership = getToolByName(portal, 'portal_membership')
+                membership = getToolByName(portal, "portal_membership")
                 memberdata = getToolByName(portal, "portal_memberdata")
                 safe_id = membership._getSafeMemberId(user.id)
                 if safe_id in memberdata.portraits:


### PR DESCRIPTION
This is a very minor PR.

Currently when checking for user portrait it checks to see if the user is in `memberdata.portraits` however it is not sanitising the user id, meaning some users don't get their portrait returned even if it exists. For example if there is a hyphen in the user id.