### PR TITLE
Revert PR #1471

### DIFF
--- a/news/1448.bugfix
+++ b/news/1448.bugfix
@@ -1,2 +1,0 @@
-Fix for test cases failing when deprecating uuidToObject() from `plone.outputfilters.browser.resolveuid`.
-[anirudhhkashyap]

--- a/src/plone/restapi/serializer/utils.py
+++ b/src/plone/restapi/serializer/utils.py
@@ -1,4 +1,4 @@
-from plone.app.uuid.utils import uuidToObject
+from plone.outputfilters.browser.resolveuid import uuidToObject
 from plone.outputfilters.browser.resolveuid import uuidToURL
 from plone.restapi.interfaces import IObjectPrimaryFieldTarget
 from zope.component import queryMultiAdapter
@@ -8,7 +8,7 @@ import re
 
 RESOLVEUID_RE = re.compile("^[./]*resolve[Uu]id/([^/]*)/?(.*)$")
 
-# Takes the resolveID URL and returns a URL to the actual object
+
 def uid_to_url(path):
     if not path:
         return ""
@@ -23,10 +23,7 @@ def uid_to_url(path):
     if suffix:
         href += "/" + suffix
     else:
-        # Pass unrestricted flag as true so the object is accessible.
-        # At uuidToObject(), this leads to unrestrictedTraverse() to be invoked instead of restrictedTraverse().
-        
-        target_object = uuidToObject(uid, unrestricted=True)
+        target_object = uuidToObject(uid)
         if target_object:
             adapter = queryMultiAdapter(
                 (target_object, target_object.REQUEST), IObjectPrimaryFieldTarget


### PR DESCRIPTION
PR #1471 depends on a version of `plone.app.uuid`, which has not been released yet. See:

https://github.com/plone/plone.restapi/pull/1471#issuecomment-1225594991

This fixes the broken tests.

Could not revert with git command.