### PR TITLE
The `@controlpanels/usergroup` does not work for Plone 5 since it doe…

### DIFF
--- a/news/1501.bugfix
+++ b/news/1501.bugfix
@@ -1,0 +1,2 @@
+The ``@controlpanels/usergroup`` does not work for Plone 5 since it does not exist there. Bring back the missing `title` just for Plone 5.
+[sneridagh]

--- a/src/plone/restapi/controlpanels/registry.py
+++ b/src/plone/restapi/controlpanels/registry.py
@@ -1,6 +1,8 @@
 from importlib import import_module
 from zope.component import adapter
+from zope.i18n import translate
 from zope.interface import Interface
+from zope.globalrequest import getRequest
 from Products.CMFPlone.interfaces.controlpanel import IDateAndTimeSchema
 from Products.CMFPlone.interfaces.controlpanel import IEditingSchema
 from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
@@ -115,4 +117,15 @@ class UserGroupControlpanel(RegistryConfigletPanel):
     configlet_id = "UsersGroupsSettings"
     configlet_category_id = "plone-users"
     if not PLONE_6:
-        title = "User and Group Settings"
+        title = translate(
+            "User and Group Settings",
+            default="User and Group Settings",
+            domain="plone",
+            context=getRequest(),
+        )
+        group = translate(
+            "Users and Groups",
+            default="Users and Groups",
+            domain="plone",
+            context=getRequest(),
+        )

--- a/src/plone/restapi/controlpanels/registry.py
+++ b/src/plone/restapi/controlpanels/registry.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 from zope.component import adapter
 from zope.interface import Interface
 from Products.CMFPlone.interfaces.controlpanel import IDateAndTimeSchema
@@ -17,6 +18,8 @@ try:
     from plone.i18n.interfaces import ILanguageSchema
 except ImportError:  # pragma: no cover
     from Products.CMFPlone.interfaces.controlpanel import ILanguageSchema
+
+PLONE_6 = getattr(import_module("Products.CMFPlone.factory"), "PLONE60MARKER", False)
 
 
 # General
@@ -111,3 +114,5 @@ class UserGroupControlpanel(RegistryConfigletPanel):
     schema = IUserGroupsSettingsSchema
     configlet_id = "UsersGroupsSettings"
     configlet_category_id = "plone-users"
+    if not PLONE_6:
+        title = "User and Group Settings"

--- a/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
@@ -73,7 +73,7 @@ Content-Type: application/json
                 "newVersion": "0006",
                 "required": false
             },
-            "version": "8.25.1.dev0"
+            "version": "8.28.1.dev0"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.session",

--- a/src/plone/restapi/tests/test_services_controlpanels.py
+++ b/src/plone/restapi/tests/test_services_controlpanels.py
@@ -114,3 +114,8 @@ class TestControlpanelsEndpoint(unittest.TestCase):
         response = response.json()
         self.assertIn("message", response)
         self.assertIn("Required input is missing.", response["message"])
+
+    def test_get_usergroup_control_panel(self):
+        # This control panel does not exist in Plone 5
+        response = self.api_session.get("/@controlpanels/usergroup")
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
…s not exist there. Bring back the missing `title` just for Plone 5.

@ksuess sorry, my bad for removing the title, I didn't know that it was a P6 only control panel.