### PR TITLE
Fix test_statictime for p.a.discussion comments

### DIFF
--- a/news/1520.bugfix
+++ b/news/1520.bugfix
@@ -1,0 +1,2 @@
+Update statictime tests following changes to p.a.disucssion (see 
+https://github.com/plone/plone.app.discussion/pull/204) - [instification]

--- a/src/plone/restapi/tests/test_statictime.py
+++ b/src/plone/restapi/tests/test_statictime.py
@@ -3,8 +3,6 @@ from DateTime import DateTime
 from datetime import timedelta
 from dateutil import tz
 from operator import itemgetter
-from pkg_resources import get_distribution
-from pkg_resources import parse_version
 from plone import api
 from plone.app.discussion.interfaces import IConversation
 from plone.app.discussion.interfaces import IDiscussionSettings

--- a/src/plone/restapi/tests/test_statictime.py
+++ b/src/plone/restapi/tests/test_statictime.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 from DateTime import DateTime
 from datetime import timedelta
-from datetime import timezone
+from dateutil import tz
 from operator import itemgetter
 from plone import api
 from plone.app.discussion.interfaces import IConversation
 from plone.app.discussion.interfaces import IDiscussionSettings
 from plone.app.discussion.interfaces import IReplies
+from plone.app.event.base import default_timezone
 from plone.app.layout.viewlets.content import ContentHistoryViewlet
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -76,10 +77,10 @@ class TestStaticTime(unittest.TestCase):
         if isinstance(pydt, DateTime):
             pydt = pydt.asdatetime()
         elif isinstance(pydt, float):
-            pydt = datetime.fromtimestamp(pydt).astimezone(timezone.utc)
+            pydt = datetime.fromtimestamp(pydt).astimezone(tz.gettz(default_timezone()))
 
         epsilon = timedelta(minutes=5)
-        now = datetime.now().astimezone(timezone.utc)
+        now = datetime.now().astimezone(tz.gettz(default_timezone()))
         upper = now + epsilon
         lower = now - epsilon
 
@@ -134,7 +135,10 @@ class TestStaticTime(unittest.TestCase):
         self.assert_of_same_type(fake_datetimes, real_datetimes)
 
     def test_statictime_comment_created(self):
-        frozen_time = datetime(1950, 7, 31, 13, 45)
+        frozen_time = datetime(1950, 7, 31, 13, 45).astimezone(
+            tz.gettz(default_timezone())
+        )
+
         statictime = StaticTime(created=frozen_time)
 
         statictime.start()
@@ -152,7 +156,9 @@ class TestStaticTime(unittest.TestCase):
         self.assert_of_same_type(fake_datetimes, real_datetimes)
 
     def test_statictime_comment_modified(self):
-        frozen_time = datetime(1950, 7, 31, 17, 30)
+        frozen_time = datetime(1950, 7, 31, 17, 30).astimezone(
+            tz.gettz(default_timezone())
+        )
         statictime = StaticTime(modified=frozen_time)
 
         statictime.start()

--- a/src/plone/restapi/tests/test_statictime.py
+++ b/src/plone/restapi/tests/test_statictime.py
@@ -30,7 +30,7 @@ import transaction
 import unittest
 
 padiscussion_version = get_distribution("plone.app.discussion").version
-if parse_version(padiscussion_version) > parse_version("4.0.0b4"):
+if parse_version(padiscussion_version) >= parse_version("4.0.0b4.dev1"):
     NEW_PADISCUSSION = True
 else:
     NEW_PADISCUSSION = False

--- a/src/plone/restapi/tests/test_statictime.py
+++ b/src/plone/restapi/tests/test_statictime.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from DateTime import DateTime
 from datetime import timedelta
+from datetime import timezone
 from operator import itemgetter
 from plone import api
 from plone.app.discussion.interfaces import IConversation
@@ -75,13 +76,10 @@ class TestStaticTime(unittest.TestCase):
         if isinstance(pydt, DateTime):
             pydt = pydt.asdatetime()
         elif isinstance(pydt, float):
-            pydt = datetime.fromtimestamp(pydt)
+            pydt = datetime.fromtimestamp(pydt).astimezone(timezone.utc)
 
         epsilon = timedelta(minutes=5)
-        now = datetime.now()
-        if pydt.tzinfo is not None:
-            now = pydt.tzinfo.localize(now)
-
+        now = datetime.now().astimezone(timezone.utc)
         upper = now + epsilon
         lower = now - epsilon
 

--- a/src/plone/restapi/tests/test_statictime.py
+++ b/src/plone/restapi/tests/test_statictime.py
@@ -35,6 +35,7 @@ if parse_version(padiscussion_version) > parse_version("4.0.0b4"):
 else:
     NEW_PADISCUSSION = False
 
+
 class TestStaticTime(unittest.TestCase):
 
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
@@ -85,7 +86,9 @@ class TestStaticTime(unittest.TestCase):
             pydt = pydt.asdatetime()
         elif isinstance(pydt, float):
             if NEW_PADISCUSSION:
-                pydt = datetime.fromtimestamp(pydt).astimezone(tz.gettz(default_timezone()))
+                pydt = datetime.fromtimestamp(pydt).astimezone(
+                    tz.gettz(default_timezone())
+                )
             else:
                 pydt = datetime.fromtimestamp(pydt)
 


### PR DESCRIPTION
Needed for https://github.com/plone/plone.app.discussion/pull/204

Tests won't pass until https://github.com/plone/plone.app.discussion/pull/204 is merged as it is a co-dependent change.

Updating p.a.discussion to set timezone aware times.

The current test is checking for a timezone, but there isn't one so the following code wasn't getting executed:

```
if pydt.tzinfo is not None:
    now = pydt.tzinfo.localize(now)
```

but `pydt.tzinfo.localize` is not a function so I have removed this check.

As the times coming from p.a.discussion will be tz aware, this update fixes the tests to compare using timezones.