### PR TITLE
Enhance Path Handling in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ YELLOW=`tput setaf 3`
 # You can set these variables from the command line.
 SPHINXOPTS      ?=
 # Internal variables.
-SPHINXBUILD     = $(realpath bin/sphinx-build)
-SPHINXAUTOBUILD = $(realpath bin/sphinx-autobuild)
+SPHINXBUILD     = "$(realpath bin/sphinx-build)"
+SPHINXAUTOBUILD = "$(realpath bin/sphinx-autobuild)"
 DOCS_DIR        = ./docs/source/
 BUILDDIR        = ../_build/
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .

--- a/news/1753.bugfix
+++ b/news/1753.bugfix
@@ -1,0 +1,1 @@
+Enhanced Makefile paths to address whitespace compatibility issues. @Vivek-04022001


### PR DESCRIPTION
Issue Description:

The Makefile uses realpath to set **SPHINXBUILD and SPHINXAUTOBUILD**:
```
SPHINXBUILD     = $(realpath bin/sphinx-build)
SPHINXAUTOBUILD = $(realpath bin/sphinx-autobuild)

```
replace with 
```
SPHINXBUILD     = "$(realpath bin/sphinx-build)"
SPHINXAUTOBUILD = "$(realpath bin/sphinx-autobuild)"

```
This can cause compatibility issues and doesn't handle special characters in paths. We need to replace realpath with a more portable and robust method. **This issues was already discussed with @stevepiercy on plone community** [conversation link](https://community.plone.org/t/error-running-training-repo-seek-advice-on-pull-request/18618/8?u=vivek-04022001)