### PR TITLE
Internationalization of @users endpoint error messages

### DIFF
--- a/news/1548.feature
+++ b/news/1548.feature
@@ -1,0 +1,1 @@
+Internationalization of ``@users`` endpoint error messages. [wesleybl]

--- a/src/plone/restapi/locales/de/LC_MESSAGES/plone.restapi.po
+++ b/src/plone/restapi/locales/de/LC_MESSAGES/plone.restapi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-02 15:33+0000\n"
+"POT-Creation-Date: 2022-12-16 02:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Timo Stollenwerk <tisto@plone.org>\n"
 "Language-Team: German <DE@li.org>\n"
@@ -18,46 +18,256 @@ msgstr ""
 msgid "${sender_fullname} via ${portal_title}"
 msgstr "${sender_fullname} via ${portal_title}"
 
-#: plone/restapi/services/email_send/post.py:76
+#: plone/restapi/services/email_send/post.py:74
 msgid "A portal user via ${portal_title}"
 msgstr "Ein Portal Nutzer via ${portal_title}"
 
-#: plone/restapi/configure.zcml:39
+#: plone/restapi/configure.zcml:73
 msgid "Adds sample content for performance testing"
 msgstr ""
 
-#: plone/restapi/configure.zcml:31
+#: plone/restapi/configure.zcml:56
 msgid "Adds sample content types for testing"
 msgstr ""
 
-#: plone/restapi/configure.zcml:55
+#: plone/restapi/configure.zcml:65
+msgid "Adds sample workflows for testing"
+msgstr ""
+
+#: plone/restapi/services/aliases/add.py:106
+msgid "Alternative urls that point to themselves will cause an endless cycle of redirects."
+msgstr ""
+
+#: plone/restapi/configure.zcml:115
+msgid "Blocks"
+msgstr ""
+
+#: plone/restapi/configure.zcml:122
+msgid "Blocks (Editable Layout)"
+msgstr ""
+
+#: plone/restapi/configure.zcml:122
+msgid "Enables Volto Blocks (editable layout) support"
+msgstr ""
+
+#: plone/restapi/configure.zcml:115
+msgid "Enables Volto Blocks support"
+msgstr ""
+
+#: plone/restapi/configure.zcml:81
+msgid "Enables blocks on the Document content type"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:133
+msgid "Enter a valid scale name (see 'Image Handling' control panel) to override (e.g. icon, tile, thumb, mini, preview, ... ). Leave empty to use default (see 'Site' control panel)."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:163
+msgid "Error in fields. ${errors_to_string}"
+msgstr ""
+
+#. Default: "The reset_token is expired."
+#: plone/restapi/services/users/add.py:312
+msgid "Expired Token"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:126
+msgid "If enabled, the portlet will not show document type icons."
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:145
+msgid "If enabled, the portlet will not show thumbs."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:296
+msgid "If you pass 'old_password' you have to pass 'new_password'"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:290
+msgid "If you pass 'reset_token' you have to pass 'new_password'"
+msgstr ""
+
+#: plone/restapi/behaviors.py:23
+msgid "Layout"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:195
+msgid "Navigation"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:132
+msgid "Override thumb scale"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:97
+msgid "Property '${fieldname}' is not allowed."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:87
+msgid "Property '${fieldname}' is required."
+msgstr ""
+
+#: plone/restapi/configure.zcml:89
 msgid "RESTful hypermedia API for Plone - Uninstall"
 msgstr ""
 
-#: plone/restapi/configure.zcml:22
+#: plone/restapi/configure.zcml:47
 msgid "RESTful hypermedia API for Plone."
 msgstr ""
 
-#: plone/restapi/services/history/patch.py:30
+#: plone/restapi/services/history/patch.py:28
 msgid "Reverted to revision ${version}"
 msgstr ""
 
-#: plone/restapi/services/email_send/post.py:88
+#: plone/restapi/services/users/add.py:48
+msgid "Roles"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:350
+msgid "See the user endpoint documentation for the valid parameters."
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:125
+msgid "Suppress Icons"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:144
+msgid "Suppress thumbs"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:342
+msgid "The password passed as 'old_password' is wrong."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:307
+msgid "The reset_token is unknown/not valid."
+msgstr ""
+
+#: plone/restapi/configure.zcml:81
+msgid "Volto Blocks"
+msgstr ""
+
+#: plone/restapi/services/users/update.py:119
+msgid "You are not authorized to perform this action"
+msgstr ""
+
+#: plone/restapi/services/email_send/post.py:91
 msgid "You are receiving this mail because ${sender_fullname} sent this message via the site ${portal_title}:"
 msgstr "Sie erhalten diese E-Mail, weil Ihnen ${sender_fullname} diese Nachricht über die Webseite ${portal_title} geschickt hat:"
 
-#: plone/restapi/configure.zcml:22
+#: plone/restapi/services/users/add.py:114
+msgid "You can't send both password and sendPasswordReset."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:322
+msgid "You can't set a password without a password reset token."
+msgstr ""
+
+#: plone/restapi/services/users/update.py:125
+msgid "You can't update the properties of this user"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:284
+msgid "You can't use 'reset_token' and 'old_password' together."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:109
+msgid "You have to either send a password or sendPasswordReset."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:154
+msgid "You need AddPortalMember permission."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:329
+msgid "You need to be logged in as the user '${username}' to set the password."
+msgstr ""
+
+#. Default: "Missing dependency"
+#: plone/restapi/services/addons/addons.py:207
+msgid "dependency_missing"
+msgstr ""
+
+#. Default: "If selected, the navigation tree will only show the current folder and its children at all times."
+#: plone/restapi/services/contextnavigation/get.py:84
+msgid "help_current_folder_only"
+msgstr ""
+
+#. Default: "Whether or not to show the top, or 'root', node in the navigation tree. This is affected by the 'Start level' setting."
+#: plone/restapi/services/contextnavigation/get.py:69
+msgid "help_include_top_node"
+msgstr ""
+
+#. Default: "You may search for and choose a folder to act as the root of the navigation tree. Leave blank to use the Plone site root."
+#: plone/restapi/services/contextnavigation/get.py:58
+msgid "help_navigation_root"
+msgstr ""
+
+#. Default: "An integer value that specifies the number of folder levels below the site root that must be exceeded before the navigation tree will display. 0 means that the navigation tree should be displayed everywhere including pages in the root of the site. 1 means the tree only shows up inside folders located in the root and downwards, never showing at the top level."
+#: plone/restapi/services/contextnavigation/get.py:96
+msgid "help_navigation_start_level"
+msgstr ""
+
+#. Default: "The title of the navigation tree."
+#: plone/restapi/services/contextnavigation/get.py:49
+msgid "help_navigation_title"
+msgstr ""
+
+#. Default: "How many folders should be included before the navigation tree stops. 0 means no limit. 1 only includes the root folder."
+#: plone/restapi/services/contextnavigation/get.py:113
+msgid "help_navigation_tree_depth"
+msgstr ""
+
+#. Default: "Only show the contents of the current folder."
+#: plone/restapi/services/contextnavigation/get.py:80
+msgid "label_current_folder_only"
+msgstr ""
+
+#. Default: "Include top node"
+#: plone/restapi/services/contextnavigation/get.py:68
+msgid "label_include_top_node"
+msgstr ""
+
+#. Default: "Root node"
+#: plone/restapi/services/contextnavigation/get.py:57
+msgid "label_navigation_root_path"
+msgstr ""
+
+#. Default: "Start level"
+#: plone/restapi/services/contextnavigation/get.py:95
+msgid "label_navigation_startlevel"
+msgstr ""
+
+#. Default: "Title"
+#: plone/restapi/services/contextnavigation/get.py:48
+msgid "label_navigation_title"
+msgstr ""
+
+#. Default: "Navigation tree depth"
+#: plone/restapi/services/contextnavigation/get.py:112
+msgid "label_navigation_tree_depth"
+msgstr ""
+
+#: plone/restapi/configure.zcml:47
 msgid "plone.restapi"
 msgstr ""
 
-#: plone/restapi/configure.zcml:39
+#: plone/restapi/configure.zcml:73
 msgid "plone.restapi performance testing"
 msgstr ""
 
-#: plone/restapi/configure.zcml:31
+#: plone/restapi/configure.zcml:56
 msgid "plone.restapi testing"
 msgstr ""
 
-#: plone/restapi/upgrades/configure.zcml:23
+#: plone/restapi/configure.zcml:65
+msgid "plone.restapi testing-workflows"
+msgstr ""
+
+#: plone/restapi/upgrades/configure.zcml:33
 msgid "plone.restapi.upgrades.0002"
+msgstr ""
+
+#: plone/restapi/upgrades/configure.zcml:52
+msgid "plone.restapi.upgrades.0004"
 msgstr ""

--- a/src/plone/restapi/locales/plone.restapi.pot
+++ b/src/plone/restapi/locales/plone.restapi.pot
@@ -1,10 +1,10 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#--- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+#SOME DESCRIPTIVE TITLE.
+#FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-02 15:33+0000\n"
+"POT-Creation-Date: 2022-12-16 02:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,46 +21,256 @@ msgstr ""
 msgid "${sender_fullname} via ${portal_title}"
 msgstr ""
 
-#: plone/restapi/services/email_send/post.py:76
+#: plone/restapi/services/email_send/post.py:74
 msgid "A portal user via ${portal_title}"
 msgstr ""
 
-#: plone/restapi/configure.zcml:39
+#: plone/restapi/configure.zcml:73
 msgid "Adds sample content for performance testing"
 msgstr ""
 
-#: plone/restapi/configure.zcml:31
+#: plone/restapi/configure.zcml:56
 msgid "Adds sample content types for testing"
 msgstr ""
 
-#: plone/restapi/configure.zcml:55
+#: plone/restapi/configure.zcml:65
+msgid "Adds sample workflows for testing"
+msgstr ""
+
+#: plone/restapi/services/aliases/add.py:106
+msgid "Alternative urls that point to themselves will cause an endless cycle of redirects."
+msgstr ""
+
+#: plone/restapi/configure.zcml:115
+msgid "Blocks"
+msgstr ""
+
+#: plone/restapi/configure.zcml:122
+msgid "Blocks (Editable Layout)"
+msgstr ""
+
+#: plone/restapi/configure.zcml:122
+msgid "Enables Volto Blocks (editable layout) support"
+msgstr ""
+
+#: plone/restapi/configure.zcml:115
+msgid "Enables Volto Blocks support"
+msgstr ""
+
+#: plone/restapi/configure.zcml:81
+msgid "Enables blocks on the Document content type"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:133
+msgid "Enter a valid scale name (see 'Image Handling' control panel) to override (e.g. icon, tile, thumb, mini, preview, ... ). Leave empty to use default (see 'Site' control panel)."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:163
+msgid "Error in fields. ${errors_to_string}"
+msgstr ""
+
+#. Default: "The reset_token is expired."
+#: plone/restapi/services/users/add.py:312
+msgid "Expired Token"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:126
+msgid "If enabled, the portlet will not show document type icons."
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:145
+msgid "If enabled, the portlet will not show thumbs."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:296
+msgid "If you pass 'old_password' you have to pass 'new_password'"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:290
+msgid "If you pass 'reset_token' you have to pass 'new_password'"
+msgstr ""
+
+#: plone/restapi/behaviors.py:23
+msgid "Layout"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:195
+msgid "Navigation"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:132
+msgid "Override thumb scale"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:97
+msgid "Property '${fieldname}' is not allowed."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:87
+msgid "Property '${fieldname}' is required."
+msgstr ""
+
+#: plone/restapi/configure.zcml:89
 msgid "RESTful hypermedia API for Plone - Uninstall"
 msgstr ""
 
-#: plone/restapi/configure.zcml:22
+#: plone/restapi/configure.zcml:47
 msgid "RESTful hypermedia API for Plone."
 msgstr ""
 
-#: plone/restapi/services/history/patch.py:30
+#: plone/restapi/services/history/patch.py:28
 msgid "Reverted to revision ${version}"
 msgstr ""
 
-#: plone/restapi/services/email_send/post.py:88
+#: plone/restapi/services/users/add.py:48
+msgid "Roles"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:350
+msgid "See the user endpoint documentation for the valid parameters."
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:125
+msgid "Suppress Icons"
+msgstr ""
+
+#: plone/restapi/services/contextnavigation/get.py:144
+msgid "Suppress thumbs"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:342
+msgid "The password passed as 'old_password' is wrong."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:307
+msgid "The reset_token is unknown/not valid."
+msgstr ""
+
+#: plone/restapi/configure.zcml:81
+msgid "Volto Blocks"
+msgstr ""
+
+#: plone/restapi/services/users/update.py:119
+msgid "You are not authorized to perform this action"
+msgstr ""
+
+#: plone/restapi/services/email_send/post.py:91
 msgid "You are receiving this mail because ${sender_fullname} sent this message via the site ${portal_title}:"
 msgstr ""
 
-#: plone/restapi/configure.zcml:22
+#: plone/restapi/services/users/add.py:114
+msgid "You can't send both password and sendPasswordReset."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:322
+msgid "You can't set a password without a password reset token."
+msgstr ""
+
+#: plone/restapi/services/users/update.py:125
+msgid "You can't update the properties of this user"
+msgstr ""
+
+#: plone/restapi/services/users/add.py:284
+msgid "You can't use 'reset_token' and 'old_password' together."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:109
+msgid "You have to either send a password or sendPasswordReset."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:154
+msgid "You need AddPortalMember permission."
+msgstr ""
+
+#: plone/restapi/services/users/add.py:329
+msgid "You need to be logged in as the user '${username}' to set the password."
+msgstr ""
+
+#. Default: "Missing dependency"
+#: plone/restapi/services/addons/addons.py:207
+msgid "dependency_missing"
+msgstr ""
+
+#. Default: "If selected, the navigation tree will only show the current folder and its children at all times."
+#: plone/restapi/services/contextnavigation/get.py:84
+msgid "help_current_folder_only"
+msgstr ""
+
+#. Default: "Whether or not to show the top, or 'root', node in the navigation tree. This is affected by the 'Start level' setting."
+#: plone/restapi/services/contextnavigation/get.py:69
+msgid "help_include_top_node"
+msgstr ""
+
+#. Default: "You may search for and choose a folder to act as the root of the navigation tree. Leave blank to use the Plone site root."
+#: plone/restapi/services/contextnavigation/get.py:58
+msgid "help_navigation_root"
+msgstr ""
+
+#. Default: "An integer value that specifies the number of folder levels below the site root that must be exceeded before the navigation tree will display. 0 means that the navigation tree should be displayed everywhere including pages in the root of the site. 1 means the tree only shows up inside folders located in the root and downwards, never showing at the top level."
+#: plone/restapi/services/contextnavigation/get.py:96
+msgid "help_navigation_start_level"
+msgstr ""
+
+#. Default: "The title of the navigation tree."
+#: plone/restapi/services/contextnavigation/get.py:49
+msgid "help_navigation_title"
+msgstr ""
+
+#. Default: "How many folders should be included before the navigation tree stops. 0 means no limit. 1 only includes the root folder."
+#: plone/restapi/services/contextnavigation/get.py:113
+msgid "help_navigation_tree_depth"
+msgstr ""
+
+#. Default: "Only show the contents of the current folder."
+#: plone/restapi/services/contextnavigation/get.py:80
+msgid "label_current_folder_only"
+msgstr ""
+
+#. Default: "Include top node"
+#: plone/restapi/services/contextnavigation/get.py:68
+msgid "label_include_top_node"
+msgstr ""
+
+#. Default: "Root node"
+#: plone/restapi/services/contextnavigation/get.py:57
+msgid "label_navigation_root_path"
+msgstr ""
+
+#. Default: "Start level"
+#: plone/restapi/services/contextnavigation/get.py:95
+msgid "label_navigation_startlevel"
+msgstr ""
+
+#. Default: "Title"
+#: plone/restapi/services/contextnavigation/get.py:48
+msgid "label_navigation_title"
+msgstr ""
+
+#. Default: "Navigation tree depth"
+#: plone/restapi/services/contextnavigation/get.py:112
+msgid "label_navigation_tree_depth"
+msgstr ""
+
+#: plone/restapi/configure.zcml:47
 msgid "plone.restapi"
 msgstr ""
 
-#: plone/restapi/configure.zcml:39
+#: plone/restapi/configure.zcml:73
 msgid "plone.restapi performance testing"
 msgstr ""
 
-#: plone/restapi/configure.zcml:31
+#: plone/restapi/configure.zcml:56
 msgid "plone.restapi testing"
 msgstr ""
 
-#: plone/restapi/upgrades/configure.zcml:23
+#: plone/restapi/configure.zcml:65
+msgid "plone.restapi testing-workflows"
+msgstr ""
+
+#: plone/restapi/upgrades/configure.zcml:33
 msgid "plone.restapi.upgrades.0002"
+msgstr ""
+
+#: plone/restapi/upgrades/configure.zcml:52
+msgid "plone.restapi.upgrades.0004"
 msgstr ""

--- a/src/plone/restapi/services/users/add.py
+++ b/src/plone/restapi/services/users/add.py
@@ -1,4 +1,6 @@
 from AccessControl import getSecurityManager
+from plone.app.users.schema import ICombinedRegisterSchema
+from plone.restapi import _
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
@@ -13,6 +15,7 @@ from zope.component import getAdapter
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.component.hooks import getSite
+from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
@@ -32,6 +35,22 @@ class UsersPost(Service):
         # Consume any path segments after /@users as parameters
         self.params.append(name)
         return self
+
+    def translate(self, msgid):
+        return translate(
+            msgid,
+            context=self.request,
+        )
+
+    def translate_fieldname(self, fieldname):
+        """Not all fields that appear on Add User Form in Volto match in Plone."""
+        if fieldname == "roles":
+            msgid = _("Roles")
+        elif fieldname == "sendPasswordReset":
+            msgid = ICombinedRegisterSchema["mail_me"].title
+        else:
+            msgid = ICombinedRegisterSchema[fieldname].title
+        return self.translate(msgid)
 
     def validate_input_data(self, portal, original_data):
         """Returns a tuple of (required_fields, allowed_fields)"""
@@ -62,11 +81,23 @@ class UsersPost(Service):
         # check input data
         for fieldname in required:
             if not data.get(fieldname, None):
-                self.add_field_error(fieldname, f"Property '{fieldname}' is required.")
+                translated_fieldname = self.translate_fieldname(fieldname)
+                self.add_field_error(
+                    fieldname,
+                    _(
+                        "Property '${fieldname}' is required.",
+                        mapping={"fieldname": translated_fieldname},
+                    ),
+                )
         for fieldname in data:
             if fieldname not in allowed:
+                translated_fieldname = self.translate_fieldname(fieldname)
                 self.add_field_error(
-                    fieldname, f"Property '{fieldname}' is not allowed."
+                    fieldname,
+                    _(
+                        "Property '${fieldname}' is not allowed.",
+                        mapping={"fieldname": translated_fieldname},
+                    ),
                 )
 
         password = data.get("password")
@@ -75,16 +106,16 @@ class UsersPost(Service):
             if password is None and send_password_reset is None:
                 self.add_field_error(
                     "sendPasswordReset",
-                    "You have to either send a password or sendPasswordReset.",
+                    _("You have to either send a password or sendPasswordReset."),
                 )
             if password and send_password_reset:
                 self.add_field_error(
                     "sendPasswordReset",
-                    "You can't send both password and sendPasswordReset.",
+                    _("You can't send both password and sendPasswordReset."),
                 )
 
-    def add_field_error(self, field, message):
-        self.errors.append({"field": field, "message": message})
+    def add_field_error(self, field, msgid):
+        self.errors.append({"field": field, "message": self.translate(msgid)})
 
     def errors_to_string(self):
         return " ".join([error["message"] for error in self.errors])
@@ -117,14 +148,23 @@ class UsersPost(Service):
 
         # Add a portal member
         if not self.can_add_member:
-            return self._error(403, "Forbidden", "You need AddPortalMember permission.")
+            return self._error(
+                403,
+                "Forbidden",
+                _("You need AddPortalMember permission."),
+            )
 
         if self.errors:
             self.request.response.setStatus(400)
             return dict(
                 error=dict(
                     type="WrongParameterError",
-                    message=f"Error in fields. {self.errors_to_string()}",
+                    message=self.translate(
+                        _(
+                            "Error in fields. ${errors_to_string}",
+                            mapping={"errors_to_string": self.errors_to_string()},
+                        )
+                    ),
                     errors=self.errors,
                 )
             )
@@ -167,7 +207,12 @@ class UsersPost(Service):
             )
         except ValueError as e:
             self.request.response.setStatus(400)
-            return dict(error=dict(type="MissingParameterError", message=str(e)))
+            return dict(
+                error=dict(
+                    type="MissingParameterError",
+                    message=self.translate(str(e)),
+                )
+            )
 
         if user_id != login_name:
             # The user id differs from the login name.  Set the login
@@ -192,9 +237,9 @@ class UsersPost(Service):
     def _get_user_by_login_name(self, user_id):
         return get_member_by_login_name(self.context, user_id, raise_exceptions=False)
 
-    def _error(self, status, type, message):
+    def _error(self, status, _type, msgid):
         self.request.response.setStatus(status)
-        return {"error": {"type": type, "message": message}}
+        return {"error": {"type": _type, "message": self.translate(msgid)}}
 
     @property
     def can_manage_users(self):
@@ -236,19 +281,19 @@ class UsersPost(Service):
             return self._error(
                 400,
                 "Invalid parameters",
-                "You can't use 'reset_token' and 'old_password' together.",
+                _("You can't use 'reset_token' and 'old_password' together."),
             )
         if reset_token and not new_password:
             return self._error(
                 400,
                 "Invalid parameters",
-                "If you pass 'reset_token' you have to pass 'new_password'",
+                _("If you pass 'reset_token' you have to pass 'new_password'"),
             )
         if old_password and not new_password:
             return self._error(
                 400,
                 "Invalid parameters",
-                "If you pass 'old_password' you have to pass 'new_password'",
+                _("If you pass 'old_password' you have to pass 'new_password'"),
             )
 
         # Reset the password with a reset token
@@ -257,10 +302,15 @@ class UsersPost(Service):
                 pwt.resetPassword(username, reset_token, new_password)
             except InvalidRequestError:
                 return self._error(
-                    403, "Unknown Token", "The reset_token is unknown/not valid."
+                    403,
+                    "Unknown Token",
+                    _("The reset_token is unknown/not valid."),
                 )
             except ExpiredRequestError:
-                return self._error(403, "Expired Token", "The reset_token is expired.")
+                return self._error(
+                    403,
+                    _("Expired Token", "The reset_token is expired."),
+                )
             return
 
         # set the new password by giving the old password
@@ -269,18 +319,17 @@ class UsersPost(Service):
                 return self._error(
                     403,
                     "Not allowed",
-                    "You can't set a password without " "a password reset token.",
+                    _("You can't set a password without a password reset token."),
                 )
             authenticated_user_id = mt.getAuthenticatedMember().getId()
             if username != authenticated_user_id:
                 return self._error(
                     403,
                     "Wrong user",
-                    (
-                        "You need to be logged in as the user '%s' to set "
-                        "the password."
-                    )
-                    % username,
+                    _(
+                        "You need to be logged in as the user '${username}' to set the password.",
+                        mapping={"username": username},
+                    ),
                 )
 
             check_password_auth = pas.authenticate(
@@ -290,7 +339,7 @@ class UsersPost(Service):
                 return self._error(
                     403,
                     "Wrong password",
-                    "The password passed as 'old_password' " "is wrong.",
+                    _("The password passed as 'old_password' is wrong."),
                 )
             mt.setPassword(new_password)
             return
@@ -298,5 +347,5 @@ class UsersPost(Service):
         return self._error(
             400,
             "Invalid parameters",
-            "See the user endpoint documentation for the " "valid parameters.",
+            _("See the user endpoint documentation for the valid parameters."),
         )

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -5,6 +5,7 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_PASSWORD
+from plone.restapi.services.users.get import UsersGet
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
 from Products.CMFCore.permissions import SetOwnPassword
@@ -13,7 +14,6 @@ from Products.CMFPlone.interfaces import ISecuritySchema
 from Products.MailHost.interfaces import IMailHost
 from zope.component import getAdapter
 from zope.component import getUtility
-from plone.restapi.services.users.get import UsersGet
 
 import os
 import re
@@ -150,7 +150,7 @@ class TestUsersEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(400, response.status_code)
-        self.assertTrue("Property 'username' is required" in response.text)
+        self.assertTrue("Property 'User Name' is required" in response.text)
 
     def test_add_user_password_is_required(self):
         response = self.api_session.post("/@users", json={"username": "noamchomsky"})
@@ -172,7 +172,7 @@ class TestUsersEndpoint(unittest.TestCase):
         )
 
         self.assertEqual(400, response.status_code)
-        self.assertTrue("Property 'username' is not allowed" in response.text)
+        self.assertTrue("Property 'User Name' is not allowed" in response.text)
 
     def test_add_user_email_with_email_login_enabled(self):
         # enable use_email_as_login
@@ -204,7 +204,7 @@ class TestUsersEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(400, response.status_code)
-        self.assertTrue("Property 'username' is not allowed" in response.text)
+        self.assertTrue("Property 'User Name' is not allowed" in response.text)
 
     def test_add_user_with_email_login_enabled(self):
         # enable use_email_as_login
@@ -882,7 +882,7 @@ class TestUsersEndpoint(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(400, response.status_code)
-        self.assertTrue("Property 'password' is not allowed" in response.text)
+        self.assertTrue("Property 'Password' is not allowed" in response.text)
 
         security_settings.enable_user_pwd_choice = True
         transaction.commit()


### PR DESCRIPTION
The `plone.restapi` domain was used.

Fixes https://github.com/plone/volto/issues/3958