### PR TITLE
Use plone.recipe.precompiler to generate mo files to test

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -14,6 +14,7 @@ parts =
     deploy-to-heroku
     omelette
     zpretty
+    precompile
 develop = .
 sources-dir = extras
 auto-checkout =
@@ -169,6 +170,11 @@ input = inline:
     find src -name '*.zcml' | xargs bin/zpretty -i
 output = ${buildout:directory}/bin/zpretty-run
 mode = 755
+
+[precompile]
+recipe = plone.recipe.precompiler
+eggs = plone.restapi
+compile-mo-files = true
 
 [sources]
 plone.rest = git git://github.com/plone/plone.rest.git pushurl=git@github.com:plone/plone.rest.git branch=master

--- a/news/1733.internal
+++ b/news/1733.internal
@@ -1,0 +1,1 @@
+Use plone.recipe.precompiler to generate mo files to test. @wesleybl

--- a/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
@@ -59,7 +59,7 @@ Content-Type: application/json
         },
         {
             "@id": "http://localhost:55001/plone/@addons/plone.restapi",
-            "description": "RESTful hypermedia API for Plone.",
+            "description": "API hipermedia RESTful para Plone.",
             "id": "plone.restapi",
             "install_profile_id": "plone.restapi:default",
             "is_installed": true,


### PR DESCRIPTION
There are tests that need translation. If we started the instance for testing, the translation files were generated, causing the documentation tests to give a different result locally, since in CI the mo files did not exist.