### PR TITLE
Expose the sources + their target instead of just some sources in "breaches" attribute in @linkintegrity endpoint response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Breaking changes:
 - Change the @linkintegrity endpoint to add `items_total`, the number of contained items which would be deleted. @davisagli, @danalvrz, @pgrunewald (#1636)
 - The default branch was renamed from `master` to `main`. @tisto, @davisagli (#1695)
 - Drop support for Python 3.7. Set python_requires to >= 3.8 @tisto (#1709)
+- Expose the sources + their target instead of just some sources in "breaches" attribute in @linkintegrity endpoint response. [jaroel]
 
 
 New features:
@@ -461,7 +462,7 @@ Bug fixes:
 
 
 - Added url field to Actions (#817)
-- Update statictime tests following changes to p.a.disucssion (see 
+- Update statictime tests following changes to p.a.disucssion (see
   https://github.com/plone/plone.app.discussion/pull/204) - [instification] (#1520)
 - Update @portrait endpoint to use sanitized user id [instification] (#1524)
 


### PR DESCRIPTION
Needs https://github.com/plone/plone.app.linkintegrity/pull/95

Breaking: this changes the shape of an endpoint.