### PR TITLE
Update Plone test versions, and pin twine

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,6 @@ jobs:
         include:
           - python-version: "3.8"
             plone-version: "5.2"
-          - python-version: "3.8"
-            plone-version: "6.0"
           - python-version: "3.9"
             plone-version: "6.0"
           - python-version: "3.10"

--- a/news/1685.internal
+++ b/news/1685.internal
@@ -1,0 +1,1 @@
+Update CI. @davisagli

--- a/plone-6.0.x-python3.8.cfg
+++ b/plone-6.0.x-python3.8.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/6.0.12/versions.cfg
+    https://dist.plone.org/release/6.0.14/versions.cfg
     base.cfg
 
 [instance]
@@ -15,3 +15,4 @@ robotframework-assertion-engine = 2.0.0
 robotframework-debuglibrary = 2.3.0
 robotframework-pythonlibcore = 4.2.0
 grpcio-tools = 1.59.0
+twine = 5.1.1

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/6.0.12/versions.cfg
+    https://dist.plone.org/release/6.0.14/versions.cfg
     base.cfg
 
 [buildout:python37]
@@ -22,3 +22,4 @@ robotframework-assertion-engine = 2.0.0
 robotframework-debuglibrary = 2.3.0
 robotframework-pythonlibcore = 4.2.0
 grpcio-tools = 1.59.0
+twine = 5.1.1

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -3,23 +3,9 @@ extends =
     https://dist.plone.org/release/6.0.14/versions.cfg
     base.cfg
 
-[buildout:python37]
-parts =
-    test
-    code-analysis
-
 [instance]
 recipe = plone.recipe.zope2instance
 zodb-temporary-storage = off
 
 [versions]
-# Override pin from Zope. https://github.com/zopefoundation/Zope/issues/1220
-docutils = 0.21.2
-pygments = 2.14.0
-plone.app.linkintegrity = 4.0.3
-robotframework-browser = 17.5.2
-robotframework-assertion-engine = 2.0.0
-robotframework-debuglibrary = 2.3.0
-robotframework-pythonlibcore = 4.2.0
-grpcio-tools = 1.59.0
 twine = 5.1.1

--- a/plone-6.1.x.cfg
+++ b/plone-6.1.x.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/6.1.0a3/versions.cfg
+    https://dist.plone.org/release/6.1.0b2/versions.cfg
     base.cfg
 
 [buildout:python37]

--- a/plone-6.1.x.cfg
+++ b/plone-6.1.x.cfg
@@ -3,15 +3,8 @@ extends =
     https://dist.plone.org/release/6.1.0b2/versions.cfg
     base.cfg
 
-[buildout:python37]
-parts =
-    test
-    code-analysis
-
 [instance]
 recipe = plone.recipe.zope2instance
 zodb-temporary-storage = off
 
 [versions]
-# Override pin from Zope. https://github.com/zopefoundation/Zope/issues/1220
-docutils = 0.21.2

--- a/requirements-6.0.txt
+++ b/requirements-6.0.txt
@@ -1,1 +1,1 @@
--r https://dist.plone.org/release/6.0.12/requirements.txt
+-r https://dist.plone.org/release/6.0.14/requirements.txt

--- a/requirements-6.1.txt
+++ b/requirements-6.1.txt
@@ -1,1 +1,1 @@
--r https://dist.plone.org/release/6.1.0a3/requirements.txt
+-r https://dist.plone.org/release/6.1.0b2/requirements.txt

--- a/src/plone/restapi/tests/http-examples/registry_get_list.resp
+++ b/src/plone/restapi/tests/http-examples/registry_get_list.resp
@@ -423,5 +423,5 @@ Content-Type: application/json
             "value": "The person that created an item"
         }
     ],
-    "items_total": 2973
+    "items_total": 2974
 }

--- a/src/plone/restapi/tests/http-examples/site_get.resp
+++ b/src/plone/restapi/tests/http-examples/site_get.resp
@@ -4,7 +4,7 @@ Content-Type: application/json
 {
     "@id": "http://localhost:55001/plone/@site",
     "features": {
-        "filter_aliases_by_date": false
+        "filter_aliases_by_date": true
     },
     "plone.allowed_sizes": [
         "huge 1600:65536",


### PR DESCRIPTION
There was a new release of twine today which requires packaging 24.0, which is not in our KGS. /cc @mauritsvanrees 

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1865.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->