### PR TITLE
Uses Python 3.12.0 in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,8 @@ jobs:
             plone-version: "6.0"
           - python-version: "3.11"
             plone-version: "6.0"
-          - python-version: "3.12"
+          # FIXME: Change to 3.12 when errors in tests with Python 3.12.1 are fixed.
+          - python-version: "3.12.0"
             plone-version: "6.0"
     steps:
       # git checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
             plone-version: "6.0"
           - python-version: "3.11"
             plone-version: "6.0"
-          # FIXME: Change to 3.12 when errors in tests with Python 3.12.1 are fixed.
+          # FIXME: Change to 3.12 when https://github.com/python/cpython/issues/113267 is fixed
           - python-version: "3.12.0"
             plone-version: "6.0"
     steps:

--- a/news/1740.internal
+++ b/news/1740.internal
@@ -1,0 +1,1 @@
+Uses Python 3.12.0 in tests, while https://github.com/zopefoundation/Zope/issues/1188 is not fixed. @wesleybl

--- a/news/1740.internal
+++ b/news/1740.internal
@@ -1,1 +1,1 @@
-Uses Python 3.12.0 in tests, while https://github.com/zopefoundation/Zope/issues/1188 is not fixed. @wesleybl
+Use Python 3.12.0 in tests to work around https://github.com/python/cpython/issues/113267. @wesleybl


### PR DESCRIPTION
Uses Python 3.12.0 in tests, while errors in tests with Python 3.12.1 are not fixed

Tests in 3.12.1 is broken.

Fixes #1740