### PR TITLE
additional tests

### DIFF
--- a/news/1840.internal
+++ b/news/1840.internal
@@ -1,0 +1,2 @@
+Additional tests to login name changes
+[erral]

--- a/src/plone/restapi/services/users/update.py
+++ b/src/plone/restapi/services/users/update.py
@@ -107,7 +107,20 @@ class UsersPatch(Service):
             if security.use_email_as_login and "email" in user_settings_to_update:
                 value = user_settings_to_update["email"]
                 pas = getToolByName(self.context, "acl_users")
-                pas.updateLoginName(user.getId(), value)
+
+                try:
+                    pas.updateLoginName(user.getId(), value)
+                except ValueError:
+                    return self._error(
+                        400,
+                        "Bad request",
+                        _(
+                            "Cannot update login name of user to '${new_email}'.",
+                            mapping={
+                                "new_email": value,
+                            },
+                        ),
+                    )
 
             roles = user_settings_to_update.get("roles", {})
             if roles:
@@ -149,7 +162,17 @@ class UsersPatch(Service):
 
             if security.use_email_as_login and "email" in user_settings_to_update:
                 value = user_settings_to_update["email"]
-                set_own_login_name(user, value)
+                try:
+                    set_own_login_name(user, value)
+                except ValueError:
+                    return self._error(
+                        400,
+                        "Bad request",
+                        _(
+                            "Cannot update login name of user to '${new_email}'.",
+                            mapping={"new_email": value},
+                        ),
+                    )
 
         else:
             if self._is_anonymous:

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -1714,6 +1714,12 @@ class TestUsersEndpoint(unittest.TestCase):
             },
         )
         self.assertFalse(email_change_response.ok)
+        self.assertEqual(email_change_response.status_code, 400)
+        email_change_response_json = email_change_response.json()
+        self.assertEqual(
+            email_change_response_json.get("error", {}).get("message"),
+            "Cannot update login name of user to 'second@example.com'.",
+        )
 
         # Email was not changed, so log in with the old one
         new_login_with_old_email_response = self.anon_api_session.post(
@@ -1777,7 +1783,12 @@ class TestUsersEndpoint(unittest.TestCase):
             json={"email": "second@example.com"},
         )
 
-        self.assertFalse(email_change_response.ok)
+        self.assertEqual(email_change_response.status_code, 400)
+        email_change_response_json = email_change_response.json()
+        self.assertEqual(
+            email_change_response_json.get("error", {}).get("message"),
+            "Cannot update login name of user to 'second@example.com'.",
+        )
 
         # email was not changed, so log in with the old one
         new_login_with_old_email_response = self.anon_api_session.post(


### PR DESCRIPTION
As a follow-up of #1836, I add additional tests showing that we return an error when trying to change a login to an existing one (see https://github.com/plone/plone.restapi/pull/1836#pullrequestreview-2424965276)

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1840.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->