### PR TITLE
Be more strict when checking if mimetype is allowed inline.

### DIFF
--- a/news/1167.bugfix
+++ b/news/1167.bugfix
@@ -1,0 +1,2 @@
+Be more strict when checking if mimetype is allowed to be displayed inline.
+[maurits]

--- a/src/plone/restapi/services/users/get.py
+++ b/src/plone/restapi/services/users/get.py
@@ -28,13 +28,16 @@ from zope.publisher.interfaces import IPublishTraverse
 DEFAULT_SEARCH_RESULTS_LIMIT = 25
 
 try:
-    from OFS.Image import extract_media_type
+    # Zope 5.8.4+
+    from OFS.Image import extract_media_type as _extract_media_type
 except ImportError:
     try:
-        from plone.namedfile.utils import extract_media_type
+        from plone.namedfile.utils import extract_media_type as _extract_media_type
     except ImportError:
+        # Note that we start the method with an underscore, to signal that this
+        # is a private implementation detail and no one should be importing this.
 
-        def extract_media_type(content_type):
+        def _extract_media_type(content_type):
             """extract the proper media type from *content_type*.
 
             Ignore parameters and whitespace and normalize to lower case.
@@ -271,7 +274,7 @@ class PortraitGet(Service):
 
     def _should_force_download(self, portrait):
         # If this returns True, the caller should set the Content-Disposition header.
-        mimetype = extract_media_type(portrait.content_type)
+        mimetype = _extract_media_type(portrait.content_type)
         if not mimetype:
             return False
         if self.use_denylist:

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -25,7 +25,7 @@ import unittest
 
 class TestUnit(unittest.TestCase):
     def test_extract_media_type(self):
-        from plone.restapi.services.users.get import extract_media_type as extract
+        from plone.restapi.services.users.get import _extract_media_type as extract
 
         self.assertIsNone(extract(None))
         self.assertEqual(extract("text/plain"), "text/plain")

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -23,6 +23,17 @@ import transaction
 import unittest
 
 
+class TestUnit(unittest.TestCase):
+    def test_extract_media_type(self):
+        from plone.restapi.services.users.get import extract_media_type as extract
+
+        self.assertIsNone(extract(None))
+        self.assertEqual(extract("text/plain"), "text/plain")
+        self.assertEqual(extract("TEXT/PLAIN"), "text/plain")
+        self.assertEqual(extract("text / plain"), "text/plain")
+        self.assertEqual(extract(" text/plain ; charset=utf-8"), "text/plain")
+
+
 class TestUsersEndpoint(unittest.TestCase):
 
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING


### PR DESCRIPTION
This takes over some code from https://github.com/zopefoundation/Zope/pull/1167. See also https://github.com/plone/plone.namedfile/pull/154