### PR TITLE
CI: run the tests on Ubuntu 20.04, instead of latest. [7.x.x]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Plone RESTAPI CI
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/news/2004.internal
+++ b/news/2004.internal
@@ -1,0 +1,3 @@
+CI: run the tests on Ubuntu 20.04, instead of latest.
+Python 2.7 and 3.6 are not available on latest.
+[maurits]

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -16,3 +16,6 @@ virtualenv = 20.0.35
 
 # Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.23)
 importlib-metadata = 2.0.0
+
+# latest version compatible with Python 2
+flake8-print = 4.0.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -77,7 +77,9 @@ readme-renderer = 28.0
 packaging = 20.9
 
 # latest version compatible with Python 2
+# With a dash it works on 4.3, but on 5.2 I still see a newer version, so try an underscore as well.
 flake8-print = 4.0.1
+flake8_print = 4.0.1
 
 # latest version compatible with Python 2
 attrs = 21.2.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -60,3 +60,21 @@ cffi = 1.14.4
 
 # latest version compatible with Python 2
 bleach = 3.3.1 
+
+# latest version compatible with Python 2
+pep517 = 0.12
+
+# latest version compatible with Python 2
+alabaster = 0.7.12
+
+# latest version compatible with Python 2
+z3c.dependencychecker = 2.7
+
+# latest version compatible with Python 2
+readme-renderer = 28.0
+
+# latest version compatible with Python 2
+packaging = 20.9
+
+# latest version compatible with Python 2
+flake8-print = 4.0.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -78,3 +78,6 @@ packaging = 20.9
 
 # latest version compatible with Python 2
 flake8-print = 4.0.1
+
+# latest version compatible with Python 2
+attrs = 21.2.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -77,9 +77,7 @@ readme-renderer = 28.0
 packaging = 20.9
 
 # latest version compatible with Python 2
-# With a dash it works on 4.3, but on 5.2 I still see a newer version, so try an underscore as well.
 flake8-print = 4.0.1
-flake8_print = 4.0.1
 
 # latest version compatible with Python 2
 attrs = 21.2.0


### PR DESCRIPTION
Python 2.7 and 3.6 are not available on latest.
See broken runs on this PR job:
https://github.com/plone/plone.restapi/actions/runs/4565635527?pr=1608

BTW, for me it would be fine to stop testing with Python 3.6: it is no longer supported by Plone 5.2. But if this PR gets it going for a few more months, then all is well.