### PR TITLE
Fixed tests in combination with newer plone.app.z3cform.

### DIFF
--- a/news/162.internal
+++ b/news/162.internal
@@ -1,0 +1,2 @@
+Fixed tests in combination with newer ``plone.app.z3cform``.
+[maurits]

--- a/src/plone/restapi/tests/test_functional_auth.py
+++ b/src/plone/restapi/tests/test_functional_auth.py
@@ -13,7 +13,6 @@ import unittest
 
 
 class TestFunctionalAuth(unittest.TestCase):
-
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -173,8 +172,17 @@ class TestFunctionalAuth(unittest.TestCase):
             200,
             "Wrong Plone login challenge status code",
         )
+        # The input differs slightly per Plone version.
         self.assertTrue(
-            '<input id="__ac_password" name="__ac_password"' in challenge_resp.text,
+            "<input" in challenge_resp.text,
+            "Plone login challenge response content missing input",
+        )
+        self.assertTrue(
+            'id="__ac_password"' in challenge_resp.text,
+            "Plone login challenge response content missing password field",
+        )
+        self.assertTrue(
+            'name="__ac_password"' in challenge_resp.text,
             "Plone login challenge response content missing password field",
         )
         login_resp = session.post(


### PR DESCRIPTION
See https://github.com/plone/plone.app.z3cform/pull/162

Instead of

```
<input id="__ac_password" name="__ac_password"
```

we get:

```
<input class="form-control password-widget required password-field" id="__ac_password" name="__ac_password" type="password" />
```