### PR TITLE
fix: contextnavigation when a file has an unknown type

### DIFF
--- a/news/1864.bugfix
+++ b/news/1864.bugfix
@@ -1,1 +1,1 @@
-Fix the context navigation bug that occurs when a file type is unknown. @mamico
+In the `@contextnavigation` endpoint, return `"icon": null` for Files with a mimetype not found in the `content_type_registry`, instead of raising `TypeError`. @mamico

--- a/news/1864.bugfix
+++ b/news/1864.bugfix
@@ -1,0 +1,1 @@
+Fix the context navigation bug that occurs when a file type is unknown. @mamico

--- a/src/plone/restapi/services/contextnavigation/get.py
+++ b/src/plone/restapi/services/contextnavigation/get.py
@@ -357,7 +357,8 @@ class NavigationPortletRenderer:
             mtt = getToolByName(self.context, "mimetypes_registry")
             if fileo.contentType:
                 ctype = mtt.lookup(fileo.contentType)
-                return os.path.join(portal_url, guess_icon_path(ctype[0]))
+                if ctype:
+                    return os.path.join(portal_url, guess_icon_path(ctype[0]))
         except AttributeError:
             pass
 

--- a/src/plone/restapi/tests/test_services_contextnavigation.py
+++ b/src/plone/restapi/tests/test_services_contextnavigation.py
@@ -3,6 +3,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
+from plone.namedfile.file import NamedBlobFile
 from plone.registry.interfaces import IRegistry
 from plone.restapi.services.contextnavigation.get import ContextNavigation
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
@@ -99,6 +100,9 @@ class TestServicesContextNavigation(unittest.TestCase):
         folder2.invokeFactory("Document", "doc22")
         folder2.invokeFactory("Document", "doc23")
         folder2.invokeFactory("File", "file21")
+        folder2.file21.file = NamedBlobFile(
+            data="Hello World", contentType="text/plain", filename="file.txt"
+        )
         folder2.invokeFactory("Folder", "folder21")
         folder21 = getattr(folder2, "folder21")
         folder21.invokeFactory("Document", "doc211")
@@ -995,4 +999,29 @@ class TestServicesContextNavigation(unittest.TestCase):
             res["@components"]["contextnavigation"]["items"][0]["@id"].endswith(
                 "/plone/folder1/doc11",
             )
+        )
+
+    def testIcon(self):
+        view = self.renderer(
+            self.portal.folder2.file21,
+            opts(root_path="/folder2", topLevel=0),
+        )
+        tree = view.getNavTree()
+        self.assertTrue(tree)
+        self.assertEqual(
+            tree["items"][0]["icon"],
+            "/plone/++resource++mimetype.icons/txt.png",
+        )
+
+    def testIconNotRegisteredMimetype(self):
+        self.portal.folder2.file21.file.contentType = "plain/x-text"
+        view = self.renderer(
+            self.portal.folder2.file21,
+            opts(root_path="/folder2", topLevel=0),
+        )
+        tree = view.getNavTree()
+        self.assertTrue(tree)
+        self.assertEqual(
+            tree["items"][0]["icon"],
+            None,
         )


### PR DESCRIPTION
Fix the context navigation bug that occurs when a file type is unknown.

In my case, the file had a content type of `application/pkcs7` when I encountered the bug

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1864.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->