### PR TITLE
image_scales in serializer are returned as json_compatible format

### DIFF
--- a/news/1772.bugfix
+++ b/news/1772.bugfix
@@ -1,0 +1,1 @@
+image_scales in serializer are returned as json_compatible format. @cekk

--- a/src/plone/restapi/serializer/blocks.py
+++ b/src/plone/restapi/serializer/blocks.py
@@ -65,7 +65,9 @@ class ResolveUIDSerializerBase:
                     continue
                 newdata[field], brain = resolve_uid(data[field])
                 if brain is not None and "image_scales" not in newdata:
-                    newdata["image_scales"] = getattr(brain, "image_scales", None)
+                    newdata["image_scales"] = json_compatible(
+                        getattr(brain, "image_scales", None)
+                    )
             result = {
                 field: (
                     newdata[field]

--- a/src/plone/restapi/tests/test_blocks_serializer.py
+++ b/src/plone/restapi/tests/test_blocks_serializer.py
@@ -505,3 +505,15 @@ class TestBlocksSerializer(unittest.TestCase):
         )
         self.assertEqual(res["123"]["url"], self.image.absolute_url())
         self.assertIn("image_scales", res["123"])
+
+    @unittest.skipUnless(
+        HAS_PLONE_6,
+        "image_scales were added to the catalog in Plone 6",
+    )
+    def test_image_scales_serializer_is_json_compatible(self):
+        image_uid = self.image.UID()
+        res = self.serialize(
+            context=self.portal["doc1"],
+            blocks={"123": {"@type": "image", "url": f"../resolveuid/{image_uid}"}},
+        )
+        self.assertIs(type(res["123"]["image_scales"]), dict)


### PR DESCRIPTION
This lead to problems when for example we have a custom service that serialize some blocks and do not force a json_compatible formatting to the returned data.

I have a service that take some blocks, serialize them and return the result.
But image_scales are a PersistentMapping instance and breaks json formatting.

For content-types serialization or other services like @search this is not a problem because there is something that force json compatibility.