### PR TITLE
depth is bottomLevel

### DIFF
--- a/src/plone/restapi/services/contextnavigation/get.py
+++ b/src/plone/restapi/services/contextnavigation/get.py
@@ -117,7 +117,7 @@ class INavigationPortlet(Interface):
             "means no limit. 1 only includes the "
             "root folder.",
         ),
-        default=0,
+        default=9,
         required=False,
     )
 
@@ -647,9 +647,9 @@ class QueryBuilder:
         # use a regular depth-1 query in this case.
 
         if currentPath != rootPath and not currentPath.startswith(rootPath + "/"):
-            query["path"] = {"query": rootPath, "depth": 1}
+            query["path"] = {"query": rootPath, "depth": data.bottomLevel}
         else:
-            query["path"] = {"query": currentPath, "navtree": 1}
+            query["path"] = {"query": currentPath, "depth": data.bottomLevel}
 
         topLevel = data.topLevel
         if topLevel and topLevel > 0:


### PR DESCRIPTION
When using  @contextnavigation endpoint it would not respect the bottomLevel and go maximum 1 level in depth. 

ex: https://6.demo.plone.org/++api++/events/@contextnavigation?expand.contextnavigation.topLevel=0&expand.contextnavigation.bottomLevel=5&expand.contextnavigation.currentFolderOnly=false&expand.contextnavigation.root_path=/

way to replicate this: have a folder/page inside folder/page (and go as far as you want) in the /events page, lets say. Then navigate to the above link to see the result. I would expect to go 5 times into subfolders before it stops but it shows 1.

versus @navigation endpoint https://6.demo.plone.org/++api++/@navigation?expand.navigation.depth=5 that goes in depth