### PR TITLE
jwt_auth plugin extractCredentials: check request content-type

### DIFF
--- a/news/1728.bugfix
+++ b/news/1728.bugfix
@@ -1,0 +1,1 @@
+Fix jwt_auth extractCredentials plugin to only try to read credentials from the request body if there is a `Content-Type: application/json` header. @davisagli

--- a/src/plone/restapi/pas/plugin.py
+++ b/src/plone/restapi/pas/plugin.py
@@ -96,13 +96,14 @@ class JWTAuthenticationPlugin(BasePlugin):
         # Prefer any credentials in a JSON POST request under the assumption that any
         # such requested sent when a JWT token is already in the `Authorization` header
         # is intended to change or update the logged in user.
-        try:
-            creds = deserializer.json_body(request)
-        except exceptions.DeserializationError:
-            pass
-        else:
-            if "login" in creds and "password" in creds:
-                return creds
+        if request.getHeader("Content-Type") == "application/json":
+            try:
+                creds = deserializer.json_body(request)
+            except exceptions.DeserializationError:
+                pass
+            else:
+                if "login" in creds and "password" in creds:
+                    return creds
 
         creds = {}
         auth = request._auth


### PR DESCRIPTION
Alternative to #1726 

We should only try to parse the request body as JSON if there's a request header saying it's JSON.