### PR TITLE
Allows working copy of the Portal

### DIFF
--- a/news/1823.feature
+++ b/news/1823.feature
@@ -1,1 +1,1 @@
-Allows working copy of the Portal. @wesleybl
+Support working copies of the Plone Site. This feature is available when using `plone.app.iterate` 6.1.0 or later. @wesleybl

--- a/news/1823.feature
+++ b/news/1823.feature
@@ -1,0 +1,1 @@
+Allows working copy of the Portal. @wesleybl

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -6,7 +6,6 @@ from plone.autoform.interfaces import READ_PERMISSIONS_KEY
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import iterSchemata
-from plone.restapi import HAS_PLONE_6
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.bbb import base_hasattr
 from plone.restapi.deserializer import boolean_value
@@ -47,12 +46,12 @@ def update_with_working_copy_info(context, result):
     if WorkingCopyInfo is None:
         return
 
-    # Does not return working copy information when serializing Portal in Plone 5.2.
-    if not HAS_PLONE_6 and context.portal_type == "Plone Site":
-        return
-
     working_copy_info = WorkingCopyInfo(context)
-    baseline, working_copy = working_copy_info.get_working_copy_info()
+    try:
+        baseline, working_copy = working_copy_info.get_working_copy_info()
+    except TypeError:
+        # not supported for this content type
+        return
     result.update({"working_copy": working_copy, "working_copy_of": baseline})
 
 

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -42,6 +42,12 @@ except ImportError:
     WorkingCopyInfo = None
 
 
+def update_with_working_copy_info(context, result):
+    if WorkingCopyInfo is not None:
+        baseline, working_copy = WorkingCopyInfo(context).get_working_copy_info()
+        result.update({"working_copy": working_copy, "working_copy_of": baseline})
+
+
 def get_allow_discussion_value(context, request, result):
     # This test is to handle the situation of plone.app.discussion not being installed
     # or not being activated.
@@ -108,11 +114,7 @@ class SerializeToJson:
             result.update({"previous_item": {}, "next_item": {}})
 
         # Insert working copy information
-        if WorkingCopyInfo is not None:
-            baseline, working_copy = WorkingCopyInfo(
-                self.context
-            ).get_working_copy_info()
-            result.update({"working_copy": working_copy, "working_copy_of": baseline})
+        update_with_working_copy_info(self.context, result)
 
         # Insert locking information
         result.update({"lock": lock_info(obj)})

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -6,6 +6,7 @@ from plone.autoform.interfaces import READ_PERMISSIONS_KEY
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import iterSchemata
+from plone.restapi import HAS_PLONE_6
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.deserializer import boolean_value
 from plone.restapi.interfaces import IFieldSerializer
@@ -43,9 +44,16 @@ except ImportError:
 
 
 def update_with_working_copy_info(context, result):
-    if WorkingCopyInfo is not None:
-        baseline, working_copy = WorkingCopyInfo(context).get_working_copy_info()
-        result.update({"working_copy": working_copy, "working_copy_of": baseline})
+    if WorkingCopyInfo is None:
+        return
+
+    # Does not return working copy information when serializing Portal in Plone 5.2.
+    if not HAS_PLONE_6 and context.portal_type == "Plone Site":
+        return
+
+    working_copy_info = WorkingCopyInfo(context)
+    baseline, working_copy = working_copy_info.get_working_copy_info()
+    result.update({"working_copy": working_copy, "working_copy_of": baseline})
 
 
 def get_allow_discussion_value(context, request, result):

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -12,6 +12,7 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.dxcontent import get_allow_discussion_value
+from plone.restapi.serializer.dxcontent import update_with_working_copy_info
 from plone.restapi.serializer.expansion import expandable_elements
 from plone.restapi.serializer.utils import get_portal_type_title
 from plone.restapi.services.locking import lock_info
@@ -25,6 +26,7 @@ from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema import getFields
 from zope.security.interfaces import IPermission
+
 
 import json
 
@@ -73,6 +75,9 @@ class SerializeSiteRootToJson:
             "is_folderish": True,
             "description": self.context.description,
         }
+
+        # Insert working copy information
+        update_with_working_copy_info(self.context, result)
 
         if HAS_PLONE_6:
             result["UID"] = self.context.UID()

--- a/src/plone/restapi/services/workingcopy/configure.zcml
+++ b/src/plone/restapi/services/workingcopy/configure.zcml
@@ -39,4 +39,37 @@
       name="@workingcopy"
       />
 
+  <plone:service
+      method="GET"
+      factory=".get.GetWorkingCopy"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      permission="zope2.View"
+      name="@workingcopy"
+      />
+
+  <plone:service
+      method="POST"
+      factory=".create.CreateWorkingCopy"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      permission="plone.app.iterate.CheckOutContent"
+      name="@workingcopy"
+      />
+
+
+  <plone:service
+      method="PATCH"
+      factory=".update.UpdateWorkingCopy"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      permission="plone.app.iterate.CheckInContent"
+      name="@workingcopy"
+      />
+
+  <plone:service
+      method="DELETE"
+      factory=".delete.DeleteWorkingCopy"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      permission="zope2.DeleteObjects"
+      name="@workingcopy"
+      />
+
 </configure>


### PR DESCRIPTION
This is part of: https://github.com/plone/volto/issues/5284

Allows working copy services to be accessed in the Portal. Also returns working copy data in the Portal serialization.

In Plone 6.0, this PR should be tested together with the following PRs:

https://github.com/plone/plone.app.iterate/pull/128
https://github.com/plone/Products.CMFEditions/pull/113

In Plone 6.1, the `plone.app.iterate` PR should be replaced with:

https://github.com/plone/plone.app.iterate/pull/130

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1823.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->