### PR TITLE
Fix status code in GET aliases service

### DIFF
--- a/news/1862.bugfix
+++ b/news/1862.bugfix
@@ -1,0 +1,1 @@
+Fix wrong status code from aliases GET service. @Faakhir30

--- a/src/plone/restapi/services/aliases/get.py
+++ b/src/plone/restapi/services/aliases/get.py
@@ -26,7 +26,7 @@ class Aliases:
         context_path = "/".join(self.context.getPhysicalPath())
         redirects = storage.redirects(context_path)
         aliases = [deroot_path(alias) for alias in redirects]
-        self.request.response.setStatus(201)
+        self.request.response.setStatus(200)
         self.request.response.setHeader("Content-Type", "application/json")
         return [{"path": alias} for alias in aliases], len(aliases)
 
@@ -42,7 +42,7 @@ class Aliases:
         for redirect in redirects:
             del redirect["redirect"]
             redirect["datetime"] = datetimelike_to_iso(redirect["datetime"])
-        self.request.response.setStatus(201)
+        self.request.response.setStatus(200)
 
         self.request.form["b_start"] = "0"
         self.request.form["b_size"] = "1000000"
@@ -61,7 +61,7 @@ class Aliases:
         for redirect in redirects:
             del redirect["redirect"]
             redirect["datetime"] = datetimelike_to_iso(redirect["datetime"])
-        self.request.response.setStatus(201)
+        self.request.response.setStatus(200)
 
         self.request.form["b_start"] = "0"
         self.request.form["b_size"] = "1000000"

--- a/src/plone/restapi/tests/http-examples/aliases_get.resp
+++ b/src/plone/restapi/tests/http-examples/aliases_get.resp
@@ -1,4 +1,4 @@
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/json
 
 {

--- a/src/plone/restapi/tests/http-examples/aliases_root_filter.resp
+++ b/src/plone/restapi/tests/http-examples/aliases_root_filter.resp
@@ -1,4 +1,4 @@
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/json
 
 {

--- a/src/plone/restapi/tests/http-examples/aliases_root_get.resp
+++ b/src/plone/restapi/tests/http-examples/aliases_root_get.resp
@@ -1,4 +1,4 @@
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/json
 
 {

--- a/src/plone/restapi/tests/http-examples/aliases_root_get_csv_format.resp
+++ b/src/plone/restapi/tests/http-examples/aliases_root_get_csv_format.resp
@@ -1,4 +1,4 @@
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: text/csv; charset=utf-8
 
 old path,new path,datetime,manual

--- a/src/plone/restapi/tests/test_services_aliases.py
+++ b/src/plone/restapi/tests/test_services_aliases.py
@@ -44,7 +44,7 @@ class TestAliases(unittest.TestCase):
 
         # Verify alias exists
         response = self.api_session.get("/front-page/@aliases")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["items"]), 1)
 
     def test_alias_add_invalid_datetime(self):
@@ -66,7 +66,7 @@ class TestAliases(unittest.TestCase):
         response = self.api_session.post("/@aliases", json=data)
         self.assertEqual(response.status_code, 204)
         response = self.api_session.get("/@aliases")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["items"]), 2)
 
     def test_alias_add_invalid_path(self):
@@ -76,7 +76,7 @@ class TestAliases(unittest.TestCase):
         response = self.api_session.post("/@aliases", json=data)
         self.assertEqual(response.status_code, 400)
         response = self.api_session.get("/@aliases")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["items"]), 0)
 
     def test_duplicate_alias(self):
@@ -108,7 +108,7 @@ class TestAliases(unittest.TestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(response.content, b"")
         response = self.api_session.get("/@aliases")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json().get("items"),
             [
@@ -136,7 +136,7 @@ class TestAliases(unittest.TestCase):
         self.api_session.post("/@aliases", json=data)
         headers = {"Accept": "text/csv"}
         response = self.api_session.get("/@aliases", headers=headers)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertIn("Content-Disposition", response.headers)
         self.assertEqual(response.headers["Content-Type"], "text/csv; charset=utf-8")
         content = b"old path,new path,datetime,manual\r\n/alias-page,/front-page,2022/01/01 00:00:00 GMT+0,True\r\n"
@@ -158,5 +158,5 @@ class TestAliases(unittest.TestCase):
         self.assertEqual(response.status_code, 204)
 
         response = self.api_session.get("/@aliases")
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["items"]), 0)


### PR DESCRIPTION
Fixes #1862 

Minor bug fix:
Aliases get service was returning  `201` status code on get endpoints. Updated status code to `200`.

- [x] Fixed aliases get service status code
- [ ] Updated tests
- [ ] Updated HTTP samples
- [ ] Verified tests locally