### PR TITLE
Users service: fix edge case where a userid is returned by search but isn't an actual user

### DIFF
--- a/news/1775.bugfix
+++ b/news/1775.bugfix
@@ -1,0 +1,1 @@
+Users service: Fixed edge case AttributeError if a user is enumerated but doesn't actually exist. @davisagli

--- a/src/plone/restapi/services/users/get.py
+++ b/src/plone/restapi/services/users/get.py
@@ -115,7 +115,9 @@ class UsersGet(Service):
         principals = []
         for principal_info in search_for_principal(hunter, self.search_term):
             principal_id = principal_info[id_key]
-            principals.append(get_principal_by_id(principal_id))
+            principal = get_principal_by_id(principal_id)
+            if principal is not None:
+                principals.append(principal)
 
         return principals
 


### PR DESCRIPTION
Fixes #1774 

@djay Any chance you can test whether this fixes the error you reported?