### PR TITLE
Merge plone.restapi glossary terms into main docs at plone/documentat…

### DIFF
--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -53,4 +53,11 @@ Authentication Method
 
 Basic Auth
     A simple {term}`Authentication Method` referenced in the {term}`Authorization Header` that needs to be provided by the server.
+
+content rule
+    A content rule will automatically perform an action when a certain event, known as a {term}`trigger`, takes place.
+
+trigger
+    A trigger is an event in Plone that causes the execution of defined actions.
+    Example triggers include object modified, user logged in, and workflow state changed.
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -36,7 +36,7 @@ contributing/index
 
 ```{toctree}
 http-status-codes
-glossary
+/glossary
 ```
 
 

--- a/news/1508.doc
+++ b/news/1508.doc
@@ -1,0 +1,1 @@
+Merge glossary terms into main plone/documentation. [stevepiercy]


### PR DESCRIPTION
…ion.

- Add terms from an open PR in plone.restapi that should be merged soon.
- In plone/documentation, exclude the plone.restapi glossary.

See:
- https://github.com/plone/documentation/issues/1337
- https://github.com/plone/documentation/pull/1338