### PR TITLE
Tests: pin plone.schema to 1.4.0 in Plone 4.3.

### DIFF
--- a/news/140.internal
+++ b/news/140.internal
@@ -1,0 +1,4 @@
+Tests: pin ``plone.schema`` to 1.4.0 in Plone 4.3.
+This is the latest version compatible with Python 2.
+On Plone 5.0 and higher this package is already pinned.
+[maurits]

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -20,3 +20,6 @@ pyparsing = 2.4.7
 
 # Required by plone.restapi
 six = 1.12.0
+
+# latest version compatible with Python 2
+plone.schema = 1.4.0


### PR DESCRIPTION
@tisto I wanted to create a release of 7.x.x for the upcoming Plone 5.2 release, but saw the build was broken.  This should fix it.

This `plone.schema` is the latest version compatible with Python 2. On Plone 5.0 and higher this package is already pinned. A Python 3 only version was released on April 6th, and broke the build: https://github.com/plone/plone.restapi/actions/runs/4635281794/jobs/8202199547

```
Traceback (most recent call last):
  File "/home/runner/work/plone.restapi/plone.restapi/src/plone/restapi/tests/test_behaviors.py", line 7, in <module>
    from plone.restapi.behaviors import IBlocks
  File "/home/runner/work/plone.restapi/plone.restapi/src/plone/restapi/behaviors.py", line 4, in <module>
    from plone.schema import JSONField
  File "/home/runner/work/plone.restapi/plone.restapi/eggs/plone.schema-2.0.0-py2.7.egg/plone/schema/__init__.py", line 3, in <module>
    from .jsonfield import IJSONField
  File "/home/runner/work/plone.restapi/plone.restapi/eggs/plone.schema-2.0.0-py2.7.egg/plone/schema/jsonfield.py", line 1, in <module>
    from json import JSONDecodeError
ImportError: cannot import name JSONDecodeError
```
