### PR TITLE
Fix error getting allow_discussion  when p.a.discussion is not activated.

### DIFF
--- a/news/1808.bugfix
+++ b/news/1808.bugfix
@@ -1,0 +1,2 @@
+Fix error getting allow_discussion value when p.a.discussion is not activated.
+[maurits]

--- a/src/plone/restapi/tests/http-examples/jwt_logged_in.resp
+++ b/src/plone/restapi/tests/http-examples/jwt_logged_in.resp
@@ -31,7 +31,7 @@ Content-Type: application/json
     "@id": "http://localhost:55001/plone",
     "@type": "Plone Site",
     "UID": "55c25ebc220d400393574f37d648727c",
-    "allow_discussion": null,
+    "allow_discussion": false,
     "contributors": [],
     "creators": [
         "admin"

--- a/src/plone/restapi/tests/http-examples/navroot_site_get.resp
+++ b/src/plone/restapi/tests/http-examples/navroot_site_get.resp
@@ -33,7 +33,7 @@ Content-Type: application/json
         "@id": "http://localhost:55001/plone",
         "@type": "Plone Site",
         "UID": "55c25ebc220d400393574f37d648727c",
-        "allow_discussion": null,
+        "allow_discussion": false,
         "contributors": [],
         "creators": [
             "admin"

--- a/src/plone/restapi/tests/http-examples/navroot_standard_site_content_get.resp
+++ b/src/plone/restapi/tests/http-examples/navroot_standard_site_content_get.resp
@@ -33,7 +33,7 @@ Content-Type: application/json
         "@id": "http://localhost:55001/plone",
         "@type": "Plone Site",
         "UID": "55c25ebc220d400393574f37d648727c",
-        "allow_discussion": null,
+        "allow_discussion": false,
         "contributors": [],
         "creators": [
             "admin"

--- a/src/plone/restapi/tests/http-examples/navroot_standard_site_content_get_expansion.resp
+++ b/src/plone/restapi/tests/http-examples/navroot_standard_site_content_get_expansion.resp
@@ -50,7 +50,7 @@ Content-Type: application/json
                 "@id": "http://localhost:55001/plone",
                 "@type": "Plone Site",
                 "UID": "55c25ebc220d400393574f37d648727c",
-                "allow_discussion": null,
+                "allow_discussion": false,
                 "contributors": [],
                 "creators": [
                     "admin"

--- a/src/plone/restapi/tests/http-examples/navroot_standard_site_get.resp
+++ b/src/plone/restapi/tests/http-examples/navroot_standard_site_get.resp
@@ -33,7 +33,7 @@ Content-Type: application/json
         "@id": "http://localhost:55001/plone",
         "@type": "Plone Site",
         "UID": "55c25ebc220d400393574f37d648727c",
-        "allow_discussion": null,
+        "allow_discussion": false,
         "contributors": [],
         "creators": [
             "admin"

--- a/src/plone/restapi/tests/http-examples/navroot_standard_site_get_expansion.resp
+++ b/src/plone/restapi/tests/http-examples/navroot_standard_site_get_expansion.resp
@@ -50,7 +50,7 @@ Content-Type: application/json
                 "@id": "http://localhost:55001/plone",
                 "@type": "Plone Site",
                 "UID": "55c25ebc220d400393574f37d648727c",
-                "allow_discussion": null,
+                "allow_discussion": false,
                 "contributors": [],
                 "creators": [
                     "admin"
@@ -101,7 +101,7 @@ Content-Type: application/json
     "@id": "http://localhost:55001/plone",
     "@type": "Plone Site",
     "UID": "55c25ebc220d400393574f37d648727c",
-    "allow_discussion": null,
+    "allow_discussion": false,
     "contributors": [],
     "creators": [
         "admin"

--- a/src/plone/restapi/tests/http-examples/site_get_expand_navroot.resp
+++ b/src/plone/restapi/tests/http-examples/site_get_expand_navroot.resp
@@ -50,7 +50,7 @@ Content-Type: application/json
                 "@id": "http://localhost:55001/plone",
                 "@type": "Plone Site",
                 "UID": "55c25ebc220d400393574f37d648727c",
-                "allow_discussion": null,
+                "allow_discussion": false,
                 "contributors": [],
                 "creators": [
                     "admin"
@@ -125,7 +125,7 @@ Content-Type: application/json
     "@id": "http://localhost:55001/plone",
     "@type": "Plone Site",
     "UID": "55c25ebc220d400393574f37d648727c",
-    "allow_discussion": null,
+    "allow_discussion": false,
     "contributors": [],
     "creators": [
         "admin"

--- a/src/plone/restapi/tests/http-examples/siteroot.resp
+++ b/src/plone/restapi/tests/http-examples/siteroot.resp
@@ -31,7 +31,7 @@ Content-Type: application/json
     "@id": "http://localhost:55001/plone",
     "@type": "Plone Site",
     "UID": "55c25ebc220d400393574f37d648727c",
-    "allow_discussion": null,
+    "allow_discussion": false,
     "contributors": [],
     "creators": [
         "admin"


### PR DESCRIPTION
This fixes an error in Plone 6.1 when the `plone.app.discussion` package is available but not activated in the Add-ons. Problem is that the `conversation_view` is only defined when the browser layer of `plone.app.discussion` is found. Traceback:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 181, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 391, in publish_module
  Module ZPublisher.WSGIPublisher, line 285, in publish
  Module ZPublisher.mapply, line 98, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module plone.rest.service, line 21, in __call__
  Module plone.restapi.services, line 19, in render
  Module plone.restapi.services.content.get, line 16, in reply
  Module plone.restapi.serializer.dxcontent, line 179, in __call__
  Module plone.restapi.serializer.dxcontent, line 142, in __call__
  Module plone.restapi.serializer.dxcontent, line 48, in get_allow_discussion_value
  Module zope.component._api, line 113, in getMultiAdapter
zope.interface.interfaces.ComponentLookupError:
 ((<FolderishDocument at /PloneVolto/page>,
   <WSGIRequest, URL=http://localhost:8080/PloneVolto/++api++/page/GET_application_json_>),
 <InterfaceClass zope.interface.Interface>, 'conversation_view')
```

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1808.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->