### PR TITLE
update_password should check password validity

### DIFF
--- a/news/1630.bugfix
+++ b/news/1630.bugfix
@@ -1,0 +1,2 @@
+Respect Password Policy
+[tschorr]

--- a/src/plone/restapi/services/users/add.py
+++ b/src/plone/restapi/services/users/add.py
@@ -302,7 +302,7 @@ class UsersPost(Service):
                 err = registration_tool.testPasswordValidity(new_password)
                 if err is not None:
                     return self._error(
-                        403,
+                        400,
                         "Invalid password",
                         _(err),
                     )


### PR DESCRIPTION
`p.restapi` is using `PasswordResetTool.resetPassword` for updating passwords, however this method doesn't check for password validity (https://github.com/plone/Products.CMFPlone/blame/master/Products/CMFPlone/PasswordResetTool.py#L103).
This results in Volto bypassing the default password policy. Although the minimum password length has been updated to 8 characters (https://github.com/plone/Products.PlonePAS/pull/69), Volto still mentions a minimum of 5 characters (https://github.com/plone/volto/blob/master/src/components/theme/PasswordReset/PasswordReset.jsx#L54) and Plone lets you get away with this. I actually could use a 3 letter password.