### PR TITLE
Fix portrait endpoint for email address user id's

### DIFF
--- a/news/1524.bugfix
+++ b/news/1524.bugfix
@@ -1,0 +1,1 @@
+Update @portrait endpoint to use sanitized user id [instification]

--- a/src/plone/restapi/serializer/discussion.py
+++ b/src/plone/restapi/serializer/discussion.py
@@ -108,9 +108,9 @@ class CommentSerializer:
         if username is None:
             return
         portal = getSite()
-        portal_membership = getToolByName(portal, "portal_membership")
-        portrait = portal_membership.getPersonalPortrait(username)
-        if portrait and not isDefaultPortrait(portrait):
+        portal_membership = getToolByName(portal, "portal_membership", None)
+        image = portal_membership.getPersonalPortrait(username)
+        if image and not isDefaultPortrait(image):
             # Despite being called username, it is actually a userid.
             # See https://github.com/plone/plone.app.discussion/blob/dd0255fd5db6662a1b1b4cb7046785038d0d6b71/plone/app/discussion/browser/comments.py#L211-L217
             user = portal_membership.getMemberById(username)

--- a/src/plone/restapi/serializer/user.py
+++ b/src/plone/restapi/serializer/user.py
@@ -2,6 +2,7 @@ from plone.app.users.browser.userdatapanel import getUserDataSchema
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.services.users.get import getPortraitUrl
 from plone.restapi.serializer.converters import json_compatible
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFCore.utils import getToolByName
@@ -39,13 +40,7 @@ class BaseSerializer:
 
         for name in getFieldNames(schema):
             if name == "portrait":
-                membership = getToolByName(portal, "portal_membership")
-                memberdata = getToolByName(portal, "portal_memberdata")
-                safe_id = membership._getSafeMemberId(user.id)
-                if safe_id in memberdata.portraits:
-                    value = f"{portal.absolute_url()}/@portrait/{safe_id}"
-                else:
-                    value = None
+                value = getPortraitUrl(user)
             elif name == "pdelete":
                 continue
             else:

--- a/src/plone/restapi/services/users/get.py
+++ b/src/plone/restapi/services/users/get.py
@@ -26,12 +26,13 @@ def getPortraitUrl(user):
     if not user:
         return
     portal = getSite()
-    portal_membership = getToolByName(portal, "portal_membership")    
+    portal_membership = getToolByName(portal, "portal_membership")
     portrait = portal_membership.getPersonalPortrait(user.id)
     if portrait and not isDefaultPortrait(portrait):
         safe_id = portal_membership._getSafeMemberId(user.id)
         return f"{portal.absolute_url()}/@portrait/{safe_id}"
     return
+
 
 def isDefaultPortrait(value):
     portal = getSite()
@@ -238,14 +239,11 @@ class PortraitGet(Service):
             user = decleanId(self.params[0])
             portrait = self.portal_membership.getPersonalPortrait(user)
         elif len(self.params) == 0:
-            current_user_id = \
-                self.portal_membership.getAuthenticatedMember().getId()
-            portrait = \
-                self.portal_membership.getPersonalPortrait(current_user_id)
+            current_user_id = self.portal_membership.getAuthenticatedMember().getId()
+            portrait = self.portal_membership.getPersonalPortrait(current_user_id)
         else:
             raise Exception(
-                "Must supply exactly zero (own portrait) or one parameter "
-                "(user id)"
+                "Must supply exactly zero (own portrait) or one parameter " "(user id)"
             )
         # User uploaded portraits have a meta_type of "Image"
         if not portrait or isDefaultPortrait(portrait):

--- a/src/plone/restapi/services/users/get.py
+++ b/src/plone/restapi/services/users/get.py
@@ -36,8 +36,9 @@ def getPortraitUrl(user):
 
 def isDefaultPortrait(value):
     portal = getSite()
-    default_portrait_value = getattr(portal, default_portrait, None)
-    return aq_inner(value) == aq_inner(default_portrait_value)
+    default_portrait_value = portal.restrictedTraverse(default_portrait, None)
+    return aq_inner(value).getPhysicalPath() ==\
+        aq_inner(default_portrait_value).getPhysicalPath()
 
 
 @implementer(IPublishTraverse)

--- a/src/plone/restapi/services/users/get.py
+++ b/src/plone/restapi/services/users/get.py
@@ -37,8 +37,10 @@ def getPortraitUrl(user):
 def isDefaultPortrait(value):
     portal = getSite()
     default_portrait_value = portal.restrictedTraverse(default_portrait, None)
-    return aq_inner(value).getPhysicalPath() ==\
-        aq_inner(default_portrait_value).getPhysicalPath()
+    return (
+        aq_inner(value).getPhysicalPath()
+        == aq_inner(default_portrait_value).getPhysicalPath()
+    )
 
 
 @implementer(IPublishTraverse)

--- a/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
@@ -73,7 +73,7 @@ Content-Type: application/json
                 "newVersion": "0006",
                 "required": false
             },
-            "version": "8.30.1.dev0"
+            "version": "8.31.1.dev0"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.session",

--- a/src/plone/restapi/tests/test_comments.py
+++ b/src/plone/restapi/tests/test_comments.py
@@ -111,7 +111,7 @@ class TestCommentsSerializers(TestCase):
 
         serializer = getMultiAdapter((self.comment, self.request), ISerializeToJson)
         self.assertEqual(
-            f"{self.portal_url}/portal_memberdata/portraits/test_user_1_",
+            f"{self.portal_url}/@portrait/test_user_1_",
             serializer().get("author_image"),
         )
 

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -957,22 +957,24 @@ class TestUsersEndpoint(unittest.TestCase):
     def test_get_own_user_portrait(self):
         image = self.makeRealImage()
         pm = api.portal.get_tool("portal_membership")
-        pm.changeMemberPortrait(image, "admin")
+        pm.changeMemberPortrait(image, "noam")
         transaction.commit()
 
-        response = self.api_session.get(
+        self.assertEqual("noam", pm.getPersonalPortrait("noam").getId())
+
+        noam_api_session = RelativeSession(self.portal_url, test=self)
+        noam_api_session.headers.update({"Accept": "application/json"})
+        noam_api_session.auth = ("noam", "password")
+
+        response = noam_api_session.get(
             "/@portrait",
         )
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.headers["Content-Type"], "image/gif")
+        noam_api_session.close()
 
     def test_get_own_user_portrait_logged_out(self):
-        image = self.makeRealImage()
-        pm = api.portal.get_tool("portal_membership")
-        pm.changeMemberPortrait(image, "admin")
-        transaction.commit()
-
         response = self.anon_api_session.get(
             "/@portrait",
         )
@@ -981,7 +983,7 @@ class TestUsersEndpoint(unittest.TestCase):
 
     def test_get_user_portrait_not_set(self):
         response = self.anon_api_session.get(
-            "/@portrait/admin",
+            "/@portrait/noam",
         )
 
         self.assertEqual(404, response.status_code)
@@ -989,11 +991,11 @@ class TestUsersEndpoint(unittest.TestCase):
     def test_get_user_portrait(self):
         image = self.makeRealImage()
         pm = api.portal.get_tool("portal_membership")
-        pm.changeMemberPortrait(image, "admin")
+        pm.changeMemberPortrait(image, "noam")
         transaction.commit()
 
         response = self.api_session.get(
-            "/@portrait/admin",
+            "/@portrait/noam",
         )
 
         self.assertEqual(200, response.status_code)
@@ -1017,7 +1019,7 @@ class TestUsersEndpoint(unittest.TestCase):
         security_settings = getAdapter(self.portal, ISecuritySchema)
         security_settings.use_email_as_login = True
         transaction.commit()
-        
+
         response = self.api_session.post(
             "/@users",
             json={"email": "howard.zinn@example.com", "password": TEST_USER_PASSWORD},
@@ -1028,11 +1030,11 @@ class TestUsersEndpoint(unittest.TestCase):
         pm = api.portal.get_tool("portal_membership")
         pm.changeMemberPortrait(image, "howard.zinn@example.com")
         transaction.commit()
-        
+
         response = self.api_session.get("/@users/howard.zinn@example.com")
         self.assertEqual(200, response.status_code)
         portrait_url = response.json()["portrait"]
-        urlre = re.match(r'.*/@portrait/(.*)', portrait_url)
+        urlre = re.match(r".*/@portrait/(.*)", portrait_url)
         portrait = urlre.group(1)
 
         response = self.api_session.get(

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -1044,7 +1044,7 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.headers["Content-Type"], "image/gif")
 
-    def test_get_user_defalut_portrait(self):
+    def test_get_user_default_portrait(self):
         response = self.anon_api_session.get(
             "/@portrait/admin",
         )

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -1017,6 +1017,7 @@ class TestUsersEndpoint(unittest.TestCase):
         security_settings = getAdapter(self.portal, ISecuritySchema)
         security_settings.use_email_as_login = True
         transaction.commit()
+        
         response = self.api_session.post(
             "/@users",
             json={"email": "howard.zinn@example.com", "password": TEST_USER_PASSWORD},
@@ -1025,13 +1026,13 @@ class TestUsersEndpoint(unittest.TestCase):
 
         image = self.makeRealImage()
         pm = api.portal.get_tool("portal_membership")
-        pm.changeMemberPortrait(image, "admin")
+        pm.changeMemberPortrait(image, "howard.zinn@example.com")
         transaction.commit()
-
-        response = self.api_session.get("/@users/noam")
-
-        self.assertEqual(response.status_code, 200)
-        urlre = re.match(r'.*/@portrait/(.*)', response.json()["portrait"])
+        
+        response = self.api_session.get("/@users/howard.zinn@example.com")
+        self.assertEqual(200, response.status_code)
+        portrait_url = response.json()["portrait"]
+        urlre = re.match(r'.*/@portrait/(.*)', portrait_url)
         portrait = urlre.group(1)
 
         response = self.api_session.get(

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -1044,6 +1044,12 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.headers["Content-Type"], "image/gif")
 
+    def test_get_user_defalut_portrait(self):
+        response = self.anon_api_session.get(
+            "/@portrait/admin",
+        )
+        self.assertEqual(404, response.status_code)
+
     def test_user_with_datetime(self):
         """test that when using a datetime field in the user schema
         the endpoints works correctly


### PR DESCRIPTION
The previous pr #1466 resolved an issue where the endpoint was returning unsanitized user id's.

Following #1481 the new @portrait endpoint does not require sanitized user id's so when email login is enabled, portraits break.

The solution would either be to revert the change made in #1466 and return the raw user id, or to update the @portrait endpoint to handle sanitized id's.

This PR does the latter as well as:

 - Updating the endpoint for discussion/comments to use the new url
 - Updates the tests
   - Uses a Plone user instead of the zmi admin user, as this causes issues rendering the portrait
   - Adds a tests for users where login by email is enabled
   - Updates comments tests