### PR TITLE
Make sure CMFPlone's permissions are loaded

### DIFF
--- a/news/1827.bugfix
+++ b/news/1827.bugfix
@@ -1,0 +1,1 @@
+Fix `ComponentLookupError` for `Products.CMFPlone.ManagePortalAliases` permission, which could happen depending on package load order. @davisagli

--- a/src/plone/restapi/configure.zcml
+++ b/src/plone/restapi/configure.zcml
@@ -22,6 +22,7 @@
   <include package="plone.behavior" />
   <include package="plone.rest" />
   <include package="plone.schema" />
+  <include package="Products.CMFPlone" />
 
   <include
       package="plone.app.caching"


### PR DESCRIPTION
This fixes a `zope.interface.interfaces.ComponentLookupError: (<InterfaceClass zope.security.interfaces.IPermission>, 'Products.CMFPlone.ManagePortalAliases')` which can happen depending on the order in which packages load.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1827.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->