### PR TITLE
Apply the resolveuid transform to all JSON fields, not only blocks

### DIFF
--- a/news/1886.feature
+++ b/news/1886.feature
@@ -1,1 +1,2 @@
-Convert internal URLs to resolveuid URLs in JSON fields. @davisagli
+Apply block serialization and deserialization transforms also to JSON fields.
+This includes converting internal URLs to resolveuid URLs. @davisagli

--- a/news/1886.feature
+++ b/news/1886.feature
@@ -1,0 +1,1 @@
+Convert internal URLs to resolveuid URLs in JSON fields. @davisagli

--- a/src/plone/restapi/deserializer/blocks.py
+++ b/src/plone/restapi/deserializer/blocks.py
@@ -12,6 +12,7 @@ from plone.restapi.interfaces import IFieldDeserializer
 from plone.schema import IJSONField
 from zope.component import adapter
 from zope.interface import implementer
+from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserRequest
 
 import os
@@ -32,10 +33,11 @@ def iterate_children(value):
 
 
 @implementer(IFieldDeserializer)
-@adapter(IJSONField, IBlocks, IBrowserRequest)
+@adapter(IJSONField, Interface, IBrowserRequest)
 class BlocksJSONFieldDeserializer(DefaultFieldDeserializer):
     def __call__(self, value):
         value = super().__call__(value)
+
         if self.field.getName() == "blocks":
             for block in visit_blocks(self.context, value):
                 new_block = block.copy()
@@ -45,6 +47,14 @@ class BlocksJSONFieldDeserializer(DefaultFieldDeserializer):
                     new_block = handler(new_block)
                 block.clear()
                 block.update(new_block)
+        else:
+            fake_block = {"@type": "jsonfield", "value": value}
+            for handler in iter_block_transform_handlers(
+                self.context, fake_block, IBlockFieldDeserializationTransformer
+            ):
+                fake_block = handler(fake_block)
+            value = fake_block["value"]
+
         return value
 
 
@@ -145,10 +155,10 @@ class ImageBlockDeserializerBase:
         return block
 
 
-@adapter(IBlocks, IBrowserRequest)
+@adapter(Interface, IBrowserRequest)
 @implementer(IBlockFieldDeserializationTransformer)
 class ResolveUIDDeserializer(ResolveUIDDeserializerBase):
-    """Deserializer for content-types that implements IBlocks behavior"""
+    """URL-to-UID transformer for all content types"""
 
 
 @adapter(IPloneSiteRoot, IBrowserRequest)

--- a/src/plone/restapi/serializer/blocks.py
+++ b/src/plone/restapi/serializer/blocks.py
@@ -26,7 +26,7 @@ import os
 import re
 
 
-@adapter(IJSONField, IBlocks, Interface)
+@adapter(IJSONField, Interface, Interface)
 @implementer(IFieldSerializer)
 class BlocksJSONFieldSerializer(DefaultFieldSerializer):
     def __call__(self):
@@ -41,6 +41,14 @@ class BlocksJSONFieldSerializer(DefaultFieldSerializer):
                     new_block = handler(new_block)
                 block.clear()
                 block.update(new_block)
+        else:
+            fake_block = {"@type": "jsonfield", "value": value}
+            for handler in iter_block_transform_handlers(
+                self.context, fake_block, IBlockFieldSerializationTransformer
+            ):
+                fake_block = handler(fake_block)
+            value = fake_block["value"]
+
         return json_compatible(value)
 
 
@@ -112,9 +120,9 @@ class TextBlockSerializerBase:
 
 
 @implementer(IBlockFieldSerializationTransformer)
-@adapter(IBlocks, IBrowserRequest)
+@adapter(Interface, IBrowserRequest)
 class ResolveUIDSerializer(ResolveUIDSerializerBase):
-    """Serializer for content-types with IBlocks behavior"""
+    """UID-to-URL transformer for all content types"""
 
 
 @implementer(IBlockFieldSerializationTransformer)

--- a/src/plone/restapi/tests/dxtypes.py
+++ b/src/plone/restapi/tests/dxtypes.py
@@ -9,6 +9,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.namedfile import field as namedfile
 from plone.restapi.tests.helpers import ascii_token
+from plone.schema import JSONField
 from plone.supermodel import model
 from plone.supermodel.directives import primary
 from Products.CMFCore.utils import getToolByName
@@ -186,6 +187,7 @@ class IDXTestDocumentSchema(model.Schema):
     test_float_field = schema.Float(required=False)
     test_frozenset_field = schema.FrozenSet(required=False)
     test_int_field = schema.Int(required=False)
+    test_json_field = JSONField(required=False)
     test_list_field = schema.List(required=False)
     test_list_field_with_choice_with_vocabulary = schema.List(
         value_type=schema.Choice(

--- a/src/plone/restapi/tests/test_dxfield_deserializer.py
+++ b/src/plone/restapi/tests/test_dxfield_deserializer.py
@@ -5,7 +5,9 @@ from datetime import timedelta
 from decimal import Decimal
 from plone import namedfile
 from plone.app.textfield.value import RichTextValue
+from plone.dexterity.schema import SCHEMA_CACHE
 from plone.dexterity.utils import iterSchemata
+from plone.restapi.behaviors import IBlocks
 from plone.restapi.interfaces import IFieldDeserializer
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from plone.restapi.tests.dxtypes import IDXTestDocumentSchema
@@ -645,3 +647,19 @@ class TestDXFieldDeserializer(unittest.TestCase):
         self.assertEqual("http://www.plone.com", value)
         value = self.deserialize("test_textline_field", "http://nohost/plone/doc1")
         self.assertEqual(self.portal.doc1.absolute_url(), value)
+
+    def test_json_field_deserializer_converts_internal_links_to_uid(self):
+        value = self.deserialize(
+            "test_json_field", {"@id": self.portal.doc1.absolute_url()}
+        )
+        self.assertEqual(value["@id"], f"../resolveuid/{self.portal.doc1.UID()}")
+
+    def test_json_field_deserializer_with_blocks(self):
+        fti = self.portal.portal_types.DXTestDocument
+        fti.behaviors = ("volto.blocks",)
+        SCHEMA_CACHE.invalidate("DXTestDocument")
+        assert IBlocks.providedBy(self.portal.doc1)
+        value = self.deserialize(
+            "test_json_field", {"@id": self.portal.doc1.absolute_url()}
+        )
+        self.assertEqual(value["@id"], f"../resolveuid/{self.portal.doc1.UID()}")


### PR DESCRIPTION
Fixes #1842 

This makes it possible to use a non-blocks JSONField that stores internal links as resolveuid URLs.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1886.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->