### PR TITLE
Do not break slate linkintegrity if block is not a slate block

### DIFF
--- a/news/1849.bugfix
+++ b/news/1849.bugfix
@@ -1,0 +1,1 @@
+Do not break slate linkintegrity if block is not a slate block. @cekk

--- a/news/1849.bugfix
+++ b/news/1849.bugfix
@@ -1,1 +1,1 @@
-Do not break slate linkintegrity if block is not a slate block. @cekk
+Make slate block linkintegrity checking more robust in case data isn't in the expected format. @cekk

--- a/src/plone/restapi/blocks_linkintegrity.py
+++ b/src/plone/restapi/blocks_linkintegrity.py
@@ -69,9 +69,8 @@ class SlateBlockLinksRetriever:
     def __call__(self, block):
         value = (block or {}).get(self.field, [])
         children = iterate_children(value or [])
-
         for child in children:
-            node_type = child.get("type")
+            node_type = child.get("type", "")
             if node_type:
                 handler = getattr(self, f"handle_{node_type}", None)
                 if handler:

--- a/src/plone/restapi/deserializer/blocks.py
+++ b/src/plone/restapi/deserializer/blocks.py
@@ -24,9 +24,10 @@ def iterate_children(value):
     queue = deque(value)
     while queue:
         child = queue.pop()
-        yield child
-        if child.get("children"):
-            queue.extend(child["children"] or [])
+        if isinstance(child, dict):
+            yield child
+            if child.get("children", []):
+                queue.extend(child["children"] or [])
 
 
 @implementer(IFieldDeserializer)


### PR DESCRIPTION
These are some compatibility fixes when blocks are not proper slate blocks.

We registered some linkintegrity adapters that extends slate one, but in some cases (we have some old installations that does not have slate yet) some methods breaks.

This pr tries to graceful handle them.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1849.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->