### PR TITLE
Temporarily disable form memory limit checking for files and images.

### DIFF
--- a/news/3848.bugfix
+++ b/news/3848.bugfix
@@ -1,0 +1,5 @@
+Allow uploads up to 16 MB.
+This fixes a regression due to a low Zope form memory limit of 1MB used since Plone 6.0.7.
+You can use ``dos_protection`` settings in ``etc/zope.conf`` to change the limit.
+See `CMFPlone issue 3848 <https://github.com/plone/Products.CMFPlone/issues/3848>`_ and `Zope PR 1142 <https://github.com/zopefoundation/Zope/pull/1142>`_.
+@maurits

--- a/news/3848.bugfix
+++ b/news/3848.bugfix
@@ -1,5 +1,4 @@
-Allow uploads up to 16 MB.
+Temporarily disable form memory limit checking for files and images.
 This fixes a regression due to a low Zope form memory limit of 1MB used since Plone 6.0.7.
-You can use ``dos_protection`` settings in ``etc/zope.conf`` to change the limit.
 See `CMFPlone issue 3848 <https://github.com/plone/Products.CMFPlone/issues/3848>`_ and `Zope PR 1142 <https://github.com/zopefoundation/Zope/pull/1142>`_.
 @maurits

--- a/src/plone/restapi/__init__.py
+++ b/src/plone/restapi/__init__.py
@@ -1,3 +1,4 @@
+from . import patches  # noqa: ignore=F401
 from AccessControl import allow_module
 from AccessControl.Permissions import add_user_folders
 from plone.restapi.pas import plugin

--- a/src/plone/restapi/deserializer/__init__.py
+++ b/src/plone/restapi/deserializer/__init__.py
@@ -4,6 +4,9 @@ import json
 
 
 def json_body(request):
+    # TODO We should not read the complete request BODY in memory.
+    # Once we have fixed this, we can remove the temporary patches.py.
+    # See there for background information.
     try:
         data = json.loads(request.get("BODY") or "{}")
     except ValueError:

--- a/src/plone/restapi/patches.py
+++ b/src/plone/restapi/patches.py
@@ -1,0 +1,20 @@
+# TEMPORARY patch for low form memory limit introduced in Zope 5.8.4.
+# See https://github.com/plone/Products.CMFPlone/issues/3848
+# and https://github.com/zopefoundation/Zope/pull/1180
+# Should be removed once `plone.restapi.deserializer.json_body` no longer
+# reads the complete request BODY in memory.
+from ZPublisher import HTTPRequest
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+_attr = "FORM_MEMORY_LIMIT"
+_limit = getattr(HTTPRequest, _attr, None)
+if _limit and _limit == 2**20:
+    setattr(HTTPRequest, _attr, 2**24)
+    logger.info(
+        "PATCH: ZPublisher.HTTPRequest.%s is at a too low default of 1MB. "
+        "Increased it to 16MB to enable larger file uploads.",
+        _attr,
+    )

--- a/src/plone/restapi/patches.py
+++ b/src/plone/restapi/patches.py
@@ -3,18 +3,18 @@
 # and https://github.com/zopefoundation/Zope/pull/1180
 # Should be removed once `plone.restapi.deserializer.json_body` no longer
 # reads the complete request BODY in memory.
-from ZPublisher import HTTPRequest
+from ZPublisher.HTTPRequest import ZopeFieldStorage
 
 import logging
 
 
 logger = logging.getLogger(__name__)
-_attr = "FORM_MEMORY_LIMIT"
-_limit = getattr(HTTPRequest, _attr, None)
-if _limit and _limit == 2**20:
-    setattr(HTTPRequest, _attr, 2**24)
+_attr = "VALUE_LIMIT"
+_limit = getattr(ZopeFieldStorage, _attr, None)
+if _limit:
+    setattr(ZopeFieldStorage, _attr, None)
     logger.info(
-        "PATCH: ZPublisher.HTTPRequest.%s is at a too low default of 1MB. "
-        "Increased it to 16MB to enable larger file uploads.",
+        "PATCH: Disabled ZPublisher.HTTPRequest.ZopeFieldStorage.%s. "
+        "This enables file uploads larger than 1MB.",
         _attr,
     )


### PR DESCRIPTION
This fixes a regression due to a low Zope form memory limit of 1MB used since Plone 6.0.7. You can use ``dos_protection`` settings in ``etc/zope.conf`` to change the limit. See https://github.com/plone/Products.CMFPlone/issues/3848 and https://github.com/zopefoundation/Zope/pull/1142.