### PR TITLE
fix: disable CSRF protection on @history endpoint

### DIFF
--- a/src/plone/restapi/services/history/get.py
+++ b/src/plone/restapi/services/history/get.py
@@ -2,7 +2,6 @@ from datetime import datetime as dt
 from datetime import timezone
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-import plone.protect.interfaces
 from plone.app.layout.viewlets.content import ContentHistoryViewlet
 from plone.restapi.bbb import safe_text
 from plone.restapi.interfaces import ISerializeToJson

--- a/src/plone/restapi/services/history/get.py
+++ b/src/plone/restapi/services/history/get.py
@@ -10,8 +10,12 @@ from plone.restapi.services import Service
 from zope.component import queryMultiAdapter
 from zope.component.hooks import getSite
 from zope.interface import implementer, alsoProvides
-from plone.portlets.interfaces import IPortletAssignment
 from zope.publisher.interfaces import IPublishTraverse
+
+try:
+    from plone.portlets.interfaces import IPortletAssignment
+except ImportError:
+    IPortletAssignment = None
 
 
 @implementer(IPublishTraverse)
@@ -28,7 +32,10 @@ class HistoryGet(Service):
         # Traverse to historical version
         if self.version:
             parent = aq_parent(aq_inner(self.context))
-            if not IPortletAssignment.providedBy(parent):
+            if (
+                IPortletAssignment is not None
+                and not IPortletAssignment.providedBy(parent)
+            ):
                 alsoProvides(parent, IPortletAssignment)
             serializer = queryMultiAdapter(
                 (self.context, self.request), ISerializeToJson

--- a/src/plone/restapi/services/history/get.py
+++ b/src/plone/restapi/services/history/get.py
@@ -28,9 +28,7 @@ class HistoryGet(Service):
         # Traverse to historical version
         if self.version:
             parent = aq_parent(aq_inner(self.context))
-            if "IPortletAssignment" in dir(
-                plone.portlets.interfaces
-            ) and not IPortletAssignment.providedBy(parent):
+            if not IPortletAssignment.providedBy(parent):
                 alsoProvides(parent, IPortletAssignment)
             serializer = queryMultiAdapter(
                 (self.context, self.request), ISerializeToJson

--- a/src/plone/restapi/services/history/get.py
+++ b/src/plone/restapi/services/history/get.py
@@ -1,5 +1,7 @@
 from datetime import datetime as dt
 from datetime import timezone
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 import plone.protect.interfaces
 from plone.app.layout.viewlets.content import ContentHistoryViewlet
 from plone.restapi.bbb import safe_text
@@ -9,7 +11,7 @@ from plone.restapi.services import Service
 from zope.component import queryMultiAdapter
 from zope.component.hooks import getSite
 from zope.interface import implementer, alsoProvides
-
+from plone.portlets.interfaces import IPortletAssignment
 from zope.publisher.interfaces import IPublishTraverse
 
 
@@ -26,11 +28,11 @@ class HistoryGet(Service):
     def reply(self):
         # Traverse to historical version
         if self.version:
-            if "IDisableCSRFProtection" in dir(plone.protect.interfaces):
-                alsoProvides(
-                    self.request,
-                    plone.protect.interfaces.IDisableCSRFProtection,
-                )
+            parent = aq_parent(aq_inner(self.context))
+            if "IPortletAssignment" in dir(
+                plone.portlets.interfaces
+            ) and not IPortletAssignment.providedBy(parent):
+                alsoProvides(parent, IPortletAssignment)
             serializer = queryMultiAdapter(
                 (self.context, self.request), ISerializeToJson
             )

--- a/src/plone/restapi/services/history/get.py
+++ b/src/plone/restapi/services/history/get.py
@@ -1,5 +1,6 @@
 from datetime import datetime as dt
 from datetime import timezone
+import plone.protect.interfaces
 from plone.app.layout.viewlets.content import ContentHistoryViewlet
 from plone.restapi.bbb import safe_text
 from plone.restapi.interfaces import ISerializeToJson
@@ -7,7 +8,8 @@ from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from zope.component import queryMultiAdapter
 from zope.component.hooks import getSite
-from zope.interface import implementer
+from zope.interface import implementer, alsoProvides
+
 from zope.publisher.interfaces import IPublishTraverse
 
 
@@ -24,6 +26,11 @@ class HistoryGet(Service):
     def reply(self):
         # Traverse to historical version
         if self.version:
+            if "IDisableCSRFProtection" in dir(plone.protect.interfaces):
+                alsoProvides(
+                    self.request,
+                    plone.protect.interfaces.IDisableCSRFProtection,
+                )
             serializer = queryMultiAdapter(
                 (self.context, self.request), ISerializeToJson
             )


### PR DESCRIPTION
When accessing endpoint on a successful GET call to `@history` I get below error/warning.
```
aborting transaction due to no CSRF protection on url http://localhost:3000/en/page/@history/0
```

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1877.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->