### PR TITLE
Fix serializer block with anchors, remove trailing slash before the anchor

### DIFF
--- a/news/1748.bugfix
+++ b/news/1748.bugfix
@@ -1,2 +1,1 @@
-Fix blocks resolveuid serializer with suffixes, remove trailing slash added before anchors
-[sneridagh]
+Fixed an edge case in the blocks resolveuid transforms with a trailing slash before a fragment. @sneridagh 

--- a/news/1748.bugfix
+++ b/news/1748.bugfix
@@ -1,0 +1,2 @@
+Fix blocks resolveuid serializer with suffixes, remove trailing slash added before anchors
+[sneridagh]

--- a/src/plone/restapi/deserializer/utils.py
+++ b/src/plone/restapi/deserializer/utils.py
@@ -31,7 +31,7 @@ def path2uid(context, link):
     suffix = ""
     match = PATH_RE.match(path)
     if match is not None:
-        path = match.group(1)
+        path = match.group(1).rstrip("/")
         suffix = match.group(2) or ""
 
     obj = portal.unrestrictedTraverse(path, None)

--- a/src/plone/restapi/serializer/utils.py
+++ b/src/plone/restapi/serializer/utils.py
@@ -8,7 +8,7 @@ from zope.i18n import translate
 import re
 
 
-RESOLVEUID_RE = re.compile("^(?:|.*/)resolve[Uu]id/([^/#]*)/?(.*)?$")
+RESOLVEUID_RE = re.compile("^(?:|.*/)resolve[Uu]id/([^/#]*)?(.*)?$")
 
 
 def resolve_uid(path):
@@ -29,7 +29,7 @@ def resolve_uid(path):
         return path, None
     href = brain.getURL()
     if suffix:
-        return href + "/" + suffix, brain
+        return href + suffix, brain
     target_object = brain._unrestrictedGetObject()
     adapter = queryMultiAdapter(
         (target_object, target_object.REQUEST),

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -563,9 +563,7 @@ class TestBlocksDeserializer(unittest.TestCase):
         res = self.deserialize(blocks=blocks)
         value = res.blocks["abc"]["value"]
         link = value[0]["children"][1]["data"]["url"]
-        self.assertEqual(
-            link, f"../resolveuid/{self.image.UID()}#anchor-id"
-        )
+        self.assertEqual(link, f"../resolveuid/{self.image.UID()}#anchor-id")
 
     def test_aquisition_messing_with_link_deserializer(self):
         self.portal.invokeFactory(

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -535,6 +535,38 @@ class TestBlocksDeserializer(unittest.TestCase):
             link, f"../resolveuid/{self.image.UID()}/@@download/file#anchor-id"
         )
 
+    def test_slate_simple_link_deserializer_with_slash_and_anchor(self):
+        blocks = {
+            "abc": {
+                "@type": "slate",
+                "plaintext": "Frontpage content here",
+                "value": [
+                    {
+                        "children": [
+                            {"text": "Frontpage "},
+                            {
+                                "children": [{"text": "content "}],
+                                "data": {
+                                    "url": "%s/image-1/#anchor-id"
+                                    % self.portal.absolute_url()
+                                },
+                                "type": "link",
+                            },
+                            {"text": "here"},
+                        ],
+                        "type": "h2",
+                    }
+                ],
+            }
+        }
+
+        res = self.deserialize(blocks=blocks)
+        value = res.blocks["abc"]["value"]
+        link = value[0]["children"][1]["data"]["url"]
+        self.assertEqual(
+            link, f"../resolveuid/{self.image.UID()}#anchor-id"
+        )
+
     def test_aquisition_messing_with_link_deserializer(self):
         self.portal.invokeFactory(
             "Folder",

--- a/src/plone/restapi/tests/test_blocks_serializer.py
+++ b/src/plone/restapi/tests/test_blocks_serializer.py
@@ -318,7 +318,7 @@ class TestBlocksSerializer(unittest.TestCase):
         )
         value = res["abc"]["value"]
         link = value[0]["children"][1]["data"]["url"]
-        self.assertEqual(link, f"{self.portal['doc1'].absolute_url()}/#anchor-id")
+        self.assertEqual(link, f"{self.portal['doc1'].absolute_url()}#anchor-id")
 
     def test_simple_link_serializer_with_suffix(self):
         doc_uid = IUUID(self.portal["doc1"])


### PR DESCRIPTION
@davisagli we overlooked this one :( the roundtrip was bugged because of the trailing slash. Please take a look at the regex, if it's fine like this.