### PR TITLE
Formatting fixes for #1689

### DIFF
--- a/docs/source/upgrade-guide.md
+++ b/docs/source/upgrade-guide.md
@@ -12,12 +12,14 @@ myst:
 This upgrade guide lists all breaking changes in `plone.restapi`.
 It explains the steps that are needed to upgrade to the latest version.
 
+
 ## Upgrading to `plone.restapi` 8.x
 
-plone.restapi 8.x dropped support for Python 2 and Plone 5.1 and 4.3.
-Upgrading to plone.restapi 8.x does not require any changes to your code base if you use Python 3 and Plone 5.2 or newer.
+`plone.restapi` 8.x dropped support for Python 2 and Plone 5.1 and 4.3.
+Upgrading to `plone.restapi` 8.x does not require any changes to your code base if you use Python 3 and Plone 5.2 or newer.
 
-If you use Python 2 and a Plone version older than 5.2, stick with plone.restapi 7.x.
+If you use Python 2 and a Plone version older than 5.2, stick with `plone.restapi` 7.x.
+
 
 ## Upgrading to `plone.restapi` 7.x
 
@@ -25,6 +27,7 @@ The navigation endpoint has been refactored.
 Now its behavior is consistent regarding the `items` attribute.
 Now the `items` attribute is present, even if the element of the tree does not have child elements, in which case it will be an empty array.
 This might affect some logins via JavaScript, specifically if the condition is checking for the existence of the `items` attribute and expects it to be `undefined`.
+
 
 ## Upgrading to `plone.restapi` 6.x
 
@@ -48,6 +51,7 @@ If you need to fix object IDs, you can do one of the following:
 
 We expect that most content actually will not be affected.
 See <https://github.com/plone/plone.restapi/issues/827> for more details.
+
 
 ## Upgrading to `plone.restapi` 5.x
 
@@ -92,6 +96,7 @@ to:
 This change affects the `GET`, `PATCH`, and `POST` formats.
 It should only affect you if you use Volto.
 
+
 ## Upgrading to `plone.restapi` 4.x
 
 `plone.restapi` 4.0.0 introduces the following breaking changes:
@@ -100,6 +105,7 @@ It should only affect you if you use Volto.
 2.  Choice and list fields return a hyperlink to a vocabulary instead of `choices`, `enum`, and `enumNames`.
 3.  Serialize widget parameters into a `widgetOptions` object instead of adding them to the top level of the schema property.
 4.  The vocabularies endpoint does no longer returns an `@id` for terms, the results are batched, and terms are now listed as `items` instead of `terms` to match other batched responses.
+
 
 ### Serialization and Deserialization of fields with vocabularies
 
@@ -142,6 +148,7 @@ Deserialization accepts objects that contain a token, but also just the token or
 
 However, it is highly recommended to always use the token, as vocabulary terms may contain values that are not JSON serializable.
 
+
 ### Choice and List fields return link to vocabulary instead of the values
 
 Choice and List fields using named vocabularies are now serialized with a `vocabulary` property, giving the URL of the `@vocabularies` endpoint for the vocabulary instead of including `choices`,
@@ -178,6 +185,7 @@ New response:
 },
 ```
 
+
 ### Serialize widget parameters into a `widgetOptions` object
 
 Serialize widget parameters into a `widgetOptions` object instead of adding them to the top level of the schema property.
@@ -198,6 +206,7 @@ New response:
   "vocabulary": { "@id": "http://localhost:55001/plone/@vocabularies/plone.app.vocabularies.Users" }
 }
 ```
+
 
 ### Example: Vocabularies Subjects Field
 
@@ -231,6 +240,7 @@ New response:
   "type": "string"
 }
 ```
+
 
 ### Example: Available Time Zones Field (vocabulary in `items`)
 
@@ -286,6 +296,7 @@ New response:
   "uniqueItems": true
 },
 ```
+
 
 ### Example: Weekday Field (vocabulary in main property)
 
@@ -360,6 +371,7 @@ New response:
 },
 ```
 
+
 ### Vocabularies Endpoint
 
 The vocabularies endpoint no longer returns an `@id` for terms.
@@ -400,7 +412,9 @@ New response:
 }
 ```
 
+
 ## Upgrading to `plone.restapi` 3.x
+
 
 ### Image scales
 
@@ -442,6 +456,7 @@ New Response:
   "…"
 }
 ```
+
 
 ### `@sharing` endpoint
 
@@ -500,6 +515,7 @@ Content-Type: application/json
 }
 ```
 
+
 ### Custom Content Deserializers
 
 If you have implemented custom content deserializers, you have to handle the new `create` keyword in the `__call__` method, which determines if deserialization is performed during object creation or while updating an object.
@@ -508,10 +524,12 @@ Deserializers should only fire an `IObjectModifiedEvent` event if an object has 
 
 See [Dexterity content deserializer](https://github.com/plone/plone.restapi/blob/master/src/plone/restapi/deserializer/dxcontent.py) for an example.
 
+
 ## Upgrading to `plone.restapi` 2.x
 
 `plone.restapi` 2.0.0 converts all datetime, DateTime and time objects to UTC before serializing.
 The translations endpoint becomes "expandable", which introduces the following breaking changes.
+
 
 ### Translations
 
@@ -556,6 +574,7 @@ Content-Type: application/json
   ]
 }
 ```
+
 
 ## Upgrading to `plone.restapi` 1.0b1
 
@@ -709,6 +728,7 @@ Pull Request:
 
 - <https://github.com/plone/plone.restapi/pull/459>
 
+
 ## Upgrading to `plone.restapi` 1.0a25
 
 `plone.restapi` 1.0a25 introduced three breaking changes:
@@ -718,6 +738,7 @@ Pull Request:
 - Remove `sharing` attributes from `GET` response. [timo, jaroel]
 - Convert `richtext` using `.output_relative_to`.
   Direct conversion from `RichText` is no longer supported as we _always_ need a context for the `ITransformer`. [jaroel]
+
 
 ### Remove @components endpoint
 
@@ -756,6 +777,7 @@ Pull Request:
 
 - <https://github.com/plone/plone.restapi/pull/425>
 
+
 ### Remove `sharing` attribute
 
 The `sharing` attribute was removed from all content `GET` responses:
@@ -777,6 +799,7 @@ Pull Request:
 
 - <https://github.com/plone/plone.restapi/commit/1b5e9e3a74df22e53b674849e27fa4b39b792b8c>
 
+
 ### Convert `richtext` using `.output_relative_to`
 
 Use `.output_relative_to` to convert `richtext`.
@@ -789,6 +812,7 @@ Changelog:
 Pull Request:
 
 - <https://github.com/plone/plone.restapi/pull/428>
+
 
 ## Upgrading to `plone.restapi` 1.0a17
 

--- a/news/1691.documentation
+++ b/news/1691.documentation
@@ -1,0 +1,1 @@
+Restores formatting and fixes some MyST syntax from #1689. @stevepiercy


### PR DESCRIPTION
Restores formatting and fixes some MyST syntax from #1689.

I am not sure whether to restore these deleted lines: https://github.com/plone/plone.restapi/pull/1689/files#diff-5181575a5b963d950ad39243e813f929f21691c3698835f2784db8fd692ccd51R710-R722 @tisto @davisagli please advise.