### PR TITLE
In Plone 6, uses plone.textindexer to add block texts to the SearchableText index

### DIFF
--- a/news/1744.bugfix
+++ b/news/1744.bugfix
@@ -1,0 +1,1 @@
+In Plone 6, uses ``plone.textindexer`` to add block texts to the SearchableText index, instead of ``plone.indexer``. This ensures that behaviors can add fields to SearchableText with ``plone.textindexer``. @wesleybl

--- a/src/plone/restapi/indexers.py
+++ b/src/plone/restapi/indexers.py
@@ -1,10 +1,3 @@
-# XXX: EXPERIMENTAL!!!
-# This is an experimental feature meant for use in Volto only!
-# This code is likely to change in the future, even within minor releases.
-# We will make sure plone.restapi latest always works with the latest Volto release.
-# This code is planned to being refactored into plone.volto before CMFPlone 6.0 is out.
-# <tisto@plone.org>
-
 from plone.app.contenttypes.indexers import SearchableText
 from plone.indexer.decorator import indexer
 from plone.restapi import HAS_PLONE_6
@@ -16,13 +9,6 @@ from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
-
-
-try:
-    from plone.app.dexterity import textindexer
-except ImportError:
-    # BBB: Plone 5.2 does not have plone.app.dexterity.textindexer.
-    pass
 
 
 @implementer(IBlockSearchableText)
@@ -134,6 +120,8 @@ if HAS_PLONE_6:
     # In Plone 6, uses IDynamicTextIndexExtender to index block texts.
     # This ensures that indexing with plone.textindexer continues to work. See:
     # https://github.com/plone/plone.restapi/issues/1744
+    from plone.app.dexterity import textindexer
+
     @implementer(textindexer.IDynamicTextIndexExtender)
     @adapter(IBlocks)
     class BlocksSearchableTextExtender(object):

--- a/src/plone/restapi/indexers.zcml
+++ b/src/plone/restapi/indexers.zcml
@@ -4,23 +4,27 @@
     i18n_domain="plone"
     >
 
-  <configure zcml:condition="installed plone.app.contenttypes">
-    <adapter
-        factory=".indexers.SearchableText_blocks"
-        name="SearchableText"
-        />
-    <adapter
-        factory=".indexers.TextBlockSearchableText"
-        name="text"
-        />
-    <adapter
-        factory=".indexers.SlateTextIndexer"
-        name="slate"
-        />
-    <adapter
-        factory=".indexers.TableBlockSearchableText"
-        name="table"
-        />
-  </configure>
+  <adapter
+      factory=".indexers.BlocksSearchableTextExtender"
+      name="IBlocks"
+      zcml:condition="have plone-60"
+      />
+  <adapter
+      factory=".indexers.SearchableText_blocks"
+      name="SearchableText"
+      zcml:condition="not-have plone-60"
+      />
+  <adapter
+      factory=".indexers.TextBlockSearchableText"
+      name="text"
+      />
+  <adapter
+      factory=".indexers.SlateTextIndexer"
+      name="slate"
+      />
+  <adapter
+      factory=".indexers.TableBlockSearchableText"
+      name="table"
+      />
 
 </configure>

--- a/src/plone/restapi/tests/test_blocks_searchable_text.py
+++ b/src/plone/restapi/tests/test_blocks_searchable_text.py
@@ -7,7 +7,7 @@ from plone.dexterity.interfaces import IDexterityItem
 from plone.dexterity.utils import createContentInContainer
 from plone.restapi.behaviors import IBlocks
 from plone.restapi.interfaces import IBlockSearchableText
-from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_BLOCKS_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
 from zope.component import adapter
 from zope.component import provideAdapter
@@ -21,7 +21,7 @@ import unittest
 
 class TestSearchTextInBlocks(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+    layer = PLONE_RESTAPI_BLOCKS_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.app = self.layer["app"]


### PR DESCRIPTION
This ensures that behaviors can add fields to SearchableText with `plone.textindexer`.

`IBlocks` now inherits from `IDexterityTextIndexer`, so there is no need to add the `plone.textindexer` behavior to the types to enable indexing. The content simply needs to have the `IBlocks` behavior.

fixes #1744 