### PR TITLE
Fix possible startup error by loading plone.app.contentrules zcml

### DIFF
--- a/news/1644.bugfix
+++ b/news/1644.bugfix
@@ -1,0 +1,3 @@
+Fix possible startup error by explicitly loading ``plone.app.contentrules`` zcml.
+Also: only load code related to contentrules when this package is available.
+[maurits]

--- a/src/plone/restapi/serializer/controlpanels/configure.zcml
+++ b/src/plone/restapi/serializer/controlpanels/configure.zcml
@@ -1,11 +1,15 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone.restapi"
     >
 
   <adapter factory=".ControlpanelSerializeToJson" />
   <adapter factory=".ControlpanelSummarySerializeToJson" />
   <adapter factory=".types.DexterityTypesControlpanelSerializeToJson" />
-  <adapter factory=".rules.ContentRulesControlpanelSerializeToJson" />
+  <adapter
+      factory=".rules.ContentRulesControlpanelSerializeToJson"
+      zcml:condition="installed plone.app.contentrules"
+      />
 
 </configure>

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -32,7 +32,6 @@
   <include package=".registry" />
   <include package=".relations" />
   <include package=".roles" />
-  <include package=".rules" />
   <include package=".search" />
   <include package=".system" />
   <include package=".sources" />
@@ -62,5 +61,9 @@
   <include
       package=".tiles"
       zcml:condition="installed plone.tiles"
+      />
+  <include
+      package=".rules"
+      zcml:condition="installed plone.app.contentrules"
       />
 </configure>

--- a/src/plone/restapi/services/controlpanels/configure.zcml
+++ b/src/plone/restapi/services/controlpanels/configure.zcml
@@ -60,6 +60,7 @@
       factory="plone.restapi.controlpanels.rules.ContentRulesControlpanel"
       provides="plone.restapi.controlpanels.interfaces.IContentRulesControlpanel"
       name="content-rules"
+      zcml:condition="installed plone.app.contentrules"
       />
 
   <configure zcml:condition="have plone-5">

--- a/src/plone/restapi/services/rules/configure.zcml
+++ b/src/plone/restapi/services/rules/configure.zcml
@@ -3,6 +3,8 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     >
 
+  <include package="plone.app.contentrules" />
+
   <plone:service
       method="GET"
       factory=".get.ContentRulesGet"


### PR DESCRIPTION
Also: only load code related to contentrules when this package is available.
Fixes https://github.com/plone/plone.restapi/issues/1644

I have a small doubt where some of these conditions should be on `plone.contentrules` instead of `plone.app.contentrules`.  But I guess this is one of those split packages where you either have none or both.  I doubt that anyone has written an own implementation on top of `plone.contentrules` that actually works with the current restapi code around it.  I think we do not need to worry.