### PR TITLE
Improve the block transforms to include also anchors when resolving uid back and forth

### DIFF
--- a/news/1746.bugfix
+++ b/news/1746.bugfix
@@ -1,0 +1,1 @@
+Improve the block transforms to include also anchors when resolving uid back and forth @sneridagh

--- a/news/1746.bugfix
+++ b/news/1746.bugfix
@@ -1,1 +1,1 @@
-Improve the block transforms to include also anchors when resolving uid back and forth @sneridagh
+Fixed the logic for converting public URLs to and from internal UID-based URLs. Now if the URL includes a fragment, it is preserved. @sneridagh

--- a/src/plone/restapi/deserializer/utils.py
+++ b/src/plone/restapi/deserializer/utils.py
@@ -25,11 +25,13 @@ def path2uid(context, link):
         )
 
     # handle edge-case when we have non traversable path like /@@download/file
-    if "/@@" in path:
-        path, suffix = path.split("/@@", 1)
-        suffix = "/@@" + suffix
-    else:
-        suffix = ""
+    SUFFIXES = ["/@@", "#"]
+    suffix = ""
+    for suffix_separator in SUFFIXES:
+        if suffix_separator in path:
+            path, suffix = path.split(suffix_separator, 1)
+            suffix = suffix_separator + suffix
+
     obj = portal.unrestrictedTraverse(path, None)
     if obj is None or obj == portal:
         return link

--- a/src/plone/restapi/deserializer/utils.py
+++ b/src/plone/restapi/deserializer/utils.py
@@ -41,6 +41,7 @@ def path2uid(context, link):
         if obj is None:
             break
         suffix = "/" + segments.pop() + suffix
+    print(suffix)
     # check if obj is wrong because of acquisition
     if not obj or "/".join(obj.getPhysicalPath()) != "/".join(segments):
         return link

--- a/src/plone/restapi/deserializer/utils.py
+++ b/src/plone/restapi/deserializer/utils.py
@@ -2,6 +2,9 @@ from Acquisition import aq_parent
 from plone.uuid.interfaces import IUUID
 from plone.uuid.interfaces import IUUIDAware
 from zope.component import getMultiAdapter
+import re
+
+PATH_RE = re.compile(r"^(.*?)((?=/@@|#).*)?$")
 
 
 def path2uid(context, link):
@@ -24,13 +27,12 @@ def path2uid(context, link):
             portal_path=portal_path, path=path.lstrip("/")
         )
 
-    # handle edge-case when we have non traversable path like /@@download/file
-    SUFFIXES = ["/@@", "#"]
+    # handle edge cases with suffixes like /@@download/file or a fragment
     suffix = ""
-    for suffix_separator in SUFFIXES:
-        if suffix_separator in path:
-            path, suffix = path.split(suffix_separator, 1)
-            suffix = suffix_separator + suffix
+    match = PATH_RE.match(path)
+    if match is not None:
+        path = match.group(1)
+        suffix = match.group(2) or ""
 
     obj = portal.unrestrictedTraverse(path, None)
     if obj is None or obj == portal:
@@ -41,7 +43,6 @@ def path2uid(context, link):
         if obj is None:
             break
         suffix = "/" + segments.pop() + suffix
-    print(suffix)
     # check if obj is wrong because of acquisition
     if not obj or "/".join(obj.getPhysicalPath()) != "/".join(segments):
         return link

--- a/src/plone/restapi/serializer/utils.py
+++ b/src/plone/restapi/serializer/utils.py
@@ -8,7 +8,7 @@ from zope.i18n import translate
 import re
 
 
-RESOLVEUID_RE = re.compile("^(?:|.*/)resolve[Uu]id/([^/#]*)/?(.*?)(#.*)?$")
+RESOLVEUID_RE = re.compile("^(?:|.*/)resolve[Uu]id/([^/#]*)/?(.*)?$")
 
 
 def resolve_uid(path):
@@ -23,19 +23,13 @@ def resolve_uid(path):
     if match is None:
         return path, None
 
-    uid, suffix, anchor = match.groups()
+    uid, suffix = match.groups()
     brain = uuidToCatalogBrain(uid)
     if brain is None:
         return path, None
     href = brain.getURL()
-    SUFFIXES = ["/@@", "#"]
-    suffix = ""
-    for suffix_separator in SUFFIXES:
-        if suffix_separator in path:
-            path, suffix = path.split(suffix_separator, 1)
-            suffix = suffix_separator + suffix
     if suffix:
-        return href + suffix, brain
+        return href + "/" + suffix, brain
     target_object = brain._unrestrictedGetObject()
     adapter = queryMultiAdapter(
         (target_object, target_object.REQUEST),

--- a/src/plone/restapi/serializer/utils.py
+++ b/src/plone/restapi/serializer/utils.py
@@ -8,7 +8,7 @@ from zope.i18n import translate
 import re
 
 
-RESOLVEUID_RE = re.compile("^(?:|.*/)resolve[Uu]id/([^/]*)/?(.*)$")
+RESOLVEUID_RE = re.compile("^(?:|.*/)resolve[Uu]id/([^/#]*)/?(.*?)(#.*)?$")
 
 
 def resolve_uid(path):
@@ -23,13 +23,15 @@ def resolve_uid(path):
     if match is None:
         return path, None
 
-    uid, suffix = match.groups()
+    uid, suffix, anchor = match.groups()
     brain = uuidToCatalogBrain(uid)
     if brain is None:
         return path, None
     href = brain.getURL()
     if suffix:
         return href + "/" + suffix, brain
+    if anchor:
+        return href + anchor, brain
     target_object = brain._unrestrictedGetObject()
     adapter = queryMultiAdapter(
         (target_object, target_object.REQUEST),

--- a/src/plone/restapi/serializer/utils.py
+++ b/src/plone/restapi/serializer/utils.py
@@ -28,10 +28,14 @@ def resolve_uid(path):
     if brain is None:
         return path, None
     href = brain.getURL()
+    SUFFIXES = ["/@@", "#"]
+    suffix = ""
+    for suffix_separator in SUFFIXES:
+        if suffix_separator in path:
+            path, suffix = path.split(suffix_separator, 1)
+            suffix = suffix_separator + suffix
     if suffix:
-        return href + "/" + suffix, brain
-    if anchor:
-        return href + anchor, brain
+        return href + suffix, brain
     target_object = brain._unrestrictedGetObject()
     adapter = queryMultiAdapter(
         (target_object, target_object.REQUEST),

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -503,6 +503,38 @@ class TestBlocksDeserializer(unittest.TestCase):
         link = value[0]["children"][1]["data"]["url"]
         self.assertEqual(link, f"../resolveuid/{self.image.UID()}/@@download/file")
 
+    def test_slate_simple_link_deserializer_with_suffix_and_anchor(self):
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": "%s/image-1/@@download/file#anchor-id"
+                                    % self.portal.absolute_url()
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+
+        res = self.deserialize(blocks=blocks)
+        value = res.blocks["abc"]["value"]
+        link = value[0]["children"][1]["data"]["url"]
+        self.assertEqual(
+            link, f"../resolveuid/{self.image.UID()}/@@download/file#anchor-id"
+        )
+
     def test_aquisition_messing_with_link_deserializer(self):
         self.portal.invokeFactory(
             "Folder",

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -18,7 +18,6 @@ import unittest
 
 
 class TestBlocksDeserializer(unittest.TestCase):
-
     layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
 
     def setUp(self):
@@ -443,6 +442,66 @@ class TestBlocksDeserializer(unittest.TestCase):
         value = res.blocks["abc"]["value"]
         link = value[0]["children"][1]["data"]["url"]
         self.assertTrue(link.startswith("../resolveuid/"))
+
+    def test_slate_simple_link_deserializer_with_anchor(self):
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": "%s/image-1#anchor-id"
+                                    % self.portal.absolute_url()
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+
+        res = self.deserialize(blocks=blocks)
+        value = res.blocks["abc"]["value"]
+        link = value[0]["children"][1]["data"]["url"]
+        self.assertEqual(link, f"../resolveuid/{self.image.UID()}#anchor-id")
+
+    def test_slate_simple_link_deserializer_with_suffix(self):
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": "%s/image-1/@@download/file"
+                                    % self.portal.absolute_url()
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+
+        res = self.deserialize(blocks=blocks)
+        value = res.blocks["abc"]["value"]
+        link = value[0]["children"][1]["data"]["url"]
+        self.assertEqual(link, f"../resolveuid/{self.image.UID()}/@@download/file")
 
     def test_aquisition_messing_with_link_deserializer(self):
         self.portal.invokeFactory(

--- a/src/plone/restapi/tests/test_blocks_serializer.py
+++ b/src/plone/restapi/tests/test_blocks_serializer.py
@@ -29,7 +29,6 @@ IMAGE_DATA = IMAGE_PATH.read_bytes()
 
 
 class TestBlocksSerializer(unittest.TestCase):
-
     layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
 
     def setUp(self):
@@ -285,7 +284,75 @@ class TestBlocksSerializer(unittest.TestCase):
         )
         value = res["abc"]["value"]
         link = value[0]["children"][1]["data"]["url"]
-        self.assertTrue(link, self.portal.absolute_url() + "/doc1")
+        self.assertEqual(link, self.portal.absolute_url() + "/doc1")
+
+    def test_simple_link_serializer_with_anchor(self):
+        doc_uid = IUUID(self.portal["doc1"])
+        resolve_uid_link = f"../resolveuid/{doc_uid}#anchor-id"
+
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": resolve_uid_link,
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+        res = self.serialize(
+            context=self.portal["doc1"],
+            blocks=blocks,
+        )
+        value = res["abc"]["value"]
+        link = value[0]["children"][1]["data"]["url"]
+        self.assertEqual(link, f"{self.portal['doc1'].absolute_url()}#anchor-id")
+
+    def test_simple_link_serializer_with_suffix(self):
+        doc_uid = IUUID(self.portal["doc1"])
+        resolve_uid_link = f"../resolveuid/{doc_uid}/@@download/file"
+
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": resolve_uid_link,
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+        res = self.serialize(
+            context=self.portal["doc1"],
+            blocks=blocks,
+        )
+        value = res["abc"]["value"]
+        link = value[0]["children"][1]["data"]["url"]
+        self.assertEqual(link, f"{self.portal['doc1'].absolute_url()}/@@download/file")
 
     def test_slate_table_block_link_serializer(self):
         doc_uid = IUUID(self.portal["doc1"])
@@ -388,7 +455,7 @@ class TestBlocksSerializer(unittest.TestCase):
         rows = res["abc"]["table"]["rows"]
         cell = rows[1]["cells"][0]
         link = cell["value"][0]["children"][1]["data"]["url"]
-        self.assertTrue(link, self.portal.absolute_url() + "/doc1")
+        self.assertEqual(link, self.portal.absolute_url() + "/doc1")
 
     @unittest.skipUnless(
         HAS_PLONE_6,

--- a/src/plone/restapi/tests/test_blocks_serializer.py
+++ b/src/plone/restapi/tests/test_blocks_serializer.py
@@ -318,7 +318,7 @@ class TestBlocksSerializer(unittest.TestCase):
         )
         value = res["abc"]["value"]
         link = value[0]["children"][1]["data"]["url"]
-        self.assertEqual(link, f"{self.portal['doc1'].absolute_url()}#anchor-id")
+        self.assertEqual(link, f"{self.portal['doc1'].absolute_url()}/#anchor-id")
 
     def test_simple_link_serializer_with_suffix(self):
         doc_uid = IUUID(self.portal["doc1"])

--- a/src/plone/restapi/tests/test_blocks_serializer.py
+++ b/src/plone/restapi/tests/test_blocks_serializer.py
@@ -354,6 +354,42 @@ class TestBlocksSerializer(unittest.TestCase):
         link = value[0]["children"][1]["data"]["url"]
         self.assertEqual(link, f"{self.portal['doc1'].absolute_url()}/@@download/file")
 
+    def test_simple_link_serializer_with_suffix_and_anchor(self):
+        doc_uid = IUUID(self.portal["doc1"])
+        resolve_uid_link = f"../resolveuid/{doc_uid}/@@download/file#anchor-id"
+
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": resolve_uid_link,
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+        res = self.serialize(
+            context=self.portal["doc1"],
+            blocks=blocks,
+        )
+        value = res["abc"]["value"]
+        link = value[0]["children"][1]["data"]["url"]
+        self.assertEqual(
+            link, f"{self.portal['doc1'].absolute_url()}/@@download/file#anchor-id"
+        )
+
     def test_slate_table_block_link_serializer(self):
         doc_uid = IUUID(self.portal["doc1"])
         resolve_uid_link = f"../resolveuid/{doc_uid}"


### PR DESCRIPTION
Now it covers the use case if an anchor is present.