### PR TITLE
Improve blocks linkintegrity retrieval of internal links

### DIFF
--- a/news/1565.bugfix
+++ b/news/1565.bugfix
@@ -1,0 +1,1 @@
+Fix blocks linkintegrity to find some links in `url` and `href` fields that were previously ignored. [davisagli]

--- a/src/plone/restapi/tests/test_blocks_linkintegrity.py
+++ b/src/plone/restapi/tests/test_blocks_linkintegrity.py
@@ -156,6 +156,24 @@ class TestBlocksLinkintegrity(TestCase):
         self.assertEqual(len(value), 1)
         self.assertIn("../resolveuid/{}".format(uid), value)
 
+    def test_links_retriever_return_internal_links_in_generic_block_href_list(self):
+        uid = IUUID(self.doc2)
+        blocks = {"111": {"@type": "foo", "href": ["../resolveuid/{}".format(uid)]}}
+        self.portal.doc1.blocks = blocks
+        value = self.retrieve_links(blocks)
+
+        self.assertEqual(len(value), 1)
+        self.assertIn("../resolveuid/{}".format(uid), value)
+
+    def test_links_retriever_return_internal_links_in_generic_block_href_id(self):
+        uid = IUUID(self.doc2)
+        blocks = {"111": {"@type": "foo", "href": [{"@id": "../resolveuid/{}".format(uid)}]}}
+        self.portal.doc1.blocks = blocks
+        value = self.retrieve_links(blocks)
+
+        self.assertEqual(len(value), 1)
+        self.assertIn("../resolveuid/{}".format(uid), value)
+
     def test_links_retriever_return_internal_links_in_text_block_once(self):
         uid = IUUID(self.doc2)
         blocks = {

--- a/src/plone/restapi/tests/test_blocks_linkintegrity.py
+++ b/src/plone/restapi/tests/test_blocks_linkintegrity.py
@@ -167,7 +167,9 @@ class TestBlocksLinkintegrity(TestCase):
 
     def test_links_retriever_return_internal_links_in_generic_block_href_id(self):
         uid = IUUID(self.doc2)
-        blocks = {"111": {"@type": "foo", "href": [{"@id": "../resolveuid/{}".format(uid)}]}}
+        blocks = {
+            "111": {"@type": "foo", "href": [{"@id": "../resolveuid/{}".format(uid)}]}
+        }
         self.portal.doc1.blocks = blocks
         value = self.retrieve_links(blocks)
 


### PR DESCRIPTION
Fixes #1565

The linksintegrity retriever should handle the same data formats that are handled by the resolveuid transform.