### PR TITLE
Add unrestricted keyword argument to uuidToObject()

### DIFF
--- a/news/1448.bugfix
+++ b/news/1448.bugfix
@@ -1,0 +1,2 @@
+Fix for test cases failing when deprecating uuidToObject() from `plone.outputfilters.browser.resolveuid`.
+[anirudhhkashyap]

--- a/src/plone/restapi/serializer/utils.py
+++ b/src/plone/restapi/serializer/utils.py
@@ -8,7 +8,7 @@ import re
 
 RESOLVEUID_RE = re.compile("^[./]*resolve[Uu]id/([^/]*)/?(.*)$")
 
-
+# Takes the resolveID URL and returns a URL to the actual object
 def uid_to_url(path):
     if not path:
         return ""
@@ -23,10 +23,10 @@ def uid_to_url(path):
     if suffix:
         href += "/" + suffix
     else:
-        """ Pass unrestricted flag as true so the object is accessible.
-        At uuidToObject(), this leads to unrestrictedTraverse() to be invoked instead of restrictedTraverse().
-        """
-        target_object = uuidToObject(uid, unrestricted = True)
+        # Pass unrestricted flag as true so the object is accessible.
+        # At uuidToObject(), this leads to unrestrictedTraverse() to be invoked instead of restrictedTraverse().
+        
+        target_object = uuidToObject(uid, unrestricted=True)
         if target_object:
             adapter = queryMultiAdapter(
                 (target_object, target_object.REQUEST), IObjectPrimaryFieldTarget

--- a/src/plone/restapi/serializer/utils.py
+++ b/src/plone/restapi/serializer/utils.py
@@ -1,4 +1,4 @@
-from plone.outputfilters.browser.resolveuid import uuidToObject
+from plone.app.uuid.utils import uuidToObject
 from plone.outputfilters.browser.resolveuid import uuidToURL
 from plone.restapi.interfaces import IObjectPrimaryFieldTarget
 from zope.component import queryMultiAdapter
@@ -23,7 +23,10 @@ def uid_to_url(path):
     if suffix:
         href += "/" + suffix
     else:
-        target_object = uuidToObject(uid)
+        """ Pass unrestricted flag as true so the object is accessible.
+        At uuidToObject(), this leads to unrestrictedTraverse() to be invoked instead of restrictedTraverse().
+        """
+        target_object = uuidToObject(uid, unrestricted = True)
         if target_object:
             adapter = queryMultiAdapter(
                 (target_object, target_object.REQUEST), IObjectPrimaryFieldTarget


### PR DESCRIPTION
Fixes: [#1448](https://github.com/plone/plone.restapi/issues/1448)

Changes:
- Pass unrestricted keyword argument to uuidToObject()
- The unrestricted argument value is set to True

Setting the unrestricted flag to True invokes the unrestrictedTraversal() method instead of the restrictedTraversal() method as shown [here](https://github.com/plone/plone.app.uuid/blob/65cdc16a81a9ed12453829fd3fd37d3aca5ac328/plone/app/uuid/utils.py#L94-L96). Earlier, invoking the latter threw the Unauthorized Exception. Now the access to the object can be controlled using the unrestricted flag. This will help in deprecating uuidToObject() from plone.outputfilters.browser.resolveuid.