### PR TITLE
Fix param handling in querystringsearch GET

### DIFF
--- a/news/1621.bugfix
+++ b/news/1621.bugfix
@@ -1,0 +1,1 @@
+Fix bugs in handling parameters when the `@querystringsearch` endpoint is called with the GET method. @davisagli

--- a/src/plone/restapi/tests/test_services_querystringsearch.py
+++ b/src/plone/restapi/tests/test_services_querystringsearch.py
@@ -53,14 +53,17 @@ class TestQuerystringSearchEndpoint(unittest.TestCase):
         self.assertNotIn("effective", response.json()["items"][0])
 
     def test_querystringsearch_basic_get(self):
+        self.portal.invokeFactory("Document", "doc2", title="Test Document 2")
+        transaction.commit()
+
         response = self.api_session.get(
-            "/@querystring-search?query=%7B%22query%22%3A%5B%7B%22i%22%3A%22portal_type%22%2C%22o%22%3A%20%22plone.app.querystring.operation.selection.any%22%2C%22v%22%3A%5B%22Document%22%5D%7D%5D%7D"
+            "/@querystring-search?query=%7B%22query%22%3A%20%5B%7B%22i%22%3A%20%22portal_type%22%2C%20%22o%22%3A%20%22plone.app.querystring.operation.selection.any%22%2C%20%22v%22%3A%20%5B%22Document%22%5D%7D%5D%2C%20%22b_size%22%3A%201%7D"
         )
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("items", response.json())
         self.assertIn("items_total", response.json())
-        self.assertEqual(response.json()["items_total"], 1)
+        self.assertEqual(response.json()["items_total"], 2)
         self.assertEqual(len(response.json()["items"]), 1)
         self.assertNotIn("effective", response.json()["items"][0])
 


### PR DESCRIPTION
Copy the params from the querystring into the request body, because there are too many bits of code that expect to find things there.

Adjusted the test to confirm pagination works.

Fixes #1621 