### PR TITLE
Add Documentation for Code Formatting and Testing

### DIFF
--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -9,7 +9,6 @@ myst:
 
 # Contributing to `plone.restapi`
 
-
 ## Generating documentation examples
 
 This documentation includes examples of requests and responses (http, curl, httpie, and python-requests).
@@ -37,7 +36,6 @@ Include them in the documentation using MyST syntax:
 Build the documentation locally to test the rendering by running `./bin/sphinxbuilder`.
 Alternatively, you can use Makefile targets:
 
-
 `docs-clean`
 : Clean current and legacy docs build directories, and Python virtual environment
 
@@ -58,9 +56,8 @@ Alternatively, you can use Makefile targets:
 
 `docs`
 : Build Docs
- 
-Make sure you add and commit the generated files in `http-examples`.
 
+Make sure you add and commit the generated files in `http-examples`.
 
 ## Conventions
 
@@ -69,3 +66,11 @@ Make sure you add and commit the generated files in `http-examples`.
 
 conventions
 ```
+
+## Code Formatting and Testing
+
+To ensure consistent code formatting, it's recommended to have the "black" tool installed locally. You can install it by running the "make" command inside the "plone.restapi" folder. Once installed, you can use "black" to automatically format the code.
+
+The project has a set of dependencies required for its proper functioning. You can install these dependencies by running the "make" command, which will handle the installation process for you.
+
+To run tests locally and ensure your changes don't introduce any issues, use the "make" command followed by "make test". This will execute the test suite and provide test feedback.

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -9,6 +9,13 @@ myst:
 
 # Contributing to `plone.restapi`
 
+We use GNU `make` when developing `plone.restapi`.
+To install this package, its dependencies, and its documentation, code formatting, and testing tools, run the following command in the root of the project.
+
+```shell
+make
+```
+
 ## Generating documentation examples
 
 This documentation includes examples of requests and responses (http, curl, httpie, and python-requests).
@@ -67,10 +74,20 @@ Make sure you add and commit the generated files in `http-examples`.
 conventions
 ```
 
-## Code Formatting and Testing
+## Code formatting and testing
 
-To ensure consistent code formatting, it's recommended to have the "black" tool installed locally. You can install it by running the "make" command inside the "plone.restapi" folder. Once installed, you can use "black" to automatically format the code.
+To ensure consistent code formatting, we use [Black](https://black.readthedocs.io/en/stable/index.html).
+All pull requests must pass code formatting checks.
+We recommend that you run Black locally.
+You can use the following command to automatically format the code.
 
-The project has a set of dependencies required for its proper functioning. You can install these dependencies by running the "make" command, which will handle the installation process for you.
+```shell
+make black
+```
 
-To run tests locally and ensure your changes don't introduce any issues, use the "make" command followed by "make test". This will execute the test suite and provide test feedback.
+To run tests locally and ensure your changes don't introduce any issues, use the following command.
+This will execute the test suite and provide test feedback.
+
+```shell
+make test
+```

--- a/news/1664.documentation
+++ b/news/1664.documentation
@@ -1,0 +1,1 @@
+added instruction to ensure consistent code formatting. @Akshat2Jain


### PR DESCRIPTION
## Description

This pull request adds documentation for code formatting and testing in the `plone.restapi` project.

The documentation includes instructions on installing the "black" tool for code formatting, using the `make` command to install project dependencies, and running tests locally.

This pr is related to #1664 