### PR TITLE
Fix No such index: 'sort_on' warnings

### DIFF
--- a/news/1558.bugfix
+++ b/news/1558.bugfix
@@ -1,0 +1,2 @@
+Fix mistaken warnings about sort_on and sort_order parameters in the @query
+service. [davisagli]

--- a/src/plone/restapi/search/query.py
+++ b/src/plone/restapi/search/query.py
@@ -102,12 +102,13 @@ class ZCatalogCompatibleQueryAdapter:
     def __call__(self, query):
         for idx_name, idx_query in query.items():
             if idx_name in self.global_query_params:
-                # It's a query-wide parameter like 'sort_on'
+                # It's a query-wide parameter like 'sort_limit'
                 query[idx_name] = self.parse_query_param(idx_name, idx_query)
                 continue
 
             if idx_name in self.multiple_types_global_query_params:
                 query[idx_name] = self.parse_multiple_types_param(idx_name, idx_query)
+                continue
 
             # Then check for each index present in the query if there is an
             # IIndexQueryParser that knows how to deserialize any values

--- a/src/plone/restapi/tests/__init__.py
+++ b/src/plone/restapi/tests/__init__.py
@@ -1,0 +1,5 @@
+import sys
+
+
+# BBB: Remove when drop Python 3.9 support.
+PY3_10 = sys.version_info[0:2] >= (3, 10)

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -11,6 +11,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.textfield.value import RichTextValue
 from plone.dexterity.utils import createContentInContainer
 from plone.registry.interfaces import IRegistry
+from plone.restapi.search.query import ZCatalogCompatibleQueryAdapter
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
 from plone.restapi.tests.helpers import result_paths
@@ -817,3 +818,20 @@ class TestSearchFunctional(unittest.TestCase):
 
         noLongerProvides(self.folder, INavigationRoot)
         transaction.commit()
+
+    def test_zcatalogcompatiblequeryadapter_log(self):
+        """When we have sort_on or sort_order in the query passed to
+        ZCatalogCompatibleQueryAdapter, warnings should not be issued in the
+        log.
+        """
+        query_adapter = ZCatalogCompatibleQueryAdapter(self.portal, self.request)
+        with self.assertNoLogs("plone.restapi.search.query", level="WARN"):
+            query_adapter(
+                {
+                    "b_size": "50",
+                    "metadata_fields": "_all",
+                    "path": {"depth": "1", "query": "/Plone"},
+                    "sort_on": "getObjPositionInParent",
+                    "sort_order": "ascending",
+                },
+            )

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -14,6 +14,7 @@ from plone.registry.interfaces import IRegistry
 from plone.restapi.search.query import ZCatalogCompatibleQueryAdapter
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
+from plone.restapi.tests import PY3_10
 from plone.restapi.tests.helpers import result_paths
 from plone.uuid.interfaces import IMutableUUID
 from Products.CMFCore.utils import getToolByName
@@ -819,6 +820,8 @@ class TestSearchFunctional(unittest.TestCase):
         noLongerProvides(self.folder, INavigationRoot)
         transaction.commit()
 
+    # BBB: Remove condition when drop Python 3.9 support.
+    @unittest.skipUnless(PY3_10, "assertNoLogs is only in Python >= 3.10")
     def test_zcatalogcompatiblequeryadapter_log(self):
         """When we have sort_on or sort_order in the query passed to
         ZCatalogCompatibleQueryAdapter, warnings should not be issued in the


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/plone/plone.restapi/pull/1533