### PR TITLE
Handle parentheses search queries

### DIFF
--- a/news/1828.bugfix
+++ b/news/1828.bugfix
@@ -1,1 +1,1 @@
-Fix error when search query contains parantheses. @tedw87
+Removed parentheses from search query. @tedw87

--- a/news/1828.bugfix
+++ b/news/1828.bugfix
@@ -1,0 +1,1 @@
+Fix error when search query contains parantheses. @tedw87

--- a/news/1828.bugfix
+++ b/news/1828.bugfix
@@ -1,1 +1,1 @@
-Removed parentheses from search query. @tedw87
+`@search` service: Remove parentheses from search query. @tedw87

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -77,7 +77,7 @@ class SearchHandler:
 
     def quote_chars(self, query):
         # Escape parentheses by adding backslashes before them
-        return query.replace('(', '').replace(')', '').strip()
+        return query.replace("(", "").replace(")", "").strip()
 
     def search(self, query=None):
         if query is None:

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -75,6 +75,10 @@ class SearchHandler:
             path = "/".join(self.context.getPhysicalPath())
             query["path"]["query"] = path
 
+    def quote_chars(self, query):
+        # Escape parentheses by adding backslashes before them
+        return query.replace('(', '').replace(')', '').strip()
+
     def search(self, query=None):
         if query is None:
             query = {}
@@ -92,6 +96,12 @@ class SearchHandler:
 
         if use_site_search_settings:
             query = self.filter_query(query)
+
+        if "SearchableText" in query:
+            # Sanitize SearchableText by removing parentheses
+            query["SearchableText"] = self.quote_chars(query["SearchableText"])
+            if not query["SearchableText"] or query["SearchableText"] == "*":
+                return []
 
         self._constrain_query_by_path(query)
         query = self._parse_query(query)

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -76,7 +76,7 @@ class SearchHandler:
             query["path"]["query"] = path
 
     def quote_chars(self, query):
-        # Escape parentheses by adding backslashes before them
+        # Remove parentheses from the query
         return query.replace("(", "").replace(")", "").strip()
 
     def search(self, query=None):

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -77,7 +77,7 @@ class SearchHandler:
 
     def quote_chars(self, query):
         # Remove parentheses from the query
-        return query.replace("(", "").replace(")", "").strip()
+        return query.replace("(", " ").replace(")", " ").strip()
 
     def search(self, query=None):
         if query is None:
@@ -110,7 +110,6 @@ class SearchHandler:
         results = getMultiAdapter((lazy_resultset, self.request), ISerializeToJson)(
             fullobjects=fullobjects
         )
-
         return results
 
     def filter_types(self, types):

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -151,6 +151,23 @@ class TestSearchFunctional(unittest.TestCase):
             set(result_paths(response.json())),
         )
 
+    def test_search_with_parentheses(self):
+        query = {"SearchableText": "("}
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [], "Expected no items for query with only parentheses")
+
+        query = {"SearchableText": ")"}
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [], "Expected no items for query with only parentheses")
+
+        query = {"SearchableText": "lorem(ipsum)"}
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200)
+        items = [item["title"] for item in response.json().get("items", [])]
+        self.assertIn("Lorem Ipsum", items, "Expected 'Lorem Ipsum' to be found in search results")
+
     def test_search_in_vhm(self):
         # Install a Virtual Host Monster
         if "virtual_hosting" not in self.app.objectIds():

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -153,50 +153,26 @@ class TestSearchFunctional(unittest.TestCase):
 
     def test_search_with_parentheses(self):
         query = {"SearchableText": "("}
-        response = self.api_session.get(
-            "/@search", 
-            params=query
-            )
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.status_code, 
-            200
-            )
-        self.assertEqual(
-            response.json(),
-            [], 
-            "Expected no items for query with only parentheses"
-            )
+            response.json(), [], "Expected no items for query with only parentheses"
+        )
 
         query = {"SearchableText": ")"}
-        response = self.api_session.get(
-            "/@search", 
-            params=query
-            )
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.status_code, 
-            200
-            )
-        self.assertEqual(
-            response.json(), 
-            [], 
-            "Expected no items for query with only parentheses"
-            )
+            response.json(), [], "Expected no items for query with only parentheses"
+        )
 
         query = {"SearchableText": "lorem(ipsum)"}
-        response = self.api_session.get(
-            "/@search", 
-            params=query
-            )
-        self.assertEqual(
-            response.status_code, 
-            200
-            )
+        response = self.api_session.get("/@search", params=query)
+        self.assertEqual(response.status_code, 200)
         items = [item["title"] for item in response.json().get("items", [])]
         self.assertIn(
-            "Lorem Ipsum", 
-            items, 
-            "Expected 'Lorem Ipsum' to be found in search results"
-            )
+            "Lorem Ipsum", items, "Expected 'Lorem Ipsum' to be found in search results"
+        )
 
     def test_search_in_vhm(self):
         # Install a Virtual Host Monster

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -153,20 +153,50 @@ class TestSearchFunctional(unittest.TestCase):
 
     def test_search_with_parentheses(self):
         query = {"SearchableText": "("}
-        response = self.api_session.get("/@search", params=query)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [], "Expected no items for query with only parentheses")
+        response = self.api_session.get(
+            "/@search", 
+            params=query
+            )
+        self.assertEqual(
+            response.status_code, 
+            200
+            )
+        self.assertEqual(
+            response.json(),
+            [], 
+            "Expected no items for query with only parentheses"
+            )
 
         query = {"SearchableText": ")"}
-        response = self.api_session.get("/@search", params=query)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [], "Expected no items for query with only parentheses")
+        response = self.api_session.get(
+            "/@search", 
+            params=query
+            )
+        self.assertEqual(
+            response.status_code, 
+            200
+            )
+        self.assertEqual(
+            response.json(), 
+            [], 
+            "Expected no items for query with only parentheses"
+            )
 
         query = {"SearchableText": "lorem(ipsum)"}
-        response = self.api_session.get("/@search", params=query)
-        self.assertEqual(response.status_code, 200)
+        response = self.api_session.get(
+            "/@search", 
+            params=query
+            )
+        self.assertEqual(
+            response.status_code, 
+            200
+            )
         items = [item["title"] for item in response.json().get("items", [])]
-        self.assertIn("Lorem Ipsum", items, "Expected 'Lorem Ipsum' to be found in search results")
+        self.assertIn(
+            "Lorem Ipsum", 
+            items, 
+            "Expected 'Lorem Ipsum' to be found in search results"
+            )
 
     def test_search_in_vhm(self):
         # Install a Virtual Host Monster


### PR DESCRIPTION
This PR introduces a fix to handle parentheses  in the search functionality.
There is an error when query contains parantheses.
`ParseError
Token <Token:EOF> required, '(' found`

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1828.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->