### PR TITLE
Give Site Administrator permission to add users to groups

### DIFF
--- a/news/1750.bugfix
+++ b/news/1750.bugfix
@@ -1,0 +1,1 @@
+Give Site Administrator permission to add users to groups. @wesleybl

--- a/news/1750.bugfix
+++ b/news/1750.bugfix
@@ -1,1 +1,1 @@
-Give Site Administrator permission to add users to groups. @wesleybl
+Fixed the permission check for adding users to groups and removing users from groups, so that it is allowed for users with the Site Administrator role. @wesleybl

--- a/src/plone/restapi/services/groups/add.py
+++ b/src/plone/restapi/services/groups/add.py
@@ -71,7 +71,7 @@ class GroupsPost(Service):
         # Add members
         group = gtool.getGroupById(groupname)
         for userid in users:
-            group.addMember(userid)
+            gtool.addPrincipalToGroup(userid, groupname)
 
         self.request.response.setStatus(201)
         self.request.response.setHeader(

--- a/src/plone/restapi/services/groups/update.py
+++ b/src/plone/restapi/services/groups/update.py
@@ -112,9 +112,9 @@ class GroupsPatch(Service):
         )
 
         properties = {}
-        for id, property in group.propertyItems():
-            if data.get(id, False):
-                properties[id] = data[id]
+        for _id, _property in group.propertyItems():
+            if data.get(_id, False):
+                properties[_id] = data[_id]
         group.setGroupProperties(properties)
 
         # Add/remove members
@@ -122,8 +122,8 @@ class GroupsPatch(Service):
         for userid, allow in users.items():
             if allow:
                 if userid not in memberids:
-                    group.addMember(userid)
+                    portal_groups.addPrincipalToGroup(userid, group.id)
             else:
                 if userid in memberids:
-                    group.removeMember(userid)
+                    portal_groups.removePrincipalFromGroup(userid, group.id)
         return self.reply_no_content()

--- a/src/plone/restapi/tests/test_services_groups.py
+++ b/src/plone/restapi/tests/test_services_groups.py
@@ -188,6 +188,17 @@ class TestGroupsEndpoint(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_siteadm_add_user_to_group(self):
+        self.set_siteadm()
+        payload = {
+            "users": {TEST_USER_ID: True, SITE_OWNER_NAME: False},
+        }
+        self.api_session.patch("/@groups/Reviewers", json=payload)
+        transaction.commit()
+
+        reviewers = self.gtool.getGroupById("Reviewers")
+        self.assertIn(TEST_USER_ID, reviewers.getGroupMemberIds())
+
     def test_siteadm_not_add_user_to_group_with_manager_role(self):
         self.set_siteadm()
         payload = {


### PR DESCRIPTION
The `addMember` method requires the user to have the `Manage Users` permission but the Site Administrator does not have this permission. Then we use the `addPrincipalToGroup` method, which does not require this permission.

fixes #1750 