### PR TITLE
Fix translation of user add exceptions

### DIFF
--- a/news/4395.bugfix
+++ b/news/4395.bugfix
@@ -1,0 +1,2 @@
+Fix translation of the error message for a password that is too short while
+adding a user. [davisagli]

--- a/src/plone/restapi/services/users/add.py
+++ b/src/plone/restapi/services/users/add.py
@@ -210,7 +210,7 @@ class UsersPost(Service):
             return dict(
                 error=dict(
                     type="MissingParameterError",
-                    message=self.translate(str(e)),
+                    message=self.translate(e.args[0]),
                 )
             )
 


### PR DESCRIPTION
Fixes https://github.com/plone/volto/issues/4395. The change avoids accidentally converting a message id to a string before it gets translated.

Confirmed this fixes the problem on the user add form in volto:

<img width="929" alt="Screenshot 2023-03-05 at 9 56 27 PM" src="https://user-images.githubusercontent.com/49014/223030613-034f143b-4992-453f-80c6-a5bc3d061086.png">
