### PR TITLE
updated makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ update: ## Update Make and Buildout
 bin/buildout: bin/pip
 	bin/pip install --upgrade pip
 	bin/pip install -r requirements-5.2.txt
-	bin/pip install black || true
+	bin/pip install --upgrade click==$(awk '/^click =/{print $NF}' versions.cfg) black==$(awk '/^black =/{print $NF}' versions.cfg) || true
 	@touch -c $@
 
 bin/python bin/pip:


### PR DESCRIPTION
## Description

This PR updates the Makefile to ensure consistent installations of black and click. Currently, the Makefile installs the latest versions, while the CI process installs specific versions mentioned in the versions.cfg file. This PR aligns the installations in the Makefile with the versions specified in the versions.cfg file.

## Changes Made

- Modified the Makefile to install black and click with the versions mentioned in versions.cfg.
OR
- Upgraded the installations of black and click to the latest versions mentioned in versions.cfg.

## Reason for the Changes

- Ensures consistency between local development and the CI environment.
- Aligns installations with the versions specified in versions.cfg.
OR
- Benefits from the latest features and bug fixes available in the upgraded versions.

This is pr is realated to #1655 