### PR TITLE
Fix tests: pydata-sphinx-theme 0.13.2 breaks sphinx-book-theme.

### DIFF
--- a/news/711.internal
+++ b/news/711.internal
@@ -1,0 +1,2 @@
+Fix tests: pydata-sphinx-theme 0.13.2 breaks sphinx-book-theme.
+[maurits]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -13,3 +13,6 @@ sphinxcontrib.httpdomain
 sphinxcontrib.httpexample
 sphinxcontrib-spelling
 sphinxext-opengraph
+# pydata-sphinx-theme 0.13.2 breaks sphinx-book-theme
+# https://github.com/executablebooks/sphinx-book-theme/issues/711
+pydata-sphinx-theme<=0.13.1


### PR DESCRIPTION
See also https://github.com/executablebooks/sphinx-book-theme/issues/711

Currently our build is broken on Plone 6.0 Python 3.9. You can see it locally too.  Using pyenv in my case:

```
$ pyenv local 3.9
$ make clean
$ make docs-html
...
cd ./docs/source/ && /Users/maurits/community/plone-coredev/6.0/src/plone.restapi/bin/sphinx-build -b html -d ../_build//doctrees  . ../_build//html
Running Sphinx v4.5.0
making output directory... done

Extension error:
Could not import extension sphinx_book_theme
(exception: cannot import name '_get_theme_options' from 'pydata_sphinx_theme'
(/Users/maurits/community/plone-coredev/6.0/src/plone.restapi/lib/python3.9/site-packages/pydata_sphinx_theme/__init__.py))
```

Solution for now: pin a lower version of pydate-sphinx-theme.