### PR TITLE
extractCredentials: do not fail when the request is too large to read.

### DIFF
--- a/news/3848.bugfix
+++ b/news/3848.bugfix
@@ -1,0 +1,2 @@
+``extractCredentials``: do not fail when the request is too large to read.
+@maurits

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -14,6 +14,7 @@ from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlug
 from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 from Products.PluggableAuthService.interfaces.plugins import IExtractionPlugin
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
+from zExceptions import BadRequest
 from zope.component import getUtility
 from zope.interface import implementer
 
@@ -98,6 +99,8 @@ class JWTAuthenticationPlugin(BasePlugin):
         # is intended to change or update the logged in user.
         try:
             creds = deserializer.json_body(request)
+        except BadRequest:
+            pass
         except exceptions.DeserializationError:
             pass
         else:


### PR DESCRIPTION
This is a problem since at least Zope 5.8.4, introduced in Plone 6.0.7.
See https://github.com/plone/Products.CMFPlone/issues/3848 and https://github.com/zopefoundation/Zope/pull/1180.

This PR makes sure that a too big request body does not throw an error when extracting credentials.  This makes large image upload work again in ClassicUI with `plone.restapi` installed.

Uploading a file or image larger than 1MB using `plone.restapi` still likely fails, unless you have increased the `form-memory-limit` in `zope.conf`.  Fixing this may need a change [along these lines](https://github.com/zopefoundation/Zope/issues/1177#issuecomment-1784889996), but that would be a more far reaching change that needs careful consideration.