### PR TITLE
Fix invalid values in RelationListFieldSerializer.

### DIFF
--- a/news/1818.bugfix
+++ b/news/1818.bugfix
@@ -1,0 +1,1 @@
+Fix response of `RelationListFieldSerializer` by filtering out invalid items. @Faakhir30

--- a/src/plone/restapi/serializer/relationfield.py
+++ b/src/plone/restapi/serializer/relationfield.py
@@ -7,7 +7,6 @@ from plone.restapi.serializer.dxfields import DefaultFieldSerializer
 from z3c.relationfield.interfaces import IRelationChoice
 from z3c.relationfield.interfaces import IRelationList
 from z3c.relationfield.interfaces import IRelationValue
-from z3c.relationfield import RelationValue
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
@@ -48,6 +47,4 @@ class RelationListFieldSerializer(DefaultFieldSerializer):
         )
         if not value:
             return []
-        if isinstance(value, RelationValue):
-            return [value]
         return [el for el in value if el.to_object]

--- a/src/plone/restapi/serializer/relationfield.py
+++ b/src/plone/restapi/serializer/relationfield.py
@@ -42,9 +42,7 @@ class RelationListFieldSerializer(DefaultFieldSerializer):
         Returns:
             list: List of RelationValues
         """
-        value = getattr(
-            self.field.interface(self.context), self.field.__name__, default
-        )
+        value = super().get_value()
         if not value:
             return []
-        return [el for el in value if el.to_object]
+        return [el for el in value if el.to_id]

--- a/src/plone/restapi/serializer/relationfield.py
+++ b/src/plone/restapi/serializer/relationfield.py
@@ -7,6 +7,7 @@ from plone.restapi.serializer.dxfields import DefaultFieldSerializer
 from z3c.relationfield.interfaces import IRelationChoice
 from z3c.relationfield.interfaces import IRelationList
 from z3c.relationfield.interfaces import IRelationValue
+from z3c.relationfield import RelationValue
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
@@ -33,4 +34,20 @@ class RelationChoiceFieldSerializer(DefaultFieldSerializer):
 @adapter(IRelationList, IDexterityContent, Interface)
 @implementer(IFieldSerializer)
 class RelationListFieldSerializer(DefaultFieldSerializer):
-    pass
+    def get_value(self, default=[]):
+        """Return field value reduced to list of non-broken Relationvalues.
+
+        Args:
+            default (list, optional): Default field value. Defaults to empty list.
+
+        Returns:
+            list: List of RelationValues
+        """
+        value = getattr(
+            self.field.interface(self.context), self.field.__name__, default
+        )
+        if not value:
+            return []
+        if isinstance(value, RelationValue):
+            return [value]
+        return [el for el in value if el.to_object]

--- a/src/plone/restapi/tests/test_dxcontent_serializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_serializer.py
@@ -28,6 +28,7 @@ from zope.component import provideAdapter
 from zope.component import queryUtility
 from zope.interface import Interface
 from z3c.relationfield import RelationValue
+from z3c.relationfield.event import _setRelation
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 from zope.publisher.interfaces.browser import IBrowserRequest
@@ -201,10 +202,14 @@ class TestDXContentSerializer(unittest.TestCase):
             "DXTestDocument",
             id="doc2",
         )
+        rel1 = RelationValue(intids.getId(self.portal.doc1))
+        rel2 = RelationValue(intids.getId(self.portal.doc2))
         self.portal.doc1.test_relationlist_field = [
-            RelationValue(intids.getId(self.portal.doc1)),
-            RelationValue(intids.getId(self.portal.doc2)),
+            rel1,
+            rel2,
         ]
+        _setRelation(self.portal.doc1, "test_relationlist_field", rel1)
+        _setRelation(self.portal.doc1, "test_relationlist_field", rel2)
         # delete doc2 to make sure we have a None value in the relation list
         self.portal.manage_delObjects(["doc2"])
 


### PR DESCRIPTION
Closes #1745 

Filtered `NoneType` items from the resulting list at `RelationListFieldSerializer`.

I guess we don't need to update this also in `RelationChoiceFieldSerializer`,  as it is returning a single `RelationValue` or `None` value, so it should be fine this way.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1818.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->