### PR TITLE
Bump all the versions in GitHub workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,15 +7,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
 
     steps:
       # git checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.12]
+        python-version: [3.11]
 
     steps:
       # git checkout

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -7,15 +7,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
 
     steps:
       # git checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/pyroma.yml
+++ b/.github/workflows/pyroma.yml
@@ -7,15 +7,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
 
     steps:
       # git checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,11 @@ jobs:
             plone-version: "6.0"
     steps:
       # git checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -54,7 +54,7 @@ jobs:
 
       # build sphinx
       - name: sphinx
-        run: if [ "${{ matrix.plone-version }}" == "6.0" ] && [ ${{ matrix.python-version }} == '3.9' ]; then make docs-html; fi
+        run: if [ "${{ matrix.plone-version }}" == "6.0" ] && [ ${{ matrix.python-version }} == '3.12' ]; then make docs-html; fi
 
       # test
       - name: test
@@ -69,4 +69,4 @@ jobs:
 
       # test for broken links
       - name: linkcheck
-        run: if [ "${{ matrix.plone-version }}" == "6.0" ] && [ ${{ matrix.python-version }} == '3.9' ]; then make docs-linkcheckbroken; fi
+        run: if [ "${{ matrix.plone-version }}" == "6.0" ] && [ ${{ matrix.python-version }} == '3.12' ]; then make docs-linkcheckbroken; fi

--- a/.github/workflows/zpretty.yml
+++ b/.github/workflows/zpretty.yml
@@ -7,15 +7,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
 
     steps:
       # git checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/news/1762.internal
+++ b/news/1762.internal
@@ -1,0 +1,1 @@
+Bump all the versions in GitHub workflows. @stevepiercy


### PR DESCRIPTION
flake8 is not ready for Python 3.12, so it stays at 3.11 for now, unless another tool replaces it.