### PR TITLE
Handle aliases in path2uid

### DIFF
--- a/news/1848.bugfix
+++ b/news/1848.bugfix
@@ -1,0 +1,1 @@
+Fix resolving paths in deserializer if the target was moved in the same request. @cekk

--- a/news/1848.feature
+++ b/news/1848.feature
@@ -1,0 +1,1 @@
+Handle aliases in path2uid to resolve also paths of renamed contents. @cekk

--- a/news/1848.feature
+++ b/news/1848.feature
@@ -1,1 +1,0 @@
-Handle aliases in path2uid to resolve also paths of renamed contents. @cekk

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -737,4 +737,4 @@ class TestBlocksDeserializer(unittest.TestCase):
 
         res = self.deserialize(blocks=blocks)
         link = res.blocks["abc"]["href"]
-        self.assertTrue(link.startswith("../resolveuid/"))
+        self.assertEqual(link, f"../resolveuid/{self.portal['renamed-doc'].UID()}")

--- a/src/plone/restapi/tests/test_blocks_deserializer.py
+++ b/src/plone/restapi/tests/test_blocks_deserializer.py
@@ -1,3 +1,4 @@
+from plone import api
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.interfaces import IDexterityItem
 from plone.restapi.behaviors import IBlocks
@@ -724,3 +725,16 @@ class TestBlocksDeserializer(unittest.TestCase):
         res = self.deserialize(blocks=blocks)
         self.assertTrue(res.blocks["123"]["url"].startswith("../resolveuid/"))
         self.assertNotIn("image_scales", res.blocks["123"])
+
+    def test_deserializer_resolve_path_also_if_it_is_an_alias(self):
+
+        self.portal.invokeFactory(
+            "Document",
+            id="doc",
+        )
+        api.content.move(source=self.portal.doc, id="renamed-doc")
+        blocks = {"abc": {"href": "%s/doc" % self.portal.absolute_url()}}
+
+        res = self.deserialize(blocks=blocks)
+        link = res.blocks["abc"]["href"]
+        self.assertTrue(link.startswith("../resolveuid/"))


### PR DESCRIPTION
It's me..again ;)

This time, my edge-case is:

I have a parent Document (/aaa) with some contents inside it (/aaa/foo).
The parent have some text with an internal link to /aaa/foo that is stored in block data as a resolveuid string (correct).
Now, edit parent changing its id (from "aaa" to "bbb") and add some random text.
When you save the form, Volto sends to restapi the blocks with the link to foo like this: http://localhost:3000/aaa/foo.
restapi deserializer now try to resolve all links and convert them in resolveuid-like, but it is called after parent rename, so the path "/aaa/foo" is invalid and lead to store in the parent blocks a link like "http://localhost:3000/aaa/foo" that is potentially broken.

My pr add an additional check in path2uid method, to check also aliases for a given path.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1848.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->