### PR TITLE
Fix Plone Site serialization not returning the review_state in Plone 6

### DIFF
--- a/news/1574.bugfix
+++ b/news/1574.bugfix
@@ -1,0 +1,1 @@
+Fix Plone Site serialization not returning the review_state in Plone 6. [ericof]

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -69,6 +69,12 @@ class SerializeSiteRootToJson:
 
         if HAS_PLONE_6:
             result["UID"] = self.context.UID()
+            # Insert review_state
+            wf = getToolByName(self.context, "portal_workflow")
+            result["review_state"] = wf.getInfoFor(
+                ob=self.context, name="review_state", default=None
+            )
+
             # Insert Plone Site DX root field values
             for schema in iterSchemata(self.context):
                 read_permissions = mergedTaggedValueDict(schema, READ_PERMISSIONS_KEY)

--- a/src/plone/restapi/tests/http-examples/jwt_logged_in.resp
+++ b/src/plone/restapi/tests/http-examples/jwt_logged_in.resp
@@ -59,6 +59,7 @@ Content-Type: application/json
     },
     "parent": {},
     "relatedItems": [],
+    "review_state": null,
     "rights": "",
     "subjects": [],
     "table_of_contents": null,

--- a/src/plone/restapi/tests/http-examples/siteroot.resp
+++ b/src/plone/restapi/tests/http-examples/siteroot.resp
@@ -59,6 +59,7 @@ Content-Type: application/json
     },
     "parent": {},
     "relatedItems": [],
+    "review_state": null,
     "rights": "",
     "subjects": [],
     "table_of_contents": null,


### PR DESCRIPTION
Fix #1574 