### PR TITLE
Mock addon versions in documentation tests

### DIFF
--- a/news/1538.bugfix
+++ b/news/1538.bugfix
@@ -1,0 +1,2 @@
+Mock addon versions in documentation
+[erral]

--- a/src/plone/restapi/tests/helpers.py
+++ b/src/plone/restapi/tests/helpers.py
@@ -3,6 +3,7 @@ from plone.scale import storage
 from Products.CMFCore.utils import getToolByName
 from unittest.mock import patch
 from urllib.parse import urlparse
+from plone.restapi.services.addons.addons import Addons
 
 import quopri
 
@@ -73,3 +74,14 @@ def patch_scale_uuid(value):
             storage.AnnotationStorage, "_modified_since", return_value=True
         ):
             yield
+
+
+@contextmanager
+def patch_addon_versions(value):
+    """Patch the method that extracts the version of each of the addons.
+    Without this patch we get version errors each time an addon is upgraded
+    which is really annoying when a new version of plone.restapi is released
+    because all PRs need to be updated
+    """
+    with patch.object(Addons, "get_product_version", return_value=value):
+        yield

--- a/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
@@ -13,7 +13,7 @@ Content-Type: application/json
             "title": "Soporte de Pol\u00edtica de Flujo de trabajo (CMFPlacefulWorkflow)",
             "uninstall_profile_id": "Products.CMFPlacefulWorkflow:uninstall",
             "upgrade_info": {},
-            "version": "3.0.0b2"
+            "version": "1.2.3"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/collective.MockMailHost",
@@ -28,10 +28,10 @@ Content-Type: application/json
                 "available": false,
                 "hasProfile": true,
                 "installedVersion": "2.0.0",
-                "newVersion": "2.0.0",
-                "required": false
+                "newVersion": "1.2.3",
+                "required": true
             },
-            "version": "2.0.0"
+            "version": "1.2.3"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.app.iterate",
@@ -43,7 +43,7 @@ Content-Type: application/json
             "title": "Soporte de Copia de Trabajo (Repetir)",
             "uninstall_profile_id": "plone.app.iterate:uninstall",
             "upgrade_info": {},
-            "version": "4.0.3"
+            "version": "1.2.3"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.app.multilingual",
@@ -55,7 +55,7 @@ Content-Type: application/json
             "title": "Soporte Multiidioma",
             "uninstall_profile_id": "plone.app.multilingual:uninstall",
             "upgrade_info": {},
-            "version": "6.0.0b3"
+            "version": "1.2.3"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.restapi",
@@ -73,7 +73,7 @@ Content-Type: application/json
                 "newVersion": "0006",
                 "required": false
             },
-            "version": "8.32.4.dev0"
+            "version": "1.2.3"
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.session",
@@ -85,7 +85,7 @@ Content-Type: application/json
             "title": "Soporte de actualizaci\u00f3n de sesi\u00f3n",
             "uninstall_profile_id": "plone.session:uninstall",
             "upgrade_info": {},
-            "version": "4.0.0b2"
+            "version": "1.2.3"
         }
     ]
 }

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -27,7 +27,7 @@ from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_ITERATE_FUNCTIONAL_TESTING
 from plone.restapi.testing import register_static_uuid_utility
 from plone.restapi.testing import RelativeSession
-from plone.restapi.tests.helpers import patch_scale_uuid
+from plone.restapi.tests.helpers import patch_scale_uuid, patch_addon_versions
 from plone.restapi.tests.statictime import StaticTime
 from plone.testing.z2 import Browser
 from zope.component import createObject
@@ -1371,7 +1371,7 @@ class TestDocumentation(TestDocumentationBase):
 
     def test_documentation_vocabularies_get_filtered_by_title(self):
         response = self.api_session.get(
-            "/@vocabularies/plone.app.vocabularies.ReallyUserFriendlyTypes?" "title=doc"
+            "/@vocabularies/plone.app.vocabularies.ReallyUserFriendlyTypes?title=doc"
         )
         save_request_and_response_for_docs(
             "vocabularies_get_filtered_by_title", response
@@ -1583,8 +1583,7 @@ class TestDocumentation(TestDocumentationBase):
         # Replace dynamic lock token with a static one
         response._content = re.sub(
             b'"token": "[^"]+"',
-            b'"token":'
-            b' "0.684672730996-0.25195226375-00105A989226:1477076400.000"',  # noqa
+            b'"token": "0.684672730996-0.25195226375-00105A989226:1477076400.000"',  # noqa
             response.content,
         )
         save_request_and_response_for_docs("lock", response)
@@ -1597,8 +1596,7 @@ class TestDocumentation(TestDocumentationBase):
         # Replace dynamic lock token with a static one
         response._content = re.sub(
             b'"token": "[^"]+"',
-            b'"token":'
-            b' "0.684672730996-0.25195226375-00105A989226:1477076400.000"',  # noqa
+            b'"token": "0.684672730996-0.25195226375-00105A989226:1477076400.000"',  # noqa
             response.content,
         )
         save_request_and_response_for_docs("lock_nonstealable_timeout", response)
@@ -1624,8 +1622,7 @@ class TestDocumentation(TestDocumentationBase):
         # Replace dynamic lock token with a static one
         response._content = re.sub(
             b'"token": "[^"]+"',
-            b'"token":'
-            b' "0.684672730996-0.25195226375-00105A989226:1477076400.000"',  # noqa
+            b'"token": "0.684672730996-0.25195226375-00105A989226:1477076400.000"',  # noqa
             response.content,
         )
         save_request_and_response_for_docs("refresh_lock", response)
@@ -1741,8 +1738,9 @@ class TestDocumentationMessageTranslations(TestDocumentationBase):
         )
 
     def test_translate_messages_addons(self):
-        response = self.api_session.get("/@addons")
-        save_request_and_response_for_docs("translated_messages_addons", response)
+        with patch_addon_versions("1.2.3"):
+            response = self.api_session.get("/@addons")
+            save_request_and_response_for_docs("translated_messages_addons", response)
 
 
 class TestCommenting(TestDocumentationBase):


### PR DESCRIPTION
This way we do not have to update plone.restapi's version in documentation tests each time a new release is created.

Fixes #1538