### PR TITLE
Use the mode parameter instead of direction when calling the scale method

### DIFF
--- a/news/1758.bugfix
+++ b/news/1758.bugfix
@@ -1,0 +1,1 @@
+Use the ``mode`` parameter instead of ``direction`` when calling the ``scale`` method. Also change value to ``scale`. @wesleybl

--- a/src/plone/restapi/__init__.py
+++ b/src/plone/restapi/__init__.py
@@ -2,10 +2,12 @@ from . import patches  # noqa: ignore=F401
 from AccessControl import allow_module
 from AccessControl.Permissions import add_user_folders
 from plone.restapi.pas import plugin
+from Products.CMFPlone.utils import getFSVersionTuple
 from Products.PluggableAuthService.PluggableAuthService import registerMultiPlugin
 from zope.i18nmessageid import MessageFactory
 
 import pkg_resources
+
 
 try:
     pkg_resources.get_distribution("plone.app.multilingual")
@@ -18,6 +20,9 @@ PROJECT_NAME = "plone.restapi"
 
 
 allow_module("json")
+
+# BBB: Plone 5.2
+PLONE5 = getFSVersionTuple()[0] == 5
 
 
 def initialize(context):

--- a/src/plone/restapi/__init__.py
+++ b/src/plone/restapi/__init__.py
@@ -1,8 +1,8 @@
 from . import patches  # noqa: ignore=F401
 from AccessControl import allow_module
 from AccessControl.Permissions import add_user_folders
+from importlib import import_module
 from plone.restapi.pas import plugin
-from Products.CMFPlone.utils import getFSVersionTuple
 from Products.PluggableAuthService.PluggableAuthService import registerMultiPlugin
 from zope.i18nmessageid import MessageFactory
 
@@ -22,7 +22,9 @@ PROJECT_NAME = "plone.restapi"
 allow_module("json")
 
 # BBB: Plone 5.2
-PLONE5 = getFSVersionTuple()[0] == 5
+HAS_PLONE_6 = getattr(
+    import_module("Products.CMFPlone.factory"), "PLONE60MARKER", False
+)
 
 
 def initialize(context):

--- a/src/plone/restapi/imaging.py
+++ b/src/plone/restapi/imaging.py
@@ -1,6 +1,15 @@
+from plone.restapi import PLONE5
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.globalrequest import getRequest
+
+
+if PLONE5:
+    # BBB: In Plone 5.2, it is necessary to use the direction parameter.
+    scale_parameter = {"direction": "thumbnail"}
+else:
+    # In Plone 6.0+, we must use the mode parameter
+    scale_parameter = {"mode": "scale"}
 
 
 def get_scales(context, field, width, height):
@@ -51,9 +60,8 @@ def get_original_image_url(context, fieldname, width, height):
     scale_flags = {}
     if hasattr(images_view, "picture"):
         scale_flags["pre"] = True
-    scale = images_view.scale(
-        fieldname, width=width, height=height, direction="thumbnail", **scale_flags
-    )
+    parameters = {**scale_flags, **scale_parameter}
+    scale = images_view.scale(fieldname, width=width, height=height, **parameters)
     if scale:
         return scale.url
     # Corrupt images may not have a scale.

--- a/src/plone/restapi/imaging.py
+++ b/src/plone/restapi/imaging.py
@@ -1,15 +1,15 @@
-from plone.restapi import PLONE5
+from plone.restapi import HAS_PLONE_6
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 
 
-if PLONE5:
-    # BBB: In Plone 5.2, it is necessary to use the direction parameter.
-    scale_parameter = {"direction": "thumbnail"}
-else:
+if HAS_PLONE_6:
     # In Plone 6.0+, we must use the mode parameter
     scale_parameter = {"mode": "scale"}
+else:
+    # BBB: In Plone 5.2, it is necessary to use the direction parameter.
+    scale_parameter = {"direction": "thumbnail"}
 
 
 def get_scales(context, field, width, height):


### PR DESCRIPTION
The `direction` parameter is deprecated. This avoids the warning:

DeprecationWarning: The 'direction' option is deprecated, use 'mode' instead.

Also change value to `scale`.

Even though we get the warning in Plone 5.2, the tests fail when we use mode. So we keep direction in Plone 5.2.

Ref: https://github.com/plone/Products.CMFPlone/issues/3850