### PR TITLE
Remove code-analysis from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,14 +96,8 @@ test-performance-locust-querystring-search:
 test-performance-locust-querystring-search-ci:
 	bin/locust -f performance/querystring-search.py --host http://localhost:12345/Plone --users 100 --spawn-rate 5 --run-time 5m --headless --csv=example
 
-.PHONY: Code Analysis
-code-analysis:  ## Code Analysis
-	bin/code-analysis
-	if [ -f "bin/black" ]; then bin/black src/ --check ; fi
-
 .PHONY: Black
 black:  ## Black
-	bin/code-analysis
 	if [ -f "bin/black" ]; then bin/black src/ ; fi
 
 .PHONY: zpretty

--- a/news/1517.internal
+++ b/news/1517.internal
@@ -1,0 +1,1 @@
+Remove code-analysis from Makefile. [wesleybl]

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -8,7 +8,3 @@ black = 21.7b0
 
 # Use the new plone.rest alpha
 plone.rest = 2.0.0a3
-
-[versions:python37]
-# Error: The requirement ('importlib-metadata<4.3,>=1.1.0') is not allowed by your [versions] constraint (0.23)
-importlib-metadata = 2.0.0


### PR DESCRIPTION
`plone.recipe.codeanalysis` was removed from buildout. The `importlib-metadata` pin was needed only because of code-analysis. So we're removing the pin.

Ref: #1507