### PR TITLE
Remove debug-exceptions = on from the buildout instance section

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -38,7 +38,6 @@ recipe = plone.recipe.zope2instance
 user = admin:admin
 http-address = 8080
 deprecation-warnings = on
-debug-exceptions = on
 eggs =
     Plone
     Pillow

--- a/news/1734.internal
+++ b/news/1734.internal
@@ -1,0 +1,1 @@
+Remove debug-exceptions = on from the buildout instance section. @wesleybl


### PR DESCRIPTION
This setting was causing validation errors to return `BadRequest`. This is different from a normal Plone installation.

It seems like it is a necessary configuration in performance tests. But we already have this configuration in the performance test buildout:

https://github.com/plone/plone.restapi/blob/366a9d0c61b1599032de275520e10c2a8a0925a6/plone-6.0.x-performance.cfg#L9

fixes #1734


