### PR TITLE
Fixed encoding issue on Python 3 for some mail servers. [7.x.x]

### DIFF
--- a/news/3754.bugfix
+++ b/news/3754.bugfix
@@ -1,0 +1,3 @@
+Fixed encoding issue on Python 3 for some mail servers.
+This could result in missing characters in an email body.
+[maurits]

--- a/src/plone/restapi/services/email_send/post.py
+++ b/src/plone/restapi/services/email_send/post.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
 from AccessControl.Permissions import use_mailhost_services
-from email.mime.text import MIMEText
 from plone.registry.interfaces import IRegistry
 from plone.restapi import _
 from plone.restapi.deserializer import json_body
@@ -15,6 +14,14 @@ from zope.component import getUtility
 from zope.interface import alsoProvides
 
 import plone
+
+try:
+    # Products.MailHost has a patch to fix quoted-printable soft line breaks.
+    # See https://github.com/zopefoundation/Products.MailHost/issues/35
+    from Products.MailHost.MailHost import message_from_string
+except ImportError:
+    # If the patch is ever removed, we fall back to the standard library.
+    from email import message_from_string
 
 
 class EmailSendPost(Service):
@@ -100,7 +107,7 @@ class EmailSendPost(Service):
 
         message = u"{} \n {}".format(message_intro, message)
 
-        message = MIMEText(message, "plain", encoding)
+        message = message_from_string(message)
         message["Reply-To"] = sender_from_address
         try:
             host.send(


### PR DESCRIPTION
This could result in missing characters in an email body. See https://github.com/plone/Products.CMFPlone/issues/3754

Cherry-picked from https://github.com/plone/plone.restapi/pull/1607