### PR TITLE
Change login name after changing email in sites where "use email as login" is enabled

### DIFF
--- a/news/1835.bugfix
+++ b/news/1835.bugfix
@@ -1,0 +1,2 @@
+Fix log in after changing email when "email as login" is enabled
+[erral]

--- a/src/plone/restapi/services/users/update.py
+++ b/src/plone/restapi/services/users/update.py
@@ -104,6 +104,11 @@ class UsersPatch(Service):
                         self.set_member_portrait(user, value)
                     user.setMemberProperties(mapping={key: value}, force_empty=True)
 
+            if security.use_email_as_login and "email" in user_settings_to_update:
+                value = user_settings_to_update["email"]
+                pas = getToolByName(self.context, "acl_users")
+                pas.updateLoginName(user.getId(), value)
+
             roles = user_settings_to_update.get("roles", {})
             if roles:
                 to_add = [key for key, enabled in roles.items() if enabled]
@@ -141,6 +146,10 @@ class UsersPatch(Service):
                     if key == "portrait" and isinstance(value, dict):
                         self.set_member_portrait(user, value)
                     user.setMemberProperties(mapping={key: value}, force_empty=True)
+
+            if security.use_email_as_login and "email" in user_settings_to_update:
+                value = user_settings_to_update["email"]
+                set_own_login_name(user, value)
 
         else:
             if self._is_anonymous:

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -1436,3 +1436,56 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertEqual(
             "manager@example.com", api.user.get(userid="manager").getProperty("email")
         )
+
+    def test_user_email_change_login_with_email(self):
+        """test that when login with email is enabled and the user changes their email
+        they can log in with the new email
+        """
+        # enable use_email_as_login
+        security_settings = getAdapter(self.portal, ISecuritySchema)
+        security_settings.use_email_as_login = True
+        transaction.commit()
+        # Create a user
+        response = self.api_session.post(
+            "/@users",
+            json={
+                "email": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        transaction.commit()
+        anon_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(anon_response.ok)
+        auth_token = anon_response.json().get("token")
+
+        user_api_session = RelativeSession(self.portal_url, test=self)
+        user_api_session.headers.update({"Accept": "application/json"})
+        user_api_session.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+        email_change_response = user_api_session.patch(
+            "/@users/howard.zinn@example.com",
+            json={"email": "new_email@example.com"},
+        )
+        self.assertTrue(email_change_response.ok)
+        new_login_with_old_email_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertFalse(new_login_with_old_email_response.ok)
+        new_login_with_new_email_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "new_email@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(new_login_with_new_email_response.ok)

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -1453,6 +1453,9 @@ class TestUsersEndpoint(unittest.TestCase):
                 "password": TEST_USER_PASSWORD,
             },
         )
+        self.assertTrue(response.ok)
+        userid = response.json()["id"]
+
         transaction.commit()
         anon_response = self.anon_api_session.post(
             "/@login",
@@ -1464,12 +1467,11 @@ class TestUsersEndpoint(unittest.TestCase):
         self.assertTrue(anon_response.ok)
 
         email_change_response = self.api_session.patch(
-            "/@users/howard.zinn@example.com",
+            f"/@users/{userid}",
             json={
                 "email": "new_email@example.com",
             },
         )
-
         self.assertTrue(email_change_response.ok)
         new_login_with_old_email_response = self.anon_api_session.post(
             "/@login",
@@ -1504,6 +1506,9 @@ class TestUsersEndpoint(unittest.TestCase):
                 "password": TEST_USER_PASSWORD,
             },
         )
+        self.assertTrue(response.ok)
+        userid = response.json()["id"]
+
         transaction.commit()
         anon_response = self.anon_api_session.post(
             "/@login",
@@ -1520,9 +1525,127 @@ class TestUsersEndpoint(unittest.TestCase):
         user_api_session.headers.update({"Authorization": f"Bearer {auth_token}"})
 
         email_change_response = user_api_session.patch(
-            "/@users/howard.zinn@example.com",
+            f"/@users/{userid}",
             json={"email": "new_email@example.com"},
         )
+
+        self.assertTrue(email_change_response.ok)
+        new_login_with_old_email_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertFalse(new_login_with_old_email_response.ok)
+        new_login_with_new_email_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "new_email@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(new_login_with_new_email_response.ok)
+
+    def test_manager_changes_email_when_login_with_email_and_uuid_userids(self):
+        """test that when login with email is enabled and a manager changes a user's email
+        they can log in with the new email.
+
+        The site is configured to save userids as uuid
+
+        """
+        # enable use_email_as_login
+        security_settings = getAdapter(self.portal, ISecuritySchema)
+        security_settings.use_email_as_login = True
+        security_settings.use_uuid_as_userid = True
+        transaction.commit()
+        # Create a user
+        response = self.api_session.post(
+            "/@users",
+            json={
+                "email": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(response.ok)
+        userid = response.json()["id"]
+        transaction.commit()
+        anon_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(anon_response.ok)
+
+        email_change_response = self.api_session.patch(
+            f"/@users/{userid}",
+            json={
+                "email": "new_email@example.com",
+            },
+        )
+        self.assertTrue(email_change_response.ok)
+        new_login_with_old_email_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertFalse(new_login_with_old_email_response.ok)
+        new_login_with_new_email_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "new_email@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(new_login_with_new_email_response.ok)
+
+    def test_user_changes_email_when_login_with_email_and_uuid_userids(self):
+        """test that when login with email is enabled and the user changes their email
+        they can log in with the new email
+
+        The site is configured to save userids as uuid
+
+        """
+        # enable use_email_as_login
+        security_settings = getAdapter(self.portal, ISecuritySchema)
+        security_settings.use_email_as_login = True
+        security_settings.use_uuid_as_userid = True
+
+        transaction.commit()
+        # Create a user
+        response = self.api_session.post(
+            "/@users",
+            json={
+                "email": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(response.ok)
+        userid = response.json()["id"]
+        transaction.commit()
+        anon_response = self.anon_api_session.post(
+            "/@login",
+            json={
+                "login": "howard.zinn@example.com",
+                "password": TEST_USER_PASSWORD,
+            },
+        )
+        self.assertTrue(anon_response.ok)
+        auth_token = anon_response.json().get("token")
+
+        user_api_session = RelativeSession(self.portal_url, test=self)
+        user_api_session.headers.update({"Accept": "application/json"})
+        user_api_session.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+        email_change_response = user_api_session.patch(
+            f"/@users/{userid}",
+            json={"email": "new_email@example.com"},
+        )
+
         self.assertTrue(email_change_response.ok)
         new_login_with_old_email_response = self.anon_api_session.post(
             "/@login",


### PR DESCRIPTION
Fixes #1835 

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1836.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->