### PR TITLE
Support for plone.app.discussion as core add-on

### DIFF
--- a/docs/source/endpoints/comments.md
+++ b/docs/source/endpoints/comments.md
@@ -14,7 +14,7 @@ This feature is not enabled by default in Plone 6.1 and later.
 To enable commenting, you need to install the core add-on "Discussion Support" (`plone.app.discussion`).
 ```
 
-Plone offers to users a feature to post comments on any content object.
+Discussion is a feature that allows your site visitors to comment on web pages for any content object.
 
 Commenting can be enabled globally for specific content types and for single content objects.
 

--- a/docs/source/endpoints/comments.md
+++ b/docs/source/endpoints/comments.md
@@ -9,9 +9,9 @@ myst:
 
 # Comments
 
-```{note}
-This feature is not enabled by default in Plone 6.1 and later.
-To enable commenting, you need to install the core add-on "Discussion Support" (`plone.app.discussion`).
+```{versionchanged} Plone 6.1
+Discussion is disabled by default in Plone 6.1 and later.
+To enable discussion, see the Plone 6.1 upgrade guide section {ref}`backend-upgrade-plone-v61-discussion-label`
 ```
 
 Discussion is a feature that allows your site visitors to comment on web pages for any content object.

--- a/docs/source/endpoints/comments.md
+++ b/docs/source/endpoints/comments.md
@@ -11,7 +11,7 @@ myst:
 
 ```{versionchanged} Plone 6.1
 Discussion is disabled by default in Plone 6.1 and later.
-To enable discussion, see the Plone 6.1 upgrade guide section {ref}`backend-upgrade-plone-v61-discussion-label`
+To enable discussion, see the Plone 6.1 upgrade guide section {ref}`backend-upgrade-plone-v61-discussion-label`.
 ```
 
 Discussion is a feature that allows your site visitors to comment on web pages for any content object.

--- a/docs/source/endpoints/comments.md
+++ b/docs/source/endpoints/comments.md
@@ -9,7 +9,12 @@ myst:
 
 # Comments
 
-Plone offers to users a feature to post comments on any content object with `plone.app.discussion`.
+```{note}
+This feature is not enabled by default in Plone 6.1 and later.
+To enable commenting, you need to install the core add-on "Discussion Support" (`plone.app.discussion`).
+```
+
+Plone offers to users a feature to post comments on any content object.
 
 Commenting can be enabled globally for specific content types and for single content objects.
 

--- a/news/1781.bugfix
+++ b/news/1781.bugfix
@@ -1,0 +1,1 @@
+Make plone.app.discussion an optional dependency (core add-on) [@jensens]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ TEST_REQUIRES = [
     "plone.app.caching",
     "plone.app.contenttypes[test]",
     "plone.app.iterate",
+    "plone.app.discussion[test]",
     "plone.app.testing",
     "plone.app.upgrade",
     "plone.api",

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -114,7 +114,7 @@
 
   <include package=".controlpanels" />
 
-    <!-- Summary Serializer Metadata -->
+  <!-- Summary Serializer Metadata -->
   <utility
       factory=".summary.JSONSummarySerializerMetadata"
       name="plone.restapi.summary_serializer_metadata"

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -107,12 +107,14 @@
 
   <adapter factory=".registry.SerializeRegistryToJson" />
 
-  <adapter factory=".discussion.ConversationSerializer" />
-  <adapter factory=".discussion.CommentSerializer" />
+  <configure zcml:condition="installed plone.app.discussion">
+    <adapter factory=".discussion.ConversationSerializer" />
+    <adapter factory=".discussion.CommentSerializer" />
+  </configure>
 
   <include package=".controlpanels" />
 
-  <!-- Summary Serializer Metadata -->
+    <!-- Summary Serializer Metadata -->
   <utility
       factory=".summary.JSONSummarySerializerMetadata"
       name="plone.restapi.summary_serializer_metadata"

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -18,7 +18,10 @@
   <include package=".controlpanels" />
   <include package=".copymove" />
   <include package=".database" />
-  <include package=".discussion" />
+  <include
+      zcml:condition="installed plone.app.discussion"
+      package=".discussion"
+      />
   <include package=".groups" />
   <include package=".navigation" />
   <include package=".contextnavigation" />

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -19,8 +19,8 @@
   <include package=".copymove" />
   <include package=".database" />
   <include
-      zcml:condition="installed plone.app.discussion"
       package=".discussion"
+      zcml:condition="installed plone.app.discussion"
       />
   <include package=".groups" />
   <include package=".navigation" />

--- a/src/plone/restapi/testing.py
+++ b/src/plone/restapi/testing.py
@@ -135,6 +135,9 @@ class PloneRestApiDXLayer(PloneSandboxLayer):
 
         set_supported_languages(portal)
 
+        if portal.portal_setup.profileExists("plone.app.discussion:default"):
+            applyProfile(portal, "plone.app.discussion:default")
+
         applyProfile(portal, "plone.restapi:default")
         applyProfile(portal, "plone.restapi:testing")
         add_catalog_indexes(portal, DX_TYPES_INDEXES)

--- a/src/plone/restapi/tests/statictime.py
+++ b/src/plone/restapi/tests/statictime.py
@@ -114,7 +114,9 @@ class StaticTime:
             # Patch the lightweight p.a.discussion 'Comment' type. Its dates are
             # Python datetimes, unlike DX Content types which use zope DateTimes.
             Comment.creation_date = property(
-                static_creation_date_getter_factory(self.static_created, type_=datetime),
+                static_creation_date_getter_factory(
+                    self.static_created, type_=datetime
+                ),
                 nop_setter,
             )
             Comment.modification_date = property(

--- a/src/plone/restapi/tests/statictime.py
+++ b/src/plone/restapi/tests/statictime.py
@@ -1,13 +1,17 @@
 from datetime import datetime
 from datetime import timezone
 from DateTime import DateTime
-from plone.app.discussion.comment import Comment
 from plone.app.layout.viewlets.content import ContentHistoryViewlet
 from plone.dexterity.content import DexterityContent
 from plone.locking.lockable import TTWLockable
 from plone.restapi.serializer.working_copy import WorkingCopyInfo
 from Products.CMFCore.WorkflowTool import _marker
 from Products.CMFCore.WorkflowTool import WorkflowTool
+
+try:
+    from plone.app.discussion.comment import Comment
+except ImportError:
+    Comment = None
 
 
 _originals = {
@@ -106,19 +110,19 @@ class StaticTime:
         DexterityContent.modification_date = property(
             static_modification_date_getter_factory(self.static_modified), nop_setter
         )
-
-        # Patch the lightweight p.a.discussion 'Comment' type. Its dates are
-        # Python datetimes, unlike DX Content types which use zope DateTimes.
-        Comment.creation_date = property(
-            static_creation_date_getter_factory(self.static_created, type_=datetime),
-            nop_setter,
-        )
-        Comment.modification_date = property(
-            static_modification_date_getter_factory(
-                self.static_modified, type_=datetime
-            ),
-            nop_setter,
-        )
+        if Comment is not None:
+            # Patch the lightweight p.a.discussion 'Comment' type. Its dates are
+            # Python datetimes, unlike DX Content types which use zope DateTimes.
+            Comment.creation_date = property(
+                static_creation_date_getter_factory(self.static_created, type_=datetime),
+                nop_setter,
+            )
+            Comment.modification_date = property(
+                static_modification_date_getter_factory(
+                    self.static_modified, type_=datetime
+                ),
+                nop_setter,
+            )
 
         WorkflowTool.getInfoFor = static_get_info_for_factory(self.static_modified)
 
@@ -138,8 +142,9 @@ class StaticTime:
         ]
         WorkflowTool.getInfoFor = _originals["WorkflowTool.getInfoFor"]
 
-        Comment.modification_date = None
-        Comment.creation_date = None
+        if Comment is not None:
+            Comment.modification_date = None
+            Comment.creation_date = None
 
         WorkingCopyInfo.created = _originals["WorkingCopyInfo.created"]
 

--- a/src/plone/restapi/tests/test_statictime.py
+++ b/src/plone/restapi/tests/test_statictime.py
@@ -299,10 +299,6 @@ class TestStaticTimeWorkingCopy(unittest.TestCase):
 
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(IDiscussionSettings, check=False)
-        settings.globally_enabled = True
-
         transaction.commit()
 
     def create_document(self, id_):


### PR DESCRIPTION
- Turn usage/endpoints of plone.app.discussion features into optional features: ZCML conditions and optionla imports.
- Fix tests to pull in plone.app.discussion explicitly