### PR TITLE
Fix types expander in root for 5.2 (for non-DX Plone Site Root)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-version = 3
+version = 3.8
 
 # We like colors
 # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-version = 3.8
+version = 3
 
 # We like colors
 # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects

--- a/news/1669.bugfix
+++ b/news/1669.bugfix
@@ -1,0 +1,1 @@
+Fix types expander in root for 5.2 (for non-DX Plone Site Root) @sneridagh

--- a/news/1669.bugfix
+++ b/news/1669.bugfix
@@ -1,1 +1,1 @@
-Fix types expander in root for 5.2 (for non-DX Plone Site Root) @sneridagh
+Fix types expander in root for Plone 5.2 (for non-Dexterity Plone Site Root) @sneridagh

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,10 +1,10 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/5.2.9/versions.cfg
+    https://dist.plone.org/release/5.2.12/versions.cfg
     base.cfg
 
 [versions]
 black = 21.7b0
 
-# Use the new plone.rest alpha
-plone.rest = 2.0.0a3
+# Use the newest plone.rest
+plone.rest = 3.0.0

--- a/requirements-5.2.txt
+++ b/requirements-5.2.txt
@@ -1,2 +1,2 @@
--r https://dist.plone.org/release/5.2.9/requirements.txt
+-r https://dist.plone.org/release/5.2.12/requirements.txt
 zpretty

--- a/src/plone/restapi/services/types/configure.zcml
+++ b/src/plone/restapi/services/types/configure.zcml
@@ -50,4 +50,9 @@
       name="types"
       />
 
+  <adapter
+      factory=".get.TypesInfoRoot"
+      name="types"
+      />
+
 </configure>

--- a/src/plone/restapi/services/types/get.py
+++ b/src/plone/restapi/services/types/get.py
@@ -7,6 +7,7 @@ from plone.restapi.types.utils import get_info_for_field
 from plone.restapi.types.utils import get_info_for_fieldset
 from plone.restapi.types.utils import get_info_for_type
 from Products.CMFCore.interfaces import IFolderish
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.CMFCore.utils import getToolByName
 from zExceptions import Unauthorized
 from zope.component import adapter
@@ -83,6 +84,12 @@ class TypesInfo:
         ]
 
         return result
+
+
+@implementer(IExpandableElement)
+@adapter(IPloneSiteRoot, Interface)
+class TypesInfoRoot(TypesInfo):
+    pass
 
 
 @implementer(IPublishTraverse)

--- a/src/plone/restapi/tests/test_expansion.py
+++ b/src/plone/restapi/tests/test_expansion.py
@@ -338,8 +338,94 @@ class TestExpansionFunctional(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("types", list(response.json().get("@components")))
 
+    def test_types_is_expandable_in_root(self):
+        response = self.api_session.get("/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("types", list(response.json().get("@components")))
+
     def test_types_expanded(self):
         response = self.api_session.get("/folder", params={"expand": "types"})
+
+        self.assertEqual(response.status_code, 200)
+
+        # XXX: Note: The @types endpoint currently doesn't conform to JSON-LD
+        # because it's directly returning a list, and does not have an @id
+        # property.
+
+        base_url = self.portal.absolute_url()
+
+        self.assertEqual(
+            [
+                {
+                    "@id": "/".join((base_url, "@types/Collection")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "Collection",
+                    "id": "Collection",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/DXTestDocument")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "DX Test Document",
+                    "id": "DXTestDocument",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/Event")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "Event",
+                    "id": "Event",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/File")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "File",
+                    "id": "File",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/Folder")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "Folder",
+                    "id": "Folder",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/Image")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "Image",
+                    "id": "Image",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/Link")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "Link",
+                    "id": "Link",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/News Item")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "News Item",
+                    "id": "News Item",
+                },
+                {
+                    "@id": "/".join((base_url, "@types/Document")),
+                    "addable": True,
+                    "immediately_addable": True,
+                    "title": "Page",
+                    "id": "Document",
+                },
+            ],
+            response.json().get("@components").get("types"),
+        )
+
+    def test_types_expanded_in_root(self):
+        response = self.api_session.get("/", params={"expand": "types"})
 
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Related to: https://github.com/plone/volto/pull/4946

The tests failed for 5.2 when trying to use the expander in a non-DX Plone site root.

I updated also the build for 5.2 to latest Plone 5.