### PR TITLE
Make sure slate block linkintegrity retriever doesn't return None

### DIFF
--- a/news/1553.bugfix
+++ b/news/1553.bugfix
@@ -1,0 +1,1 @@
+Fix an error when saving content with a slate block that includes an empty link. [davisagli]

--- a/src/plone/restapi/blocks_linkintegrity.py
+++ b/src/plone/restapi/blocks_linkintegrity.py
@@ -88,7 +88,9 @@ class SlateBlockLinksRetriever:
             if node_type:
                 handler = getattr(self, f"handle_{node_type}", None)
                 if handler:
-                    self.links.append(handler(child))
+                    value = handler(child)
+                    if value:
+                        self.links.append(value)
 
         return self.links
 

--- a/src/plone/restapi/tests/test_blocks_linkintegrity.py
+++ b/src/plone/restapi/tests/test_blocks_linkintegrity.py
@@ -202,6 +202,35 @@ class TestBlocksLinkintegrity(TestCase):
         self.assertEqual(len(value), 1)
         self.assertIn("../resolveuid/{}".format(uid), value)
 
+    def test_links_retriever_skip_empty_links(self):
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": None,
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+
+        self.portal.doc1.blocks = blocks
+        value = self.retrieve_links(blocks)
+
+        self.assertEqual(len(value), 0)
+
 
 class TestLinkintegrityForBlocks(TestCase):
 


### PR DESCRIPTION
Fixes #1553 