### PR TITLE
Use Plone latest in buildout

### DIFF
--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,18 +1,10 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/5.2.6/versions.cfg
+    https://dist.plone.org/release/5.2-latest/versions.cfg
     base.cfg
-find-links += https://dist.plone.org/thirdparty/
-versions=versions
 
 [versions]
 black = 21.7b0
-
-# Error: The requirement ('virtualenv>=20.0.35') is not allowed by your [versions] constraint (20.0.26)
-virtualenv = 20.0.35
-
-# Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.23)
-importlib-metadata = 2.0.0
 
 # cffi 1.14.3 fails on apple m1
 # cffi 1.14.4 fails with "ModuleNotFoundError: No module named '_cffi_backend'"
@@ -20,3 +12,11 @@ cffi = 1.14.6
 
 # Use the new plone.rest alpha
 plone.rest = 2.0.0a3
+
+[versions:python36]
+# Error: The requirement ('importlib-metadata<4.3,>=1.1.0') is not allowed by your [versions] constraint (0.23)
+importlib-metadata = 2.0.0
+
+[versions:python37]
+# Error: The requirement ('importlib-metadata<4.3,>=1.1.0') is not allowed by your [versions] constraint (0.23)
+importlib-metadata = 2.0.0

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -1,9 +1,7 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/6.0.0a4/versions.cfg
+    https://dist.plone.org/release/6.0-latest/versions.cfg
     base.cfg
-find-links = https://dist.plone.org/release/6.0.0a4/
-versions=versions
 
 [buildout:python37]
 parts =
@@ -25,3 +23,7 @@ cffi = 1.14.6
 # Requirement of flake8>=2.4.0: importlib-metadata<4.3
 # Error: The requirement ('importlib-metadata<4.3') is not allowed by your [versions] constraint (4.11.2)
 importlib-metadata = 4.2.0
+
+# Requirement of Markdown 3.4.1+: importlib-metadata>=4.4
+# Error: The requirement ('importlib-metadata>=4.4') is not allowed by your [versions] constraint (4.2.0)
+Markdown = 3.3.4

--- a/requirements-5.2.txt
+++ b/requirements-5.2.txt
@@ -1,5 +1,2 @@
-# Keep this file in sync with: https://github.com/kitconcept/buildout/edit/master/requirements.txt
-setuptools==42.0.2
-zc.buildout==2.13.4
-wheel
+-r https://dist.plone.org/release/5.2-latest/requirements.txt
 zpretty

--- a/requirements-6.0.txt
+++ b/requirements-6.0.txt
@@ -1,12 +1,1 @@
-# from https://dist.plone.org/release/6.0.0a4/requirements.txt
-setuptools==62.0.0
-zc.buildout==3.0.0rc3
-pip==22.0.4
-wheel==0.37.1
-
-# Windows specific down here (has to be installed here, fails in buildout)
-# Dependency of zope.sendmail:
-pywin32 ; platform_system == 'Windows'
-
-# SSL Certs on windows, because Python is missing them otherwise:
-certifi ; platform_system == 'Windows'
+-r https://dist.plone.org/release/6.0-latest/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements-5.2.txt

--- a/src/plone/restapi/tests/http-examples/querystring_get.resp
+++ b/src/plone/restapi/tests/http-examples/querystring_get.resp
@@ -7,16 +7,24 @@ Content-Type: application/json
         "Creator": {
             "description": "The person that created an item",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.string.currentUser",
-                "plone.app.querystring.operation.selection.any"
+                "plone.app.querystring.operation.selection.any",
+                "plone.app.querystring.operation.selection.none"
             ],
             "operators": {
                 "plone.app.querystring.operation.selection.any": {
                     "description": "Tip: you can use * to autocomplete.",
                     "operation": "plone.app.querystring.queryparser._contains",
                     "title": "Matches any of",
+                    "widget": "MultipleSelectionWidget"
+                },
+                "plone.app.querystring.operation.selection.none": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Matches none of",
                     "widget": "MultipleSelectionWidget"
                 },
                 "plone.app.querystring.operation.string.currentUser": {
@@ -34,6 +42,7 @@ Content-Type: application/json
         "Description": {
             "description": "An item's description",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Text",
             "operations": [
                 "plone.app.querystring.operation.string.contains"
@@ -54,6 +63,7 @@ Content-Type: application/json
         "SearchableText": {
             "description": "Text search of an item's contents",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Text",
             "operations": [
                 "plone.app.querystring.operation.string.contains"
@@ -74,10 +84,12 @@ Content-Type: application/json
         "Subject": {
             "description": "Tags are used for organization of content",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Text",
             "operations": [
                 "plone.app.querystring.operation.selection.any",
-                "plone.app.querystring.operation.selection.all"
+                "plone.app.querystring.operation.selection.all",
+                "plone.app.querystring.operation.selection.none"
             ],
             "operators": {
                 "plone.app.querystring.operation.selection.all": {
@@ -91,6 +103,12 @@ Content-Type: application/json
                     "operation": "plone.app.querystring.queryparser._contains",
                     "title": "Matches any of",
                     "widget": "MultipleSelectionWidget"
+                },
+                "plone.app.querystring.operation.selection.none": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Matches none of",
+                    "widget": "MultipleSelectionWidget"
                 }
             },
             "sortable": false,
@@ -101,6 +119,7 @@ Content-Type: application/json
         "Title": {
             "description": "Text search of an item's title",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Text",
             "operations": [
                 "plone.app.querystring.operation.string.contains"
@@ -121,6 +140,7 @@ Content-Type: application/json
         "created": {
             "description": "The date an item was created",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -204,6 +224,7 @@ Content-Type: application/json
         "effective": {
             "description": "The time and date an item was first published",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -287,6 +308,7 @@ Content-Type: application/json
         "effectiveRange": {
             "description": "Querying this is undefined",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [],
             "operators": {},
@@ -298,6 +320,7 @@ Content-Type: application/json
         "end": {
             "description": "The end date and time of an event",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -381,6 +404,7 @@ Content-Type: application/json
         "expires": {
             "description": "The time and date an item was expired",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -464,15 +488,23 @@ Content-Type: application/json
         "getId": {
             "description": "The short name of an item (used in the url)",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
-                "plone.app.querystring.operation.string.is"
+                "plone.app.querystring.operation.string.is",
+                "plone.app.querystring.operation.string.isNot"
             ],
             "operators": {
                 "plone.app.querystring.operation.string.is": {
                     "description": "Tip: you can use * to autocomplete.",
                     "operation": "plone.app.querystring.queryparser._equal",
                     "title": "Is",
+                    "widget": "StringWidget"
+                },
+                "plone.app.querystring.operation.string.isNot": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Is not",
                     "widget": "StringWidget"
                 }
             },
@@ -484,6 +516,7 @@ Content-Type: application/json
         "getObjPositionInParent": {
             "description": "The order of an item in its parent folder",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.int.is",
@@ -518,6 +551,7 @@ Content-Type: application/json
         "getRawRelatedItems": {
             "description": "Find items related to the selected items",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.reference.is"
@@ -538,6 +572,7 @@ Content-Type: application/json
         "isDefaultPage": {
             "description": "Find items that are the default view for their containing folder.",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.boolean.isTrue",
@@ -565,6 +600,7 @@ Content-Type: application/json
         "isFolderish": {
             "description": "Find items that can contain other objects",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.boolean.isTrue",
@@ -592,6 +628,7 @@ Content-Type: application/json
         "modified": {
             "description": "The time and date an item was last modified",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -675,6 +712,7 @@ Content-Type: application/json
         "path": {
             "description": "The location of an item ",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.string.absolutePath",
@@ -709,15 +747,23 @@ Content-Type: application/json
         "portal_type": {
             "description": "An item's type (e.g. Event)",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
-                "plone.app.querystring.operation.selection.any"
+                "plone.app.querystring.operation.selection.any",
+                "plone.app.querystring.operation.selection.none"
             ],
             "operators": {
                 "plone.app.querystring.operation.selection.any": {
                     "description": "Tip: you can use * to autocomplete.",
                     "operation": "plone.app.querystring.queryparser._contains",
                     "title": "Matches any of",
+                    "widget": "MultipleSelectionWidget"
+                },
+                "plone.app.querystring.operation.selection.none": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Matches none of",
                     "widget": "MultipleSelectionWidget"
                 }
             },
@@ -766,15 +812,23 @@ Content-Type: application/json
         "review_state": {
             "description": "An item's workflow state (e.g.published)",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
-                "plone.app.querystring.operation.selection.any"
+                "plone.app.querystring.operation.selection.any",
+                "plone.app.querystring.operation.selection.none"
             ],
             "operators": {
                 "plone.app.querystring.operation.selection.any": {
                     "description": "Tip: you can use * to autocomplete.",
                     "operation": "plone.app.querystring.queryparser._contains",
                     "title": "Matches any of",
+                    "widget": "MultipleSelectionWidget"
+                },
+                "plone.app.querystring.operation.selection.none": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Matches none of",
                     "widget": "MultipleSelectionWidget"
                 }
             },
@@ -814,6 +868,7 @@ Content-Type: application/json
         "show_inactive": {
             "description": "Select which roles have the permission to view inactive objects",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.string.showInactive"
@@ -865,10 +920,12 @@ Content-Type: application/json
         "sortable_title": {
             "description": "The item's title, transformed for sorting",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Text",
             "operations": [
                 "plone.app.querystring.operation.string.contains",
-                "plone.app.querystring.operation.string.is"
+                "plone.app.querystring.operation.string.is",
+                "plone.app.querystring.operation.string.isNot"
             ],
             "operators": {
                 "plone.app.querystring.operation.string.contains": {
@@ -882,6 +939,12 @@ Content-Type: application/json
                     "operation": "plone.app.querystring.queryparser._equal",
                     "title": "Is",
                     "widget": "StringWidget"
+                },
+                "plone.app.querystring.operation.string.isNot": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Is not",
+                    "widget": "StringWidget"
                 }
             },
             "sortable": true,
@@ -892,6 +955,7 @@ Content-Type: application/json
         "start": {
             "description": "The start date and time of an event",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -977,16 +1041,24 @@ Content-Type: application/json
         "Creator": {
             "description": "The person that created an item",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.string.currentUser",
-                "plone.app.querystring.operation.selection.any"
+                "plone.app.querystring.operation.selection.any",
+                "plone.app.querystring.operation.selection.none"
             ],
             "operators": {
                 "plone.app.querystring.operation.selection.any": {
                     "description": "Tip: you can use * to autocomplete.",
                     "operation": "plone.app.querystring.queryparser._contains",
                     "title": "Matches any of",
+                    "widget": "MultipleSelectionWidget"
+                },
+                "plone.app.querystring.operation.selection.none": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Matches none of",
                     "widget": "MultipleSelectionWidget"
                 },
                 "plone.app.querystring.operation.string.currentUser": {
@@ -1004,6 +1076,7 @@ Content-Type: application/json
         "created": {
             "description": "The date an item was created",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -1087,6 +1160,7 @@ Content-Type: application/json
         "effective": {
             "description": "The time and date an item was first published",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -1170,6 +1244,7 @@ Content-Type: application/json
         "end": {
             "description": "The end date and time of an event",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -1253,6 +1328,7 @@ Content-Type: application/json
         "expires": {
             "description": "The time and date an item was expired",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -1336,15 +1412,23 @@ Content-Type: application/json
         "getId": {
             "description": "The short name of an item (used in the url)",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
-                "plone.app.querystring.operation.string.is"
+                "plone.app.querystring.operation.string.is",
+                "plone.app.querystring.operation.string.isNot"
             ],
             "operators": {
                 "plone.app.querystring.operation.string.is": {
                     "description": "Tip: you can use * to autocomplete.",
                     "operation": "plone.app.querystring.queryparser._equal",
                     "title": "Is",
+                    "widget": "StringWidget"
+                },
+                "plone.app.querystring.operation.string.isNot": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Is not",
                     "widget": "StringWidget"
                 }
             },
@@ -1356,6 +1440,7 @@ Content-Type: application/json
         "getObjPositionInParent": {
             "description": "The order of an item in its parent folder",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
                 "plone.app.querystring.operation.int.is",
@@ -1390,6 +1475,7 @@ Content-Type: application/json
         "modified": {
             "description": "The time and date an item was last modified",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",
@@ -1473,15 +1559,23 @@ Content-Type: application/json
         "review_state": {
             "description": "An item's workflow state (e.g.published)",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Metadata",
             "operations": [
-                "plone.app.querystring.operation.selection.any"
+                "plone.app.querystring.operation.selection.any",
+                "plone.app.querystring.operation.selection.none"
             ],
             "operators": {
                 "plone.app.querystring.operation.selection.any": {
                     "description": "Tip: you can use * to autocomplete.",
                     "operation": "plone.app.querystring.queryparser._contains",
                     "title": "Matches any of",
+                    "widget": "MultipleSelectionWidget"
+                },
+                "plone.app.querystring.operation.selection.none": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Matches none of",
                     "widget": "MultipleSelectionWidget"
                 }
             },
@@ -1521,10 +1615,12 @@ Content-Type: application/json
         "sortable_title": {
             "description": "The item's title, transformed for sorting",
             "enabled": false,
+            "fetch_vocabulary": true,
             "group": "Text",
             "operations": [
                 "plone.app.querystring.operation.string.contains",
-                "plone.app.querystring.operation.string.is"
+                "plone.app.querystring.operation.string.is",
+                "plone.app.querystring.operation.string.isNot"
             ],
             "operators": {
                 "plone.app.querystring.operation.string.contains": {
@@ -1538,6 +1634,12 @@ Content-Type: application/json
                     "operation": "plone.app.querystring.queryparser._equal",
                     "title": "Is",
                     "widget": "StringWidget"
+                },
+                "plone.app.querystring.operation.string.isNot": {
+                    "description": "Tip: you can use * to autocomplete.",
+                    "operation": "plone.app.querystring.queryparser._excludes",
+                    "title": "Is not",
+                    "widget": "StringWidget"
                 }
             },
             "sortable": true,
@@ -1548,6 +1650,7 @@ Content-Type: application/json
         "start": {
             "description": "The start date and time of an event",
             "enabled": true,
+            "fetch_vocabulary": true,
             "group": "Dates",
             "operations": [
                 "plone.app.querystring.operation.date.lessThan",

--- a/src/plone/restapi/tests/http-examples/registry_get_list.resp
+++ b/src/plone/restapi/tests/http-examples/registry_get_list.resp
@@ -6,7 +6,7 @@ Content-Type: application/json
     "batching": {
         "@id": "http://localhost:55001/plone/@registry",
         "first": "http://localhost:55001/plone/@registry?b_start=0",
-        "last": "http://localhost:55001/plone/@registry?b_start=1800",
+        "last": "http://localhost:55001/plone/@registry?b_start=1850",
         "next": "http://localhost:55001/plone/@registry?b_start=25"
     },
     "items": [
@@ -434,5 +434,5 @@ Content-Type: application/json
             "value": false
         }
     ],
-    "items_total": 1823
+    "items_total": 1853
 }

--- a/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
@@ -43,7 +43,7 @@ Content-Type: application/json
             "title": "Soporte de Copia de Trabajo (Repetir)",
             "uninstall_profile_id": "plone.app.iterate:uninstall",
             "upgrade_info": {},
-            "version": "4.0.2"
+            "version": "4.0.3"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.app.multilingual",


### PR DESCRIPTION
For a PR to be accepted, it needs to pass Jenkins tests. In Jenkins, the buildout pins the newest versions. So Plone latest is "closer" to Jenkins, than a pinned version of Plone, which ends up being outdated for a long time. Testing with the most similar versions decreases the chances of the test passing on github and failing on Jenkins, and vice versa.