### PR TITLE
fix: use pam layer in pam services

### DIFF
--- a/news/1723.bugfix
+++ b/news/1723.bugfix
@@ -1,0 +1,1 @@
+limits the use of multilingual services only if multilingual is actually installed. @mamico

--- a/src/plone/restapi/services/multilingual/configure.zcml
+++ b/src/plone/restapi/services/multilingual/configure.zcml
@@ -20,8 +20,8 @@
       factory=".pam.TranslationInfo"
       for="Products.CMFCore.interfaces.IContentish"
       permission="zope2.View"
-      name="@translations"
       layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
+      name="@translations"
       />
   <cache:ruleset
       for=".pam.TranslationInfo"
@@ -34,8 +34,8 @@
       factory=".pam.LinkTranslations"
       for="Products.CMFCore.interfaces.IContentish"
       permission="plone.app.multilingual.ManageTranslations"
-      name="@translations"
       layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
+      name="@translations"
       />
 
   <plone:service
@@ -43,8 +43,8 @@
       factory=".pam.UnlinkTranslations"
       for="Products.CMFCore.interfaces.IContentish"
       permission="plone.app.multilingual.ManageTranslations"
-      name="@translations"
       layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
+      name="@translations"
       />
 
   <plone:service
@@ -52,8 +52,8 @@
       factory=".locator.TranslationLocator"
       for="Products.CMFCore.interfaces.IContentish"
       permission="plone.app.multilingual.ManageTranslations"
-      name="@translation-locator"
       layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
+      name="@translation-locator"
       />
 
 </configure>

--- a/src/plone/restapi/services/multilingual/configure.zcml
+++ b/src/plone/restapi/services/multilingual/configure.zcml
@@ -21,6 +21,7 @@
       for="Products.CMFCore.interfaces.IContentish"
       permission="zope2.View"
       name="@translations"
+      layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
       />
   <cache:ruleset
       for=".pam.TranslationInfo"
@@ -34,6 +35,7 @@
       for="Products.CMFCore.interfaces.IContentish"
       permission="plone.app.multilingual.ManageTranslations"
       name="@translations"
+      layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
       />
 
   <plone:service
@@ -42,6 +44,7 @@
       for="Products.CMFCore.interfaces.IContentish"
       permission="plone.app.multilingual.ManageTranslations"
       name="@translations"
+      layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
       />
 
   <plone:service
@@ -50,6 +53,7 @@
       for="Products.CMFCore.interfaces.IContentish"
       permission="plone.app.multilingual.ManageTranslations"
       name="@translation-locator"
+      layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
       />
 
 </configure>

--- a/src/plone/restapi/tests/test_translations.py
+++ b/src/plone/restapi/tests/test_translations.py
@@ -9,6 +9,7 @@ from plone.restapi import HAS_MULTILINGUAL
 from plone.restapi.bbb import ILanguage
 from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_FUNCTIONAL_TESTING
 from plone.restapi.testing import PLONE_RESTAPI_DX_PAM_INTEGRATION_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
 
@@ -374,3 +375,30 @@ class TestTranslationLocator(unittest.TestCase):
         self.assertEqual(200, response.status_code)
 
         self.assertEqual(self.portal_url + "/de", response.json().get("@id"))
+
+
+class TestPAMNotinstalled(unittest.TestCase):
+    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        login(self.portal, SITE_OWNER_NAME)
+        self.folder = createContentInContainer(self.portal, "Folder", title="Folder")
+        transaction.commit()
+
+    def test_translations(self):
+        response = requests.get(
+            f"{self.folder.absolute_url()}/@translations",
+            headers={"Accept": "application/json"},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        self.assertEqual(404, response.status_code)
+
+    def test_translation_locator(self):
+        response = requests.get(
+            f"{self.folder.absolute_url()}/@translation-locator",
+            headers={"Accept": "application/json"},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        self.assertEqual(404, response.status_code)


### PR DESCRIPTION
This fix limits the use of multilingual services only if multilingual is actually installed, not only if it is present tar the 'eggs' (because in the new distribution of Plone, `plone.app.multilingual` is always present).