### PR TITLE
Don't generate image scales until they are needed

### DIFF
--- a/news/1498.feature
+++ b/news/1498.feature
@@ -1,0 +1,1 @@
+- Improve performance of serializing image scales. [davisagli]

--- a/src/plone/restapi/imaging.py
+++ b/src/plone/restapi/imaging.py
@@ -48,8 +48,11 @@ def get_scales(context, field, width, height):
 def get_original_image_url(context, fieldname, width, height):
     request = getRequest()
     images_view = getMultiAdapter((context, request), name="images")
+    scale_flags = {}
+    if hasattr(images_view, "picture"):
+        scale_flags["pre"] = True
     scale = images_view.scale(
-        fieldname, width=width, height=height, direction="thumbnail"
+        fieldname, width=width, height=height, direction="thumbnail", **scale_flags
     )
     if scale:
         return scale.url

--- a/src/plone/restapi/imaging.py
+++ b/src/plone/restapi/imaging.py
@@ -12,13 +12,20 @@ def get_scales(context, field, width, height):
     images_view = getMultiAdapter((context, request), name="images")
 
     for name, actual_width, actual_height in get_scale_infos():
-        # Try first with scale name
-        scale = images_view.scale(field.__name__, scale=name)
+        # Recent versions of plone.namedfile support getting scale
+        # metadata without actually generating the image scale.
+        # This was added in the same version as the `picture` method,
+        # so we can use that to check whether the `scale` method
+        # accepts the `pre` flag.
+        scale_flags = {}
+        if hasattr(images_view, "picture"):
+            scale_flags["pre"] = True
+        scale = images_view.scale(field.__name__, scale=name, **scale_flags)
         if scale is None:
             # Sometimes it fails, but we can create it
             # using scale sizes
             scale = images_view.scale(
-                field.__name__, width=actual_width, height=actual_height
+                field.__name__, width=actual_width, height=actual_height, **scale_flags
             )
 
         if scale is None:

--- a/src/plone/restapi/serializer/dxfields.py
+++ b/src/plone/restapi/serializer/dxfields.py
@@ -106,7 +106,10 @@ class ImageFieldSerializer(DefaultFieldSerializer):
 
         url = get_original_image_url(self.context, self.field.__name__, width, height)
 
-        scales = get_scales(self.context, self.field, width, height)
+        if width != -1 and height != -1:
+            scales = get_scales(self.context, self.field, width, height)
+        else:
+            scales = {}
         result = {
             "filename": image.filename,
             "content-type": image.contentType,

--- a/src/plone/restapi/tests/test_dxfield_serializer.py
+++ b/src/plone/restapi/tests/test_dxfield_serializer.py
@@ -405,7 +405,7 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
 
             scale_download_url = "{}/@@images/{}.{}".format(
-                obj_url, scale_url_uuid, "png"
+                obj_url, scale_url_uuid, "gif" if HAS_PLONE_6 else "png"
             )
             scales = {
                 "listing": {
@@ -532,7 +532,7 @@ class TestDexterityImageFieldSerializingOriginalAndPNGScales(TestCase):
             )
 
             scale_download_url = "{}/@@images/{}.{}".format(
-                obj_url, scale_url_uuid, "png"
+                obj_url, scale_url_uuid, "gif" if HAS_PLONE_6 else "png"
             )
             scales = {
                 "listing": {


### PR DESCRIPTION
When available, use the new `pre` flag on the scale method of the imaging view so that we can serialize metadata about image scales without actually generating the scales. Improves performance and consequently should also reduce the chance of conflict errors.