### PR TITLE
Fix spelling of prerequisites

### DIFF
--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -13,9 +13,9 @@ This section describes how to contribute to the `plone.restapi` project.
 It extends {doc}`plone:contributing/index`.
 
 
-## Pre-requisites
+## Prerequisites
 
-Prepare your system by installing {ref}`plone:plone-pre-requisites-label`.
+Prepare your system by installing {ref}`plone:plone-prerequisites-label`.
 
 
 ## Set up development environment

--- a/news/1822.documentation
+++ b/news/1822.documentation
@@ -1,0 +1,1 @@
+Fixed spelling of prerequisites. @stevepiercy


### PR DESCRIPTION
See https://github.com/plone/documentation/issues/1720

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1822.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->