### PR TITLE
Explicitly globally disable comments in the tests that need it.

### DIFF
--- a/news/244.tests
+++ b/news/244.tests
@@ -1,0 +1,2 @@
+Explicitly globally disable comments in the tests that need it.
+[maurits]

--- a/src/plone/restapi/tests/test_dxcontent_serializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_serializer.py
@@ -527,6 +527,9 @@ class TestDXContentSerializer(unittest.TestCase):
         self.assertEqual(False, obj["allow_discussion"])
 
     def test_allow_discussion_obj_instance_allows_but_not_global_enabled(self):
+        registry = queryUtility(IRegistry)
+        settings = registry.forInterface(IDiscussionSettings, check=False)
+        settings.globally_enabled = False
         self.portal.invokeFactory("Document", id="doc2")
         self.portal.doc2.allow_discussion = True
         serializer = getMultiAdapter((self.portal.doc2, self.request), ISerializeToJson)
@@ -536,6 +539,9 @@ class TestDXContentSerializer(unittest.TestCase):
         self.assertEqual(False, obj["allow_discussion"])
 
     def test_allow_discussion_fti_allows_not_global_enabled(self):
+        registry = queryUtility(IRegistry)
+        settings = registry.forInterface(IDiscussionSettings, check=False)
+        settings.globally_enabled = False
         self.portal.invokeFactory("Document", id="doc2")
         portal_types = getToolByName(self.portal, "portal_types")
         document_fti = getattr(portal_types, self.portal.doc2.portal_type)


### PR DESCRIPTION
In Plone 6.1, when you actively activate plone.app.discussion, we may globally enable comments by default. This is when https://github.com/plone/plone.app.discussion/pull/244 gets merged.

We already had eight or so tests that explicitly globally enable comments. Now we explicitly globally disable them in two others. Then the tests work in Plone 6.0 and 6.1.

See two test failures here for the plone.app.discussion PR: https://jenkins.plone.org/job/pull-request-6.1-3.10/311/

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1805.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->