### PR TITLE
Make primary field target adapter return early.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/news/1851.bugfix
+++ b/news/1851.bugfix
@@ -1,0 +1,2 @@
+Make primary field target adapter return early.
+[maurits]

--- a/news/1851.bugfix
+++ b/news/1851.bugfix
@@ -1,2 +1,1 @@
-Make primary field target adapter return early.
-[maurits]
+Optimized performance of DexterityObjectPrimaryFieldTarget adapter. @maurits

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -228,7 +228,6 @@ class DexterityObjectPrimaryFieldTarget:
             field = getFields(schema).get(primary_field_name)
             if field is None:
                 continue
-            print(primary_field_name)
             if not self.check_permission(
                 read_permissions.get(primary_field_name),
                 self.context,

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -225,19 +225,22 @@ class DexterityObjectPrimaryFieldTarget:
         for schema in iterSchemata(self.context):
             read_permissions = mergedTaggedValueDict(schema, READ_PERMISSIONS_KEY)
 
-            for name, field in getFields(schema).items():
-                if name != primary_field_name:
-                    continue
+            field = getFields(schema).get(primary_field_name)
+            if field is None:
+                continue
+            print(primary_field_name)
+            if not self.check_permission(
+                read_permissions.get(primary_field_name),
+                self.context,
+            ):
+                return
 
-                if not self.check_permission(read_permissions.get(name), self.context):
-                    return
-
-                target_adapter = queryMultiAdapter(
-                    (field, self.context, self.request), IPrimaryFieldTarget
-                )
-                if not target_adapter:
-                    return
-                return target_adapter()
+            target_adapter = queryMultiAdapter(
+                (field, self.context, self.request), IPrimaryFieldTarget
+            )
+            if not target_adapter:
+                return
+            return target_adapter()
 
     def get_primary_field_name(self):
         fieldname = None

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -220,23 +220,24 @@ class DexterityObjectPrimaryFieldTarget:
 
     def __call__(self):
         primary_field_name = self.get_primary_field_name()
+        if not primary_field_name:
+            return
         for schema in iterSchemata(self.context):
             read_permissions = mergedTaggedValueDict(schema, READ_PERMISSIONS_KEY)
 
             for name, field in getFields(schema).items():
-                if not self.check_permission(read_permissions.get(name), self.context):
-                    continue
-
                 if name != primary_field_name:
                     continue
+
+                if not self.check_permission(read_permissions.get(name), self.context):
+                    return
 
                 target_adapter = queryMultiAdapter(
                     (field, self.context, self.request), IPrimaryFieldTarget
                 )
-                if target_adapter:
-                    target = target_adapter()
-                    if target:
-                        return target
+                if not target_adapter:
+                    return
+                return target_adapter()
 
     def get_primary_field_name(self):
         fieldname = None


### PR DESCRIPTION
- When there is no primary field, do not go through all fields.
- First compare the field name, then the permission: comparing two strings is cheaper.
- If the field name matches, stop iterating over other fields: you have already found the field.


<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1851.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->