### PR TITLE
Skip next/previous info for old versions if it can't be obtained

### DIFF
--- a/news/1651.bugfix
+++ b/news/1651.bugfix
@@ -1,0 +1,1 @@
+Fix content serializer with an old version of an item that was renamed. @davisagli

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -81,10 +81,15 @@ class SerializeToJson:
         }
 
         # Insert next/prev information
-        nextprevious = NextPrevious(obj)
-        result.update(
-            {"previous_item": nextprevious.previous, "next_item": nextprevious.next}
-        )
+        try:
+            nextprevious = NextPrevious(obj)
+            result.update(
+                {"previous_item": nextprevious.previous, "next_item": nextprevious.next}
+            )
+        except ValueError:
+            # If we're serializing an old version that was renamed or moved,
+            # then its id might not be found inside the current object's container.
+            pass
 
         # Insert working copy information
         if WorkingCopyInfo is not None:

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -89,7 +89,7 @@ class SerializeToJson:
         except ValueError:
             # If we're serializing an old version that was renamed or moved,
             # then its id might not be found inside the current object's container.
-            pass
+            result.update({"previous_item": {}, "next_item": {}})
 
         # Insert working copy information
         if WorkingCopyInfo is not None:

--- a/src/plone/restapi/tests/test_services_history.py
+++ b/src/plone/restapi/tests/test_services_history.py
@@ -119,6 +119,15 @@ class TestHistoryEndpoint(unittest.TestCase):
         response = self.api_session.get(url)
         self.assertEqual(response.json()["title"], "My Document")
 
+    def test_previous_version_of_renamed_item(self):
+        api.content.move(source=self.doc, id="renamed-doc")
+        transaction.commit()
+
+        url = self.doc.absolute_url() + "/@history/0"
+        response = self.api_session.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], "doc_with_history")
+
     def test_no_sharing(self):
         url = self.doc.absolute_url() + "/@history/0"
         response = self.api_session.get(url)


### PR DESCRIPTION
Fixes #1650 

If the item was renamed or moved, then its id might not be found in the current object's container. In that case let's degrade gracefully and leave out the previous_item and next_item rather than raising a ValueError.