### PR TITLE
Fix linkcheckbroken 301 redirect to https://www.4teamwork.ch/en

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ If you are having issues, please let us know via the `issue tracker <https://git
 If you require professional support, here is a list of Plone solution providers that contributed significantly to ``plone.restapi`` in the past.
 
 - `kitconcept GmbH <https://kitconcept.com>`_ (Germany)
-- `4teamwork <https://www.4teamwork.ch>`_ (Switzerland)
+- `4teamwork <https://www.4teamwork.ch/en>`_ (Switzerland)
 - `CodeSyntax <https://www.codesyntax.com/en>`_ (Spain)
 
 

--- a/news/1693.documentation
+++ b/news/1693.documentation
@@ -1,0 +1,1 @@
+Fix linkcheckbroken 301 redirect to https://www.4teamwork.ch/en. @stevepiercy


### PR DESCRIPTION
See also #1691 and #1692