### PR TITLE
Fix linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -290,7 +290,7 @@ html_use_index = True
 # base URL from which the finished HTML is served.
 # Announce that we have an opensearch plugin
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_use_opensearch
-html_use_opensearch = "https://plonerestapi.readthedocs.org/"
+html_use_opensearch = "https://plonerestapi.readthedocs.org"
 
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").

--- a/news/1846.documentation
+++ b/news/1846.documentation
@@ -1,0 +1,1 @@
+`html_use_opensearch` value must not have a trailing slash. Clean up comments. @stevepiercy


### PR DESCRIPTION
- html_use_opensearch value must not have a trailing slash
- Clean up comments

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1846.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->