### PR TITLE
Fix test to work with the new way plone.rest returns errors

### DIFF
--- a/news/1755.internal
+++ b/news/1755.internal
@@ -1,0 +1,1 @@
+Fix test to work with the new way plone.rest returns errors. For now the tests are also being skipped @wesleybl

--- a/src/plone/restapi/tests/test_content_patch.py
+++ b/src/plone/restapi/tests/test_content_patch.py
@@ -61,6 +61,9 @@ class TestContentPatch(unittest.TestCase):
         self.assertEqual(204, response.status_code)
         self.assertEqual("", self.portal.doc1.description)
 
+    # FIXE: This test requires a version of Plone with:
+    # https://github.com/plone/plone.rest/pull/179
+    @unittest.skip("Requires https://github.com/plone/plone.rest/pull/179.")
     def test_patch_document_will_not_delete_value_with_null_if_required(self):
         response = requests.patch(
             self.portal.doc1.absolute_url(),
@@ -72,9 +75,12 @@ class TestContentPatch(unittest.TestCase):
 
         # null will set field.missing_value which is u'' for the field
         self.assertEqual(400, response.status_code)
-        self.assertTrue("'field': 'title'" in response.text)
-        self.assertTrue("title is a required field." in response.text)
-        self.assertTrue("Setting it to null is not allowed." in response.text)
+        message = response.json()["message"][0]
+        self.assertEqual(message["field"], "title")
+        self.assertEqual(
+            message["message"],
+            "title is a required field. Setting it to null is not allowed.",
+        )
 
     def test_patch_document_with_representation(self):
         response = requests.patch(

--- a/src/plone/restapi/tests/test_services_controlpanels.py
+++ b/src/plone/restapi/tests/test_services_controlpanels.py
@@ -100,6 +100,9 @@ class TestControlpanelsEndpoint(unittest.TestCase):
                 "{} failed: {}".format(item["@id"], response.content),
             )
 
+    # FIXE: This test requires a version of Plone with:
+    # https://github.com/plone/plone.rest/pull/179
+    @unittest.skip("Requires https://github.com/plone/plone.rest/pull/179.")
     def test_update_required(self):
         KEY = "email_charset"
         URL = "/@controlpanels/mail"
@@ -113,7 +116,9 @@ class TestControlpanelsEndpoint(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         response = response.json()
         self.assertIn("message", response)
-        self.assertIn("Required input is missing.", response["message"])
+        self.assertEqual(
+            "Required input is missing.", response["message"][0]["message"]
+        )
 
     def test_get_usergroup_control_panel(self):
         # This control panel does not exist in Plone 5


### PR DESCRIPTION
After:

https://github.com/plone/plone.rest/pull/179

`BadRequest` errors are returned as an object and not as a string. This fix here takes this into account. But for now the tests are skipped, so that the merge can be done before the `plone.rest` change is in a Plone version.