### PR TITLE
Handle bad input as BadRequest instead of ValueError

### DIFF
--- a/news/1855.bugfix
+++ b/news/1855.bugfix
@@ -1,0 +1,1 @@
+Changed bad int inputs into 500 Exceptions to 400 BadRequest so they can be filtered out of logs more easily. - djay

--- a/news/1855.bugfix
+++ b/news/1855.bugfix
@@ -1,1 +1,1 @@
-Changed bad int inputs into 500 Exceptions to 400 BadRequest so they can be filtered out of logs more easily. - djay
+Changed bad int inputs into 500 Exceptions to 400 BadRequest so they can be filtered out of logs more easily. @djay

--- a/src/plone/restapi/services/navigation/get.py
+++ b/src/plone/restapi/services/navigation/get.py
@@ -17,6 +17,7 @@ from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import implementer
 from zope.interface import Interface
+from zExceptions import BadRequest
 
 
 @implementer(IExpandableElement)
@@ -29,7 +30,10 @@ class Navigation:
 
     def __call__(self, expand=False):
         if self.request.form.get("expand.navigation.depth", False):
-            self.depth = int(self.request.form["expand.navigation.depth"])
+            try:
+                self.depth = int(self.request.form["expand.navigation.depth"])
+            except ValueError as e:
+                raise BadRequest(e)
         else:
             self.depth = 1
 

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -190,6 +190,7 @@ class TestBatchingCollections(TestBatchingDXBase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("invalid literal for int()", response.json()["message"])
 
+
 class TestBatchingDXFolders(TestBatchingDXBase):
 
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING

--- a/src/plone/restapi/tests/test_batching.py
+++ b/src/plone/restapi/tests/test_batching.py
@@ -185,6 +185,10 @@ class TestBatchingCollections(TestBatchingDXBase):
         response = self.api_session.get("/collection?b_size=100")
         self.assertNotIn("batching", list(response.json()))
 
+    def test_batching_badrequests(self):
+        response = self.api_session.get("/collection?b_size=php")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("invalid literal for int()", response.json()["message"])
 
 class TestBatchingDXFolders(TestBatchingDXBase):
 

--- a/src/plone/restapi/tests/test_services_navigation.py
+++ b/src/plone/restapi/tests/test_services_navigation.py
@@ -239,3 +239,11 @@ class TestServicesNavigation(unittest.TestCase):
         )
 
         self.assertEqual(response.json()["items"][1]["items"][-1]["title"], nav_title)
+
+    def test_navigation_badrequests(self):
+        response = self.api_session.get(
+            "/folder/@navigation", params={"expand.navigation.depth": "php"}
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("invalid literal for int()", response.json()["message"])


### PR DESCRIPTION
useful so it can be more easily ignored

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1855.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->