### PR TITLE
Add param option to exclude basic metadata from GET content

### DIFF
--- a/docs/source/usage/content.md
+++ b/docs/source/usage/content.md
@@ -142,6 +142,8 @@ For folderish types, their children are automatically included in the response a
 To disable the inclusion, add the `GET` parameter `include_items=false` to the URL.
 
 By default, only basic metadata is included.
+To exclude basic metadata add the `GET` parameter `include_basic_metadata=false` to the URL.
+To exclude expandable elements add the `GET` parameter `include_expandable_elements=false` to the URL
 To include additional metadata, you can specify the names of the properties with the `metadata_fields` parameter.
 See also {ref}`retrieving-additional-metadata`.
 


### PR DESCRIPTION
This PR will add two more optional parameters to GET content:
- `include_basic_metadata` - by default this is `True`; If `False` all metadatas except `@id`, `@type` and `is_folderish` will be excluded from `result` allowing `metadata_fields` parameter to specify the desired metadatas
- `include_expandable_elements` - by default this is `True`; If `False` the expandable elements will not be included in the `result`