### PR TITLE
Plone 6 as first class citizen

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,17 +7,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: '3.6'
-            plone-version: '5.2'
           - python-version: '3.7'
             plone-version: '5.2'
           - python-version: '3.8'
             plone-version: '5.2'
-          - python-version: '3.7'
-            plone-version: '6.0'
           - python-version: '3.8'
             plone-version: '6.0'
           - python-version: '3.9'
+            plone-version: '6.0'
+          - python-version: '3.10'
             plone-version: '6.0'
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ docs/.DS_Store
 docs/_build
 docs/plone.restapi.http-examples
 docs/source/README.rst
+docs/Makefile
+docs/make.bat
 sphinx_build.log
 htmlcov
 npm-debug.log

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ update: ## Update Make and Buildout
 	wget -O versions.cfg https://raw.githubusercontent.com/kitconcept/buildout/5.2/versions.cfg
 
 .installed.cfg: bin/buildout *.cfg
-	bin/buildout
 
 bin/buildout: bin/pip
 	bin/pip install --upgrade pip
@@ -75,6 +74,11 @@ build-plone-6.0-performance: .installed.cfg  ## Build Plone 6.0
 	bin/pip install --upgrade pip
 	bin/pip install -r requirements-6.0.txt
 	bin/buildout -c plone-6.0.x-performance.cfg
+
+.PHONY: start
+start: ## Start Plone Backend
+	@echo "$(GREEN)==> Start Plone Backend$(RESET)"
+	PYTHONWARNINGS=ignore bin/instance fg
 
 .PHONY: Test
 test:  ## Test

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,2 +1,2 @@
 [buildout]
-extends = plone-5.2.x.cfg
+extends = plone-6.0.x.cfg

--- a/news/1503.feature
+++ b/news/1503.feature
@@ -1,0 +1,2 @@
+Plone 6 as first class citizen in builds and CI. Remove non-supported Python versions. Add 3.10 for Plone 6.
+[sneridagh]

--- a/src/plone/restapi/tests/http-examples/controlpanels_get.resp
+++ b/src/plone/restapi/tests/http-examples/controlpanels_get.resp
@@ -40,7 +40,7 @@ Content-Type: application/json
     {
         "@id": "http://localhost:55001/plone/@controlpanels/dexterity-types",
         "group": "Content",
-        "title": "Dexterity Content Types"
+        "title": "Content Types"
     },
     {
         "@id": "http://localhost:55001/plone/@controlpanels/editing",
@@ -56,6 +56,11 @@ Content-Type: application/json
         "@id": "http://localhost:55001/plone/@controlpanels/markup",
         "group": "Content",
         "title": "Markup"
+    },
+    {
+        "@id": "http://localhost:55001/plone/@controlpanels/usergroup",
+        "group": "Users",
+        "title": "User and Group Settings"
     },
     {
         "@id": "http://localhost:55001/plone/@controlpanels/security",

--- a/src/plone/restapi/tests/http-examples/controlpanels_get_dexterity.resp
+++ b/src/plone/restapi/tests/http-examples/controlpanels_get_dexterity.resp
@@ -7,6 +7,15 @@ Content-Type: application/json
     "group": "Content",
     "items": [
         {
+            "@id": "http://localhost:55001/plone/@controlpanels/dexterity-types/Plone Site",
+            "@type": "Plone Site",
+            "count": 1,
+            "description": "",
+            "id": "Plone Site",
+            "meta_type": "Dexterity FTI",
+            "title": "Plone Site"
+        },
+        {
             "@id": "http://localhost:55001/plone/@controlpanels/dexterity-types/Collection",
             "@type": "Collection",
             "count": 0,
@@ -94,5 +103,5 @@ Content-Type: application/json
         "required": [],
         "type": "object"
     },
-    "title": "Dexterity Content Types"
+    "title": "Content Types"
 }

--- a/src/plone/restapi/tests/http-examples/controlpanels_get_dexterity_item.resp
+++ b/src/plone/restapi/tests/http-examples/controlpanels_get_dexterity_item.resp
@@ -32,6 +32,7 @@ Content-Type: application/json
         "plone.richtext": false,
         "plone.shortname": false,
         "plone.tableofcontents": false,
+        "plone.textindexer": false,
         "plone.thumb_icon": false,
         "plone.translatable": false,
         "plone.versioning": false,
@@ -73,6 +74,7 @@ Content-Type: application/json
                     "plone.eventrecurrence",
                     "plone.excludefromnavigation",
                     "plone.constraintypes",
+                    "plone.textindexer",
                     "plone.leadimage",
                     "plone.locking",
                     "plone.translatable",
@@ -302,6 +304,12 @@ Content-Type: application/json
                 "description": "Adds a table of contents",
                 "factory": "Yes/No",
                 "title": "Table of contents",
+                "type": "boolean"
+            },
+            "plone.textindexer": {
+                "description": "Enables the enhanced full-text indexing for a content type ('plone.textindexer'). If a field is marked 'searchable', its content gets added to the 'SearchableText' index in the catalog.",
+                "factory": "Yes/No",
+                "title": "Full-Text Indexing",
                 "type": "boolean"
             },
             "plone.thumb_icon": {

--- a/src/plone/restapi/tests/http-examples/controlpanels_post_dexterity_item.resp
+++ b/src/plone/restapi/tests/http-examples/controlpanels_post_dexterity_item.resp
@@ -33,6 +33,7 @@ Location: http://localhost:55001/plone/@controlpanels/dexterity-types/my_custom_
         "plone.richtext": false,
         "plone.shortname": false,
         "plone.tableofcontents": false,
+        "plone.textindexer": false,
         "plone.thumb_icon": false,
         "plone.translatable": false,
         "plone.versioning": false,
@@ -74,6 +75,7 @@ Location: http://localhost:55001/plone/@controlpanels/dexterity-types/my_custom_
                     "plone.eventrecurrence",
                     "plone.excludefromnavigation",
                     "plone.constraintypes",
+                    "plone.textindexer",
                     "plone.leadimage",
                     "plone.locking",
                     "plone.translatable",
@@ -303,6 +305,12 @@ Location: http://localhost:55001/plone/@controlpanels/dexterity-types/my_custom_
                 "description": "Adds a table of contents",
                 "factory": "Yes/No",
                 "title": "Table of contents",
+                "type": "boolean"
+            },
+            "plone.textindexer": {
+                "description": "Enables the enhanced full-text indexing for a content type ('plone.textindexer'). If a field is marked 'searchable', its content gets added to the 'SearchableText' index in the catalog.",
+                "factory": "Yes/No",
+                "title": "Full-Text Indexing",
                 "type": "boolean"
             },
             "plone.thumb_icon": {

--- a/src/plone/restapi/tests/http-examples/expansion_expanded_full.resp
+++ b/src/plone/restapi/tests/http-examples/expansion_expanded_full.resp
@@ -7,100 +7,100 @@ Content-Type: application/json
             "document_actions": [],
             "object": [
                 {
-                    "icon": "",
+                    "icon": "toolbar-action/view",
                     "id": "view",
                     "title": "View"
                 },
                 {
-                    "icon": "",
+                    "icon": "toolbar-action/edit",
                     "id": "edit",
                     "title": "Edit"
                 },
                 {
-                    "icon": "",
+                    "icon": "toolbar-action/folderContents",
                     "id": "folderContents",
                     "title": "Contents"
                 },
                 {
-                    "icon": "",
+                    "icon": "toolbar-action/history",
                     "id": "history",
                     "title": "History"
                 },
                 {
-                    "icon": "",
+                    "icon": "toolbar-action/sharing",
                     "id": "local_roles",
                     "title": "Sharing"
                 }
             ],
             "object_buttons": [
                 {
-                    "icon": "",
+                    "icon": "plone-cut",
                     "id": "cut",
                     "title": "Cut"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-copy",
                     "id": "copy",
                     "title": "Copy"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-delete",
                     "id": "delete",
                     "title": "Delete"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-rename",
                     "id": "rename",
                     "title": "Rename"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-redirection",
                     "id": "redirection",
                     "title": "URL Management"
                 }
             ],
             "portal_tabs": [
                 {
-                    "icon": "",
+                    "icon": "plone-home",
                     "id": "index_html",
                     "title": "Home"
                 }
             ],
             "site_actions": [
                 {
-                    "icon": "",
+                    "icon": "plone-sitemap",
                     "id": "sitemap",
                     "title": "Site Map"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-accessibility",
                     "id": "accessibility",
                     "title": "Accessibility"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-contact-info",
                     "id": "contact",
                     "title": "Contact"
                 }
             ],
             "user": [
                 {
-                    "icon": "",
+                    "icon": "plone-user",
                     "id": "preferences",
                     "title": "Preferences"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-dashboard",
                     "id": "dashboard",
                     "title": "Dashboard"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-controlpanel",
                     "id": "plone_setup",
                     "title": "Site Setup"
                 },
                 {
-                    "icon": "",
+                    "icon": "plone-logout",
                     "id": "logout",
                     "title": "Log out"
                 }

--- a/src/plone/restapi/tests/http-examples/image.resp
+++ b/src/plone/restapi/tests/http-examples/image.resp
@@ -45,12 +45,27 @@ Content-Type: application/json
         "filename": "image.png",
         "height": 56,
         "scales": {
+            "great": {
+                "download": "http://localhost:55001/plone/image/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
+            "huge": {
+                "download": "http://localhost:55001/plone/image/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
             "icon": {
                 "download": "http://localhost:55001/plone/image/@@images/uuid1.png",
                 "height": 8,
                 "width": 32
             },
             "large": {
+                "download": "http://localhost:55001/plone/image/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
+            "larger": {
                 "download": "http://localhost:55001/plone/image/@@images/uuid1.png",
                 "height": 56,
                 "width": 215
@@ -66,6 +81,11 @@ Content-Type: application/json
                 "width": 200
             },
             "preview": {
+                "download": "http://localhost:55001/plone/image/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
+            "teaser": {
                 "download": "http://localhost:55001/plone/image/@@images/uuid1.png",
                 "height": 56,
                 "width": 215

--- a/src/plone/restapi/tests/http-examples/jwt_logged_in.resp
+++ b/src/plone/restapi/tests/http-examples/jwt_logged_in.resp
@@ -17,13 +17,25 @@ Content-Type: application/json
         },
         "navigation": {
             "@id": "http://localhost:55001/plone/@navigation"
+        },
+        "types": {
+            "@id": "http://localhost:55001/plone/@types"
+        },
+        "workflow": {
+            "@id": "http://localhost:55001/plone/@workflow"
         }
     },
     "@id": "http://localhost:55001/plone",
     "@type": "Plone Site",
-    "blocks": {},
-    "blocks_layout": {},
+    "allow_discussion": null,
+    "contributors": [],
+    "creators": [
+        "admin"
+    ],
     "description": "",
+    "effective": null,
+    "exclude_from_nav": false,
+    "expires": null,
     "id": "plone",
     "is_folderish": true,
     "items": [
@@ -36,6 +48,19 @@ Content-Type: application/json
         }
     ],
     "items_total": 1,
+    "language": {
+        "title": "English",
+        "token": "en"
+    },
+    "lock": {
+        "locked": false,
+        "stealable": true
+    },
     "parent": {},
+    "relatedItems": [],
+    "rights": "",
+    "subjects": [],
+    "table_of_contents": null,
+    "text": null,
     "title": "Plone site"
 }

--- a/src/plone/restapi/tests/http-examples/newsitem.resp
+++ b/src/plone/restapi/tests/http-examples/newsitem.resp
@@ -46,12 +46,27 @@ Content-Type: application/json
         "filename": "image.png",
         "height": 56,
         "scales": {
+            "great": {
+                "download": "http://localhost:55001/plone/newsitem/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
+            "huge": {
+                "download": "http://localhost:55001/plone/newsitem/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
             "icon": {
                 "download": "http://localhost:55001/plone/newsitem/@@images/uuid1.png",
                 "height": 8,
                 "width": 32
             },
             "large": {
+                "download": "http://localhost:55001/plone/newsitem/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
+            "larger": {
                 "download": "http://localhost:55001/plone/newsitem/@@images/uuid1.png",
                 "height": 56,
                 "width": 215
@@ -67,6 +82,11 @@ Content-Type: application/json
                 "width": 200
             },
             "preview": {
+                "download": "http://localhost:55001/plone/newsitem/@@images/uuid1.png",
+                "height": 56,
+                "width": 215
+            },
+            "teaser": {
                 "download": "http://localhost:55001/plone/newsitem/@@images/uuid1.png",
                 "height": 56,
                 "width": 215

--- a/src/plone/restapi/tests/http-examples/registry_get_list.resp
+++ b/src/plone/restapi/tests/http-examples/registry_get_list.resp
@@ -6,7 +6,7 @@ Content-Type: application/json
     "batching": {
         "@id": "http://localhost:55001/plone/@registry",
         "first": "http://localhost:55001/plone/@registry?b_start=0",
-        "last": "http://localhost:55001/plone/@registry?b_start=1850",
+        "last": "http://localhost:55001/plone/@registry?b_start=2725",
         "next": "http://localhost:55001/plone/@registry?b_start=25"
     },
     "items": [
@@ -59,177 +59,15 @@ Content-Type: application/json
             "value": "%H:%M"
         },
         {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.allowed",
-            "schema": {
-                "properties": {
-                    "default": true,
-                    "description": "Allow syndication for collections and folders on site.",
-                    "factory": "Yes/No",
-                    "title": "Allowed",
-                    "type": "boolean"
-                }
-            },
-            "value": true
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.allowed_feed_types",
-            "schema": {
-                "properties": {
-                    "additionalItems": true,
-                    "default": [
-                        "RSS|RSS 1.0",
-                        "rss.xml|RSS 2.0",
-                        "atom.xml|Atom",
-                        "itunes.xml|iTunes"
-                    ],
-                    "description": "Separate view name and title by '|'",
-                    "factory": "Tuple",
-                    "items": {
-                        "description": "",
-                        "factory": "Text line (String)",
-                        "title": "",
-                        "type": "string"
-                    },
-                    "title": "Allowed Feed Types",
-                    "type": "array",
-                    "uniqueItems": true
-                }
-            },
-            "value": [
-                "RSS|RSS 1.0",
-                "rss.xml|RSS 2.0",
-                "atom.xml|Atom",
-                "itunes.xml|iTunes"
-            ]
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.default_enabled",
-            "schema": {
-                "properties": {
-                    "default": false,
-                    "description": "If syndication should be enabled by default for all folders and collections.",
-                    "factory": "Yes/No",
-                    "title": "Enabled by default",
-                    "type": "boolean"
-                }
-            },
-            "value": false
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.max_items",
-            "schema": {
-                "properties": {
-                    "default": 15,
-                    "description": "Maximum number of items that will be syndicated.",
-                    "factory": "Integer",
-                    "minimum": 1,
-                    "title": "Maximum items",
-                    "type": "integer"
-                }
-            },
-            "value": 15
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.render_body",
-            "schema": {
-                "properties": {
-                    "default": false,
-                    "description": "If body text available for item, render it, otherwise use description.",
-                    "factory": "Yes/No",
-                    "title": "Render Body",
-                    "type": "boolean"
-                }
-            },
-            "value": false
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.search_rss_enabled",
-            "schema": {
-                "properties": {
-                    "default": true,
-                    "description": "Allows users to subscribe to feeds of search results",
-                    "factory": "Yes/No",
-                    "title": "Search RSS enabled",
-                    "type": "boolean"
-                }
-            },
-            "value": true
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.show_author_info",
-            "schema": {
-                "properties": {
-                    "default": true,
-                    "description": "Should feeds include author information",
-                    "factory": "Yes/No",
-                    "title": "Show author info",
-                    "type": "boolean"
-                }
-            },
-            "value": true
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.show_syndication_button",
-            "schema": {
-                "properties": {
-                    "description": "Makes it possible to customize syndication settings for particular folders and collections ",
-                    "factory": "Yes/No",
-                    "title": "Show settings button",
-                    "type": "boolean"
-                }
-            },
-            "value": null
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.show_syndication_link",
-            "schema": {
-                "properties": {
-                    "description": "Enable RSS link document action on the syndication content item.",
-                    "factory": "Yes/No",
-                    "title": "Show feed link",
-                    "type": "boolean"
-                }
-            },
-            "value": null
-        },
-        {
-            "name": "Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings.site_rss_items",
-            "schema": {
-                "properties": {
-                    "additionalItems": true,
-                    "default": [
-                        "/news/aggregator"
-                    ],
-                    "description": "Paths to folders and collections to link to at the portal root.",
-                    "factory": "Tuple",
-                    "items": {
-                        "description": "",
-                        "factory": "Choice",
-                        "title": "",
-                        "type": "string",
-                        "vocabulary": {
-                            "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.SyndicatableFeedItems"
-                        }
-                    },
-                    "title": "Site RSS",
-                    "type": "array",
-                    "uniqueItems": true
-                }
-            },
-            "value": [
-                "/news/aggregator"
-            ]
-        },
-        {
             "name": "plone.alignment_styles",
             "schema": {
                 "properties": {
                     "additionalItems": true,
                     "default": [
-                        "Left|alignleft|alignleft",
-                        "Center|aligncenter|aligncenter",
-                        "Right|alignright|alignright",
-                        "Justify|alignjustify|alignjustify"
+                        "Left|alignleft|align-left",
+                        "Center|aligncenter|align-center",
+                        "Right|alignright|align-right",
+                        "Justify|alignjustify|align-justify"
                     ],
                     "description": "Name|format|icon",
                     "factory": "List",
@@ -245,10 +83,10 @@ Content-Type: application/json
                 }
             },
             "value": [
-                "Left|alignleft|alignleft",
-                "Center|aligncenter|aligncenter",
-                "Right|alignright|alignright",
-                "Justify|alignjustify|alignjustify"
+                "Left|alignleft|align-left",
+                "Center|aligncenter|align-center",
+                "Right|alignright|align-right",
+                "Justify|alignjustify|align-justify"
             ]
         },
         {
@@ -291,9 +129,13 @@ Content-Type: application/json
                 "properties": {
                     "additionalItems": true,
                     "default": [
-                        "large 768:768",
-                        "preview 400:400",
-                        "mini 200:200",
+                        "huge 1600:65536",
+                        "great 1200:65536",
+                        "larger 1000:65536",
+                        "large 800:65536",
+                        "teaser 600:65536",
+                        "preview 400:65536",
+                        "mini 200:65536",
                         "thumb 128:128",
                         "tile 64:64",
                         "icon 32:32",
@@ -313,9 +155,13 @@ Content-Type: application/json
                 }
             },
             "value": [
-                "large 768:768",
-                "preview 400:400",
-                "mini 200:200",
+                "huge 1600:65536",
+                "great 1200:65536",
+                "larger 1000:65536",
+                "large 800:65536",
+                "teaser 600:65536",
+                "preview 400:65536",
+                "mini 200:65536",
                 "thumb 128:128",
                 "tile 64:64",
                 "icon 32:32",
@@ -432,7 +278,150 @@ Content-Type: application/json
                 }
             },
             "value": false
+        },
+        {
+            "name": "plone.app.discussion.interfaces.IDiscussionSettings.globally_enabled",
+            "schema": {
+                "properties": {
+                    "default": false,
+                    "description": "If selected, users are able to post comments on the site. However, you will still need to enable comments for specific content types, folders or content objects before users will be able to post comments.",
+                    "factory": "Yes/No",
+                    "title": "Globally enable comments",
+                    "type": "boolean"
+                }
+            },
+            "value": false
+        },
+        {
+            "name": "plone.app.discussion.interfaces.IDiscussionSettings.moderation_enabled",
+            "schema": {
+                "properties": {
+                    "default": false,
+                    "description": "If selected, comments will enter a \"Pending\" state in which they are invisible to the public. A user with the \"Review comments\" permission (\"Reviewer\" or \"Manager\") can approve comments to make them visible to the public. If you want to enable a custom comment workflow, you have to go to the types control panel.",
+                    "factory": "Yes/No",
+                    "title": "Enable comment moderation",
+                    "type": "boolean"
+                }
+            },
+            "value": false
+        },
+        {
+            "name": "plone.app.discussion.interfaces.IDiscussionSettings.moderator_email",
+            "schema": {
+                "properties": {
+                    "description": "Address to which moderator notifications will be sent.",
+                    "factory": "Text line (String)",
+                    "title": "Moderator Email Address",
+                    "type": "string"
+                }
+            },
+            "value": null
+        },
+        {
+            "name": "plone.app.discussion.interfaces.IDiscussionSettings.moderator_notification_enabled",
+            "schema": {
+                "properties": {
+                    "default": false,
+                    "description": "If selected, the moderator is notified if a comment needs attention. The moderator email address can be set below.",
+                    "factory": "Yes/No",
+                    "title": "Enable moderator email notification",
+                    "type": "boolean"
+                }
+            },
+            "value": false
+        },
+        {
+            "name": "plone.app.discussion.interfaces.IDiscussionSettings.show_commenter_image",
+            "schema": {
+                "properties": {
+                    "default": true,
+                    "description": "If selected, an image of the user is shown next to the comment.",
+                    "factory": "Yes/No",
+                    "title": "Show commenter image",
+                    "type": "boolean"
+                }
+            },
+            "value": true
+        },
+        {
+            "name": "plone.app.discussion.interfaces.IDiscussionSettings.text_transform",
+            "schema": {
+                "properties": {
+                    "default": "text/plain",
+                    "description": "Use this setting to choose if the comment text should be transformed in any way. You can choose between \"Plain text\" and \"Intelligent text\". \"Intelligent text\" converts plain text into HTML where line breaks and indentation is preserved, and web and email addresses are made into clickable links.",
+                    "factory": "Choice",
+                    "title": "Comment text transform",
+                    "type": "string",
+                    "vocabulary": {
+                        "@id": "http://localhost:55001/plone/@vocabularies/plone.app.discussion.vocabularies.TextTransformVocabulary"
+                    }
+                }
+            },
+            "value": "text/plain"
+        },
+        {
+            "name": "plone.app.discussion.interfaces.IDiscussionSettings.user_notification_enabled",
+            "schema": {
+                "properties": {
+                    "default": false,
+                    "description": "If selected, users can choose to be notified of new comments by email.",
+                    "factory": "Yes/No",
+                    "title": "Enable user email notification",
+                    "type": "boolean"
+                }
+            },
+            "value": false
+        },
+        {
+            "name": "plone.app.layout.globals.bodyClass.depth",
+            "schema": {
+                "properties": {
+                    "description": "Depth relative the site root that body class are generated for.\n      ",
+                    "factory": "Integer",
+                    "title": "Body class path depth",
+                    "type": "integer"
+                }
+            },
+            "value": 4
+        },
+        {
+            "name": "plone.app.portlets.PortletManagerBlacklist",
+            "schema": {
+                "properties": {
+                    "additionalItems": true,
+                    "description": "A list of portlet manager names that will not be shown in the toolbar dropdown",
+                    "factory": "List",
+                    "items": {
+                        "description": "",
+                        "factory": "Text line (String)",
+                        "title": "",
+                        "type": "string"
+                    },
+                    "title": "Toolbar Portlet Manager Blacklist",
+                    "type": "array",
+                    "uniqueItems": false
+                }
+            },
+            "value": [
+                "plone.dashboard1",
+                "plone.dashboard2",
+                "plone.dashboard3",
+                "plone.dashboard4"
+            ]
+        },
+        {
+            "name": "plone.app.querystring.field.Creator.description",
+            "schema": {
+                "properties": {
+                    "description": "",
+                    "factory": "Text",
+                    "title": "Description",
+                    "type": "string",
+                    "widget": "textarea"
+                }
+            },
+            "value": "The person that created an item"
         }
     ],
-    "items_total": 1853
+    "items_total": 2734
 }

--- a/src/plone/restapi/tests/http-examples/search.resp
+++ b/src/plone/restapi/tests/http-examples/search.resp
@@ -5,6 +5,13 @@ Content-Type: application/json
     "@id": "http://localhost:55001/plone/@search",
     "items": [
         {
+            "@id": "http://localhost:55001/plone",
+            "@type": "Plone Site",
+            "description": "",
+            "review_state": null,
+            "title": "Plone site"
+        },
+        {
             "@id": "http://localhost:55001/plone/front-page",
             "@type": "Document",
             "description": "Congratulations! You have successfully installed Plone.",
@@ -12,5 +19,5 @@ Content-Type: application/json
             "title": "Welcome to Plone"
         }
     ],
-    "items_total": 1
+    "items_total": 2
 }

--- a/src/plone/restapi/tests/http-examples/siteroot.resp
+++ b/src/plone/restapi/tests/http-examples/siteroot.resp
@@ -17,13 +17,25 @@ Content-Type: application/json
         },
         "navigation": {
             "@id": "http://localhost:55001/plone/@navigation"
+        },
+        "types": {
+            "@id": "http://localhost:55001/plone/@types"
+        },
+        "workflow": {
+            "@id": "http://localhost:55001/plone/@workflow"
         }
     },
     "@id": "http://localhost:55001/plone",
     "@type": "Plone Site",
-    "blocks": {},
-    "blocks_layout": {},
+    "allow_discussion": null,
+    "contributors": [],
+    "creators": [
+        "admin"
+    ],
     "description": "",
+    "effective": null,
+    "exclude_from_nav": false,
+    "expires": null,
     "id": "plone",
     "is_folderish": true,
     "items": [
@@ -36,6 +48,19 @@ Content-Type: application/json
         }
     ],
     "items_total": 1,
+    "language": {
+        "title": "English",
+        "token": "en"
+    },
+    "lock": {
+        "locked": false,
+        "stealable": true
+    },
     "parent": {},
+    "relatedItems": [],
+    "rights": "",
+    "subjects": [],
+    "table_of_contents": null,
+    "text": null,
     "title": "Plone site"
 }

--- a/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
@@ -13,7 +13,7 @@ Content-Type: application/json
             "title": "Soporte de Pol\u00edtica de Flujo de trabajo (CMFPlacefulWorkflow)",
             "uninstall_profile_id": "Products.CMFPlacefulWorkflow:uninstall",
             "upgrade_info": {},
-            "version": "2.0.4"
+            "version": "3.0.0b1"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/collective.MockMailHost",
@@ -55,7 +55,7 @@ Content-Type: application/json
             "title": "Soporte Multiidioma",
             "uninstall_profile_id": "plone.app.multilingual:uninstall",
             "upgrade_info": {},
-            "version": "5.6.4"
+            "version": "6.0.0b3"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.restapi",
@@ -73,7 +73,7 @@ Content-Type: application/json
                 "newVersion": "0006",
                 "required": false
             },
-            "version": "8.25.1.dev0"
+            "version": "8.28.1.dev0"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.session",
@@ -85,7 +85,7 @@ Content-Type: application/json
             "title": "Soporte de actualizaci\u00f3n de sesi\u00f3n",
             "uninstall_profile_id": "plone.session:uninstall",
             "upgrade_info": {},
-            "version": "3.7.5"
+            "version": "4.0.0b2"
         }
     ]
 }

--- a/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
@@ -55,11 +55,11 @@ Content-Type: application/json+schema
     ],
     "layouts": [
         "album_view",
-        "event_listing",
         "full_view",
         "listing_view",
         "summary_view",
-        "tabular_view"
+        "tabular_view",
+        "event_listing"
     ],
     "properties": {
         "allow_discussion": {
@@ -140,7 +140,7 @@ Content-Type: application/json+schema
         },
         "effective": {
             "behavior": "plone.dublincore",
-            "description": "La fecha en la que el documento ser\u00e1 publicado. Si no selecciona ninguna fecha, el documento ser\u00e1 publicado inmediatamente.",
+            "description": "Si la fecha es del futuro, el contenido no se mostrar\u00e1 en los listados y las b\u00fasquedas hasta esa fecha.",
             "factory": "Date/Time",
             "title": "Fecha de Publicaci\u00f3n",
             "type": "string",
@@ -156,7 +156,7 @@ Content-Type: application/json+schema
         },
         "expires": {
             "behavior": "plone.dublincore",
-            "description": "La fecha en la que expira el documento. Esto har\u00e1 autom\u00e1ticamente el documento invisible a otros a una fecha dada. Si no elije ninguna fecha, nunca expirar\u00e1.",
+            "description": "Cuando esta fecha llegue, el contenido no se mostrar\u00e1 en los listados y b\u00fasquedas.",
             "factory": "Date/Time",
             "title": "Fecha de Terminaci\u00f3n",
             "type": "string",
@@ -203,7 +203,7 @@ Content-Type: application/json+schema
                     "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Catalog"
                 }
             },
-            "title": "Contenido relacionado",
+            "title": "Related Items",
             "type": "array",
             "uniqueItems": true,
             "widgetOptions": {

--- a/src/plone/restapi/tests/http-examples/vocabularies.resp
+++ b/src/plone/restapi/tests/http-examples/vocabularies.resp
@@ -3,6 +3,14 @@ Content-Type: application/json
 
 [
     {
+        "@id": "http://localhost:55001/plone/@vocabularies/plone.contentrules.events",
+        "title": "plone.contentrules.events"
+    },
+    {
+        "@id": "http://localhost:55001/plone/@vocabularies/Behaviors",
+        "title": "Behaviors"
+    },
+    {
         "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.AvailableContentLanguages",
         "title": "plone.app.vocabularies.AvailableContentLanguages"
     },
@@ -139,14 +147,6 @@ Content-Type: application/json
         "title": "plone.app.content.ValidAddableTypes"
     },
     {
-        "@id": "http://localhost:55001/plone/@vocabularies/plone.contentrules.events",
-        "title": "plone.contentrules.events"
-    },
-    {
-        "@id": "http://localhost:55001/plone/@vocabularies/Behaviors",
-        "title": "Behaviors"
-    },
-    {
         "@id": "http://localhost:55001/plone/@vocabularies/Fields",
         "title": "Fields"
     },
@@ -167,6 +167,10 @@ Content-Type: application/json
         "title": "plone.app.contenttypes.metadatafields"
     },
     {
+        "@id": "http://localhost:55001/plone/@vocabularies/plone.app.contenttypes.migration.changed_base_classes",
+        "title": "plone.app.contenttypes.migration.changed_base_classes"
+    },
+    {
         "@id": "http://localhost:55001/plone/@vocabularies/Interfaces",
         "title": "Interfaces"
     },
@@ -179,14 +183,6 @@ Content-Type: application/json
         "title": "plone.app.discussion.vocabularies.TextTransformVocabulary"
     },
     {
-        "@id": "http://localhost:55001/plone/@vocabularies/plone.app.users.user_registration_fields",
-        "title": "plone.app.users.user_registration_fields"
-    },
-    {
-        "@id": "http://localhost:55001/plone/@vocabularies/plone.app.users.group_ids",
-        "title": "plone.app.users.group_ids"
-    },
-    {
         "@id": "http://localhost:55001/plone/@vocabularies/plone.app.multilingual.vocabularies.AllContentLanguageVocabulary",
         "title": "plone.app.multilingual.vocabularies.AllContentLanguageVocabulary"
     },
@@ -197,6 +193,14 @@ Content-Type: application/json
     {
         "@id": "http://localhost:55001/plone/@vocabularies/plone.app.multilingual.RootCatalog",
         "title": "plone.app.multilingual.RootCatalog"
+    },
+    {
+        "@id": "http://localhost:55001/plone/@vocabularies/plone.app.users.user_registration_fields",
+        "title": "plone.app.users.user_registration_fields"
+    },
+    {
+        "@id": "http://localhost:55001/plone/@vocabularies/plone.app.users.group_ids",
+        "title": "plone.app.users.group_ids"
     },
     {
         "@id": "http://localhost:55001/plone/@vocabularies/plone.restapi.testing.context_vocabulary",

--- a/src/plone/restapi/tests/http-examples/workingcopy_baseline_get.resp
+++ b/src/plone/restapi/tests/http-examples/workingcopy_baseline_get.resp
@@ -43,7 +43,7 @@ Content-Type: application/json
     "language": "",
     "layout": "document_view",
     "lock": {
-        "created": "1995-07-31T19:30:00",
+        "created": "1995-07-31T17:30:00",
         "creator": "admin",
         "creator_name": "admin",
         "creator_url": "http://localhost:55001/plone/author/admin",

--- a/src/plone/restapi/tests/http-examples/workingcopy_baseline_get.resp
+++ b/src/plone/restapi/tests/http-examples/workingcopy_baseline_get.resp
@@ -43,7 +43,7 @@ Content-Type: application/json
     "language": "",
     "layout": "document_view",
     "lock": {
-        "created": "1995-07-31T17:30:00",
+        "created": "1995-07-31T19:30:00",
         "creator": "admin",
         "creator_name": "admin",
         "creator_url": "http://localhost:55001/plone/author/admin",

--- a/test-no-uncommitted-doc-changes
+++ b/test-no-uncommitted-doc-changes
@@ -13,12 +13,12 @@ function red {
     echo "$RED $1 $RESET"
 }
 
-if [ "$PLONE_VERSION" == "5.2" ] && [ "$PYTHON_VERSION" == '3.7' ]; then
-    echo "Running check for undocumented changes for Plone 5.2.x on Python 3.7"
+if [ "$PLONE_VERSION" == "6.0" ] && [ "$PYTHON_VERSION" == '3.9' ]; then
+    echo "Running check for undocumented changes for Plone 6.0.x on Python 3.9"
 else
-    # request/response dumps have known differences for Plone 5
+    # request/response dumps have known differences for different Python/Plone combinations
     # => skip, we can't have the Plone 5 build fail because of those
-    echo "Skipping checks for undocumented changes for everything except Plone 5.2.x on Python 3.7"
+    echo "Skipping checks for undocumented changes for everything except Plone 6.0.x on Python 3.9"
     exit 0
 fi
 


### PR DESCRIPTION
Update GHA to remove checks on Python 3.6 and added 3.10 for Plone 6. Removed 3.7 from Plone 6 as well.

The amendment in Makefile was needed because of 

https://community.plone.org/t/plone-6-0-0b2-released/15643

we were initially installing the 5.x buildout then on the top the Plone 6 one. This provoked the build to fail due that an initial outdated setuptools+zc.buildout was already in place. Now it only does it once, for each. Thus, the `Makefile` amendment. 