### PR TITLE
Add a way to check for backend support of version-dependent features via the site service

### DIFF
--- a/news/1826.feature
+++ b/news/1826.feature
@@ -1,0 +1,1 @@
+Site service: Indicate whether the site supports filtering URL aliases by date. @davisagli

--- a/src/plone/restapi/services/site/get.py
+++ b/src/plone/restapi/services/site/get.py
@@ -81,9 +81,12 @@ class Site:
         This can be used by a client to check for version-dependent features.
         """
         result = {
-            "filter_aliases_by_date": hasattr(RedirectionSet, "supports_date_range_filtering"),
+            "filter_aliases_by_date": hasattr(
+                RedirectionSet, "supports_date_range_filtering"
+            ),
         }
         return result
+
 
 class SiteGet(Service):
     def reply(self):

--- a/src/plone/restapi/services/site/get.py
+++ b/src/plone/restapi/services/site/get.py
@@ -10,6 +10,7 @@ from plone.restapi.services import Service
 from Products.CMFPlone.interfaces import IImagingSchema
 from Products.CMFPlone.interfaces import ISiteSchema
 from Products.CMFPlone.utils import getSiteLogo
+from Products.CMFPlone.controlpanel.browser.redirects import RedirectionSet
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -49,6 +50,7 @@ class Site:
                 "plone.default_language": language_settings.default_language,
                 "plone.available_languages": language_settings.available_languages,
                 "plone.portal_timezone": self.plone_timezone(),
+                "features": self.features(),
             }
         )
 
@@ -73,6 +75,15 @@ class Site:
 
         return portal_timezone
 
+    def features(self):
+        """Indicates which features are supported by this site.
+
+        This can be used by a client to check for version-dependent features.
+        """
+        result = {
+            "filter_aliases_by_date": hasattr(RedirectionSet, "supports_date_range_filtering"),
+        }
+        return result
 
 class SiteGet(Service):
     def reply(self):

--- a/src/plone/restapi/tests/http-examples/site_get.resp
+++ b/src/plone/restapi/tests/http-examples/site_get.resp
@@ -3,6 +3,9 @@ Content-Type: application/json
 
 {
     "@id": "http://localhost:55001/plone/@site",
+    "features": {
+        "filter_aliases_by_date": false
+    },
     "plone.allowed_sizes": [
         "huge 1600:65536",
         "great 1200:65536",


### PR DESCRIPTION
I need this because some new filters were added in CMFPlone for the URL Management control panel, and I want to add support for them in volto, but it needs to check whether it's talking to a backend that supports them.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1826.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->