### PR TITLE
Does not test in Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.7"
-            plone-version: "5.2"
           - python-version: "3.8"
             plone-version: "5.2"
           - python-version: "3.8"

--- a/news/1732.internal
+++ b/news/1732.internal
@@ -1,0 +1,1 @@
+Does not test in Python 3.7. @wesleybl


### PR DESCRIPTION
Plone 5.2 no longer supports Python 3.7. See: https://github.com/plone/Products.CMFPlone/blob/5.2.14/setup.py#L25-L26