### PR TITLE
Add `@inherit` service to get inherited behavior values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ check: $(BIN_FOLDER)/tox ## Check and fix code base according to Plone standards
 
 .PHONY: test
 test: $(BIN_FOLDER)/zope-testrunner ## Run tests
-	$(BIN_FOLDER)/zope-testrunner --all --test-path=src -s plone.restapi
+	zope_i18n_compile_mo_files=True $(BIN_FOLDER)/zope-testrunner --all --test-path=src -s plone.restapi
 
 .PHONY: i18n
 i18n: $(BIN_FOLDER)/update_restapi_locales ## Update locales

--- a/docs/source/endpoints/index.md
+++ b/docs/source/endpoints/index.md
@@ -31,6 +31,7 @@ email-notification
 email-send
 groups
 history
+inherit
 linkintegrity
 locking
 login

--- a/docs/source/endpoints/inherit.md
+++ b/docs/source/endpoints/inherit.md
@@ -29,14 +29,13 @@ Specify the `expand.inherit.behaviors` parameter as a comma-separated list of be
 ```
 
 For each behavior, the service will find the closest ancestor which provides that behavior.
-The result includes `from` (the `@id` and `title` of the item from which values were inherited)
-and `data` (values for any fields that are part of the behavior).
+The result includes `from` (the `@id` and `title` of the item from which values were inherited) and `data` (values for any fields that are part of the behavior).
 
 ```{literalinclude} ../../../src/plone/restapi/tests/http-examples/inherit_get.resp
 :language: http
 ```
 
-Ancestor items for which the current user lacks the View permission will be skipped.
+Ancestor items for which the current user lacks the `View` permission will be skipped.
 
 (inherit-behaviors-expansion-label)=
 

--- a/docs/source/endpoints/inherit.md
+++ b/docs/source/endpoints/inherit.md
@@ -33,6 +33,8 @@ and `data` (values for any fields that are part of the behavior).
 :language: http
 ```
 
+Ancestor items for which the current user lacks the View permission will be skipped.
+
 (inherit-behaviors-expansion-label)=
 
 ## Expansion

--- a/docs/source/endpoints/inherit.md
+++ b/docs/source/endpoints/inherit.md
@@ -11,7 +11,10 @@ myst:
 
 # Inherit behaviors
 
-The `@inherit` service makes it possible to inherit data from behaviors defined on ancestors in the object hierarchy.
+Plone content is arranged in a hierarchy: a content item has a parent, which has its own parent, all the way up to the Plone site root.
+Together, all these parents are _ancestors_.
+
+The `@inherit` service makes it possible to access data from a behavior defined on one of these ancestors.
 
 ```{tip}
 Inheriting behaviors is similar to the concept of {term}`acquisition` in Zope, but it doesn't happen automatically, so it's safer.

--- a/docs/source/endpoints/inherit.md
+++ b/docs/source/endpoints/inherit.md
@@ -1,0 +1,53 @@
+---
+myst:
+  html_meta:
+    "description": "The inherit endpoint shows values inherited from content items higher in the hierarchy."
+    "property=og:description": "The inherit endpoint shows values inherited from content items higher in the hierarchy."
+    "property=og:title": "Inherit behaviors"
+    "keywords": "Plone, plone.restapi, REST, API, inherit, acquisition, behaviors"
+---
+
+(inherit-behaviors-label)=
+
+# Inherit behaviors
+
+The `@inherit` service makes it possible to inherit data from behaviors defined on ancestors in the object hierarchy.
+
+```{tip}
+Inheriting behaviors is similar to the concept of {term}`acquisition` in Zope, but it doesn't happen automatically, so it's safer.
+```
+
+To use the service, send a `GET` request to the `@inherit` endpoint in the context of the content item that is the starting point for inheriting.
+Specify the `expand.inherit.behaviors` parameter as a comma-separated list of behaviors.
+
+```{eval-rst}
+..  http:example:: curl httpie python-requests
+    :request: ../../../src/plone/restapi/tests/http-examples/inherit_get.req
+```
+
+For each behavior, the service will find the closest ancestor which provides that behavior.
+The result includes `from` (the `@id` and `title` of the item from which values were inherited)
+and `data` (values for any fields that are part of the behavior).
+
+```{literalinclude} ../../../src/plone/restapi/tests/http-examples/inherit_get.resp
+:language: http
+```
+
+(inherit-behaviors-expansion-label)=
+
+## Expansion
+
+This endpoint can be used with the {doc}`../usage/expansion` mechanism which allows getting more information about a content item in one query, avoiding unnecessary requests.
+
+You can make a `GET` request for a content item, and include parameters to request `inherit` expansion for specific behaviors:
+
+```{eval-rst}
+..  http:example:: curl httpie python-requests
+    :request: ../../../src/plone/restapi/tests/http-examples/inherit_expansion.req
+```
+
+The response will include data from the `@inherit` endpoint within the `@components` property:
+
+```{literalinclude} ../../../src/plone/restapi/tests/http-examples/inherit_expansion.resp
+:language: http
+```

--- a/docs/source/usage/expansion.md
+++ b/docs/source/usage/expansion.md
@@ -23,6 +23,7 @@ The following is a list of components that support expansion.
 -   {doc}`aliases <../endpoints/aliases>`
 -   {doc}`breadcrumbs <../endpoints/breadcrumbs>`
 -   {doc}`contextnavigation <../endpoints/contextnavigation>`
+-   {doc}`inherit <../endpoints/inherit>`
 -   {doc}`navigation <../endpoints/navigation>`
 -   {doc}`navroot <../endpoints/navroot>`
 -   {doc}`translations <../endpoints/translations>`

--- a/news/1887.feature
+++ b/news/1887.feature
@@ -1,0 +1,1 @@
+Add a new endpoint, `@inherit`, for getting values from behaviors inherited from ancestors in the object hierarchy. @davisagli

--- a/src/plone/restapi/interfaces.py
+++ b/src/plone/restapi/interfaces.py
@@ -32,6 +32,17 @@ class IContextawareJsonCompatible(IJsonCompatible):
         """Adapts value and a context"""
 
 
+class ISchemaSerializer(Interface):
+    """The schema serializer serializes all field values from a schema
+    into JSON-compatible Python data."""
+
+    def __init__(schema, context, request):
+        """Adapts schema, context, and request."""
+
+    def __call__():
+        """Returns JSON-compatible Python data."""
+
+
 class IFieldSerializer(Interface):
     """The field serializer multi adapter serializes the field value into
     JSON compatible python data.
@@ -41,7 +52,7 @@ class IFieldSerializer(Interface):
         """Adapts field, context and request."""
 
     def __call__():
-        """Returns JSON compatible python data."""
+        """Returns JSON-compatible Python data."""
 
 
 class IPrimaryFieldTarget(Interface):

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -18,6 +18,8 @@
   <adapter factory=".summary.DefaultJSONSummarySerializer" />
   <adapter factory=".summary.SiteRootJSONSummarySerializer" />
 
+  <adapter factory=".schema.SerializeSchemaToJson" />
+
   <adapter factory=".dxfields.DefaultFieldSerializer" />
   <adapter factory=".dxfields.ChoiceFieldSerializer" />
   <adapter factory=".dxfields.CollectionFieldSerializer" />

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -74,8 +74,6 @@ class SerializeToJson:
         self.context = context
         self.request = request
 
-        self.permission_cache = {}
-
     def getVersion(self, version):
         if version == "current":
             return self.context
@@ -205,8 +203,6 @@ class DexterityObjectPrimaryFieldTarget:
         self.context = context
         self.request = request
 
-        self.permission_cache = {}
-
     def __call__(self):
         primary_field_name = self.get_primary_field_name()
         if not primary_field_name:
@@ -256,8 +252,6 @@ class LinkObjectPrimaryFieldTarget:
     def __init__(self, context, request):
         self.context = context
         self.request = request
-
-        self.permission_cache = {}
 
     def __call__(self):
         """

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -1,4 +1,3 @@
-from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from plone.app.contenttypes.interfaces import ILink
@@ -12,11 +11,13 @@ from plone.restapi.deserializer import boolean_value
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import IObjectPrimaryFieldTarget
 from plone.restapi.interfaces import IPrimaryFieldTarget
+from plone.restapi.interfaces import ISchemaSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.expansion import expandable_elements
 from plone.restapi.serializer.nextprev import NextPrevious
+from plone.restapi.serializer.schema import check_permission as _check_permission
 from plone.restapi.serializer.utils import get_portal_type_title
 from plone.restapi.services.locking import lock_info
 from plone.rfc822.interfaces import IPrimaryFieldInfo
@@ -27,11 +28,9 @@ from zope.component import adapter
 from zope.component import ComponentLookupError
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema import getFields
-from zope.security.interfaces import IPermission
 
 
 try:
@@ -131,18 +130,10 @@ class SerializeToJson:
 
         # Insert field values
         for schema in iterSchemata(self.context):
-            read_permissions = mergedTaggedValueDict(schema, READ_PERMISSIONS_KEY)
-
-            for name, field in getFields(schema).items():
-                if not self.check_permission(read_permissions.get(name), obj):
-                    continue
-
-                # serialize the field
-                serializer = queryMultiAdapter(
-                    (field, obj, self.request), IFieldSerializer
-                )
-                value = serializer()
-                result[json_compatible(name)] = value
+            schema_serializer = getMultiAdapter(
+                (schema, obj, self.request), ISchemaSerializer
+            )
+            result.update(schema_serializer())
 
         target_url = getMultiAdapter(
             (self.context, self.request), IObjectPrimaryFieldTarget
@@ -160,19 +151,8 @@ class SerializeToJson:
         return review_state
 
     def check_permission(self, permission_name, obj):
-        if permission_name is None:
-            return True
-
-        if permission_name not in self.permission_cache:
-            permission = queryUtility(IPermission, name=permission_name)
-            if permission is None:
-                self.permission_cache[permission_name] = True
-            else:
-                sm = getSecurityManager()
-                self.permission_cache[permission_name] = bool(
-                    sm.checkPermission(permission.title, obj)
-                )
-        return self.permission_cache[permission_name]
+        # Here for backwards-compatibility
+        return _check_permission(permission_name, obj)
 
 
 @implementer(ISerializeToJson)
@@ -266,19 +246,8 @@ class DexterityObjectPrimaryFieldTarget:
         return fieldname
 
     def check_permission(self, permission_name, obj):
-        if permission_name is None:
-            return True
-
-        if permission_name not in self.permission_cache:
-            permission = queryUtility(IPermission, name=permission_name)
-            if permission is None:
-                self.permission_cache[permission_name] = True
-            else:
-                sm = getSecurityManager()
-                self.permission_cache[permission_name] = bool(
-                    sm.checkPermission(permission.title, obj)
-                )
-        return self.permission_cache[permission_name]
+        # for backwards-compatibility
+        return _check_permission(permission_name, obj)
 
 
 @adapter(ILink, Interface)

--- a/src/plone/restapi/serializer/schema.py
+++ b/src/plone/restapi/serializer/schema.py
@@ -1,0 +1,60 @@
+from AccessControl import getSecurityManager
+from plone.autoform.interfaces import READ_PERMISSIONS_KEY
+from plone.restapi.interfaces import IFieldSerializer
+from plone.restapi.interfaces import ISchemaSerializer
+from plone.restapi.serializer.converters import json_compatible
+from plone.supermodel.utils import mergedTaggedValueDict
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.component import queryUtility
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.interface.interfaces import IInterface
+from zope.schema import getFields
+from zope.security.interfaces import IPermission
+
+
+@adapter(IInterface, Interface, Interface)
+@implementer(ISchemaSerializer)
+class SerializeSchemaToJson:
+    """Serialize fields from a single schema, honoring read permissions."""
+
+    def __init__(self, schema, context, request):
+        self.context = context
+        self.request = request
+        self.schema = schema
+
+    def __call__(self):
+        result = {}
+
+        read_permissions = mergedTaggedValueDict(self.schema, READ_PERMISSIONS_KEY)
+        for name, field in getFields(self.schema).items():
+            if not check_permission(read_permissions.get(name), self.context):
+                continue
+            serializer = getMultiAdapter(
+                (field, self.context, self.request), IFieldSerializer
+            )
+            value = serializer()
+            result[json_compatible(name)] = value
+
+        return result
+
+
+def check_permission(permission_name, context) -> bool:
+    if permission_name is None:
+        return True
+
+    if not hasattr(context, "_v_permission_cache"):
+        context._v_permission_cache = {}
+    permission_cache = context._v_permission_cache
+
+    if permission_name not in permission_cache:
+        permission = queryUtility(IPermission, name=permission_name)
+        if permission is None:
+            permission_cache[permission_name] = True
+        else:
+            sm = getSecurityManager()
+            permission_cache[permission_name] = bool(
+                sm.checkPermission(permission.title, context)
+            )
+    return permission_cache[permission_name]

--- a/src/plone/restapi/serializer/schema.py
+++ b/src/plone/restapi/serializer/schema.py
@@ -44,9 +44,9 @@ def check_permission(permission_name, context) -> bool:
     if permission_name is None:
         return True
 
-    if not hasattr(context, "_v_permission_cache"):
-        context._v_permission_cache = {}
-    permission_cache = context._v_permission_cache
+    permission_cache = getattr(context, "_v_permission_cache", {})
+    if not permission_cache:
+        context._v_permission_cache = permission_cache
 
     if permission_name not in permission_cache:
         permission = queryUtility(IPermission, name=permission_name)

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -34,7 +34,6 @@ class SerializeSiteRootToJson:
     def __init__(self, context, request):
         self.context = context
         self.request = request
-        self.permission_cache = {}
 
     def _build_query(self):
         path = "/".join(self.context.getPhysicalPath())

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -1,31 +1,24 @@
-from AccessControl import getSecurityManager
 from importlib import import_module
-from plone.autoform.interfaces import READ_PERMISSIONS_KEY
 from plone.dexterity.utils import iterSchemata
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.bbb import IPloneSiteRoot
 from plone.restapi.blocks import iter_block_transform_handlers
 from plone.restapi.blocks import visit_blocks
 from plone.restapi.interfaces import IBlockFieldSerializationTransformer
-from plone.restapi.interfaces import IFieldSerializer
+from plone.restapi.interfaces import ISchemaSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
-from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.dxcontent import get_allow_discussion_value
 from plone.restapi.serializer.dxcontent import update_with_working_copy_info
 from plone.restapi.serializer.expansion import expandable_elements
+from plone.restapi.serializer.schema import check_permission as _check_permission
 from plone.restapi.serializer.utils import get_portal_type_title
 from plone.restapi.services.locking import lock_info
-from plone.supermodel.utils import mergedTaggedValueDict
 from Products.CMFCore.utils import getToolByName
 from zope.component import adapter
 from zope.component import getMultiAdapter
-from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 from zope.interface import implementer
 from zope.interface import Interface
-from zope.schema import getFields
-from zope.security.interfaces import IPermission
 
 import json
 
@@ -88,20 +81,10 @@ class SerializeSiteRootToJson:
 
             # Insert Plone Site DX root field values
             for schema in iterSchemata(self.context):
-                read_permissions = mergedTaggedValueDict(schema, READ_PERMISSIONS_KEY)
-
-                for name, field in getFields(schema).items():
-                    if not self.check_permission(
-                        read_permissions.get(name), self.context
-                    ):
-                        continue
-
-                    # serialize the field
-                    serializer = queryMultiAdapter(
-                        (field, self.context, self.request), IFieldSerializer
-                    )
-                    value = serializer()
-                    result[json_compatible(name)] = value
+                schema_serializer = getMultiAdapter(
+                    (schema, self.context, self.request), ISchemaSerializer
+                )
+                result.update(schema_serializer())
 
             # Insert locking information
             result.update({"lock": lock_info(self.context)})
@@ -133,19 +116,7 @@ class SerializeSiteRootToJson:
         return result
 
     def check_permission(self, permission_name, obj):
-        if permission_name is None:
-            return True
-
-        if permission_name not in self.permission_cache:
-            permission = queryUtility(IPermission, name=permission_name)
-            if permission is None:
-                self.permission_cache[permission_name] = True
-            else:
-                sm = getSecurityManager()
-                self.permission_cache[permission_name] = bool(
-                    sm.checkPermission(permission.title, obj)
-                )
-        return self.permission_cache[permission_name]
+        return _check_permission(permission_name, obj)
 
     def serialize_blocks(self):
         # This is only for below 6

--- a/src/plone/restapi/services/configure.zcml
+++ b/src/plone/restapi/services/configure.zcml
@@ -26,6 +26,7 @@
   <include package=".navigation" />
   <include package=".contextnavigation" />
   <include package=".history" />
+  <include package=".inherit" />
   <include package=".linkintegrity" />
   <include package=".locking" />
   <include package=".navroot" />

--- a/src/plone/restapi/services/inherit/configure.zcml
+++ b/src/plone/restapi/services/inherit/configure.zcml
@@ -1,0 +1,27 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:cache="http://namespaces.zope.org/cache"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    >
+
+  <plone:service
+      method="GET"
+      factory=".get.InheritedBehaviorGet"
+      for="zope.interface.Interface"
+      permission="zope2.View"
+      name="@inherit"
+      />
+
+  <adapter
+      factory=".get.InheritedBehaviorExpander"
+      name="inherit"
+      />
+
+  <cache:ruleset
+      for=".get.InheritedBehaviorGet"
+      ruleset="plone.content.dynamic"
+      zcml:condition="have plone-app-caching-3"
+      />
+
+</configure>

--- a/src/plone/restapi/services/inherit/get.py
+++ b/src/plone/restapi/services/inherit/get.py
@@ -1,0 +1,62 @@
+from plone.behavior.registration import BehaviorRegistrationNotFound
+from plone.behavior.registration import lookup_behavior_registration
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.interfaces import ISchemaSerializer
+from plone.restapi.services import Service
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IExpandableElement)
+@adapter(Interface, Interface)
+class InheritedBehaviorExpander:
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+        behavior_names = self.request.form.get("expand.inherit.behaviors")
+        self.behavior_names = behavior_names.split(",") if behavior_names else []
+
+    def __call__(self, expand=False):
+        result = {}
+        for name in self.behavior_names:
+            result[name] = {
+                "@id": f"{self.context.absolute_url()}/@inherit?expand.inherit.behaviors={name}"
+            }
+            if expand:
+                try:
+                    registration = lookup_behavior_registration(name=name)
+                except BehaviorRegistrationNotFound:
+                    continue
+                schema = registration.interface
+                closest = next(
+                    (
+                        obj
+                        for obj in self.context.aq_chain
+                        if registration.marker.providedBy(obj)
+                    ),
+                    None,
+                )
+                if closest:
+                    serializer = getMultiAdapter(
+                        (schema, self.context, self.request), ISchemaSerializer
+                    )
+                    data = serializer()
+                    result[name].update(
+                        {
+                            "from": {
+                                "@id": closest.absolute_url(),
+                                "title": closest.title,
+                            },
+                            "data": data,
+                        }
+                    )
+        return result
+
+
+class InheritedBehaviorGet(Service):
+    def reply(self):
+        expander = InheritedBehaviorExpander(self.context, self.request)
+        return expander(expand=True)

--- a/src/plone/restapi/services/inherit/get.py
+++ b/src/plone/restapi/services/inherit/get.py
@@ -21,11 +21,11 @@ class InheritedBehaviorExpander:
         self.behavior_names = behavior_names.split(",") if behavior_names else []
 
     def __call__(self, expand=False):
-        result = {}
+        if not self.behavior_names:
+            return {}
+        url = f"{self.context.absolute_url()}/@inherit?expand.inherit.behaviors={','.join(self.behavior_names)}"
+        result = {"@id": url}
         for name in self.behavior_names:
-            result[name] = {
-                "@id": f"{self.context.absolute_url()}/@inherit?expand.inherit.behaviors={name}"
-            }
             if expand:
                 try:
                     registration = lookup_behavior_registration(name=name)
@@ -46,16 +46,14 @@ class InheritedBehaviorExpander:
                         (schema, self.context, self.request), ISchemaSerializer
                     )
                     data = serializer()
-                    result[name].update(
-                        {
-                            "from": {
-                                "@id": closest.absolute_url(),
-                                "title": closest.title,
-                            },
-                            "data": data,
-                        }
-                    )
-        return result
+                    result[name] = {
+                        "from": {
+                            "@id": closest.absolute_url(),
+                            "title": closest.title,
+                        },
+                        "data": data,
+                    }
+        return {"inherit": result}
 
 
 class InheritedBehaviorGet(Service):

--- a/src/plone/restapi/services/inherit/get.py
+++ b/src/plone/restapi/services/inherit/get.py
@@ -2,6 +2,7 @@ from plone.behavior.registration import BehaviorRegistrationNotFound
 from plone.behavior.registration import lookup_behavior_registration
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISchemaSerializer
+from plone.restapi.serializer.schema import check_permission
 from plone.restapi.services import Service
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -36,6 +37,7 @@ class InheritedBehaviorExpander:
                         obj
                         for obj in self.context.aq_chain
                         if registration.marker.providedBy(obj)
+                        and check_permission("View", obj)
                     ),
                     None,
                 )

--- a/src/plone/restapi/tests/http-examples/inherit.get.req
+++ b/src/plone/restapi/tests/http-examples/inherit.get.req
@@ -1,0 +1,3 @@
+GET /plone/document/@inherit?expand.inherit.behaviors=plone.navigationroot HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0

--- a/src/plone/restapi/tests/http-examples/inherit_expansion.req
+++ b/src/plone/restapi/tests/http-examples/inherit_expansion.req
@@ -1,0 +1,3 @@
+GET /plone/document/?expand=inherit&expand.inherit.behaviors=plone.navigationroot HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0

--- a/src/plone/restapi/tests/http-examples/inherit_expansion.resp
+++ b/src/plone/restapi/tests/http-examples/inherit_expansion.resp
@@ -15,19 +15,21 @@ Content-Type: application/json
         "contextnavigation": {
             "@id": "http://localhost:55001/plone/document/@contextnavigation"
         },
+        "inherit": {
+            "@id": "http://localhost:55001/plone/document/@inherit?expand.inherit.behaviors=plone.navigationroot",
+            "plone.navigationroot": {
+                "data": {},
+                "from": {
+                    "@id": "http://localhost:55001/plone",
+                    "title": "Plone site"
+                }
+            }
+        },
         "navigation": {
             "@id": "http://localhost:55001/plone/document/@navigation"
         },
         "navroot": {
             "@id": "http://localhost:55001/plone/document/@navroot"
-        },
-        "plone.navigationroot": {
-            "@id": "http://localhost:55001/plone/document/@inherit?expand.inherit.behaviors=plone.navigationroot",
-            "data": {},
-            "from": {
-                "@id": "http://localhost:55001/plone",
-                "title": "Plone site"
-            }
         },
         "types": {
             "@id": "http://localhost:55001/plone/document/@types"

--- a/src/plone/restapi/tests/http-examples/inherit_expansion.resp
+++ b/src/plone/restapi/tests/http-examples/inherit_expansion.resp
@@ -1,0 +1,83 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "@components": {
+        "actions": {
+            "@id": "http://localhost:55001/plone/document/@actions"
+        },
+        "aliases": {
+            "@id": "http://localhost:55001/plone/document/@aliases"
+        },
+        "breadcrumbs": {
+            "@id": "http://localhost:55001/plone/document/@breadcrumbs"
+        },
+        "contextnavigation": {
+            "@id": "http://localhost:55001/plone/document/@contextnavigation"
+        },
+        "navigation": {
+            "@id": "http://localhost:55001/plone/document/@navigation"
+        },
+        "navroot": {
+            "@id": "http://localhost:55001/plone/document/@navroot"
+        },
+        "plone.navigationroot": {
+            "@id": "http://localhost:55001/plone/document/@inherit?expand.inherit.behaviors=plone.navigationroot",
+            "data": {},
+            "from": {
+                "@id": "http://localhost:55001/plone",
+                "title": "Plone site"
+            }
+        },
+        "types": {
+            "@id": "http://localhost:55001/plone/document/@types"
+        },
+        "workflow": {
+            "@id": "http://localhost:55001/plone/document/@workflow"
+        }
+    },
+    "@id": "http://localhost:55001/plone/document",
+    "@type": "Document",
+    "UID": "SomeUUID000000000000000000000002",
+    "allow_discussion": false,
+    "changeNote": "",
+    "contributors": [],
+    "created": "1995-07-31T13:45:00+00:00",
+    "creators": [
+        "test_user_1_"
+    ],
+    "description": "",
+    "effective": null,
+    "exclude_from_nav": false,
+    "expires": null,
+    "id": "document",
+    "is_folderish": false,
+    "language": "",
+    "layout": "document_view",
+    "lock": {
+        "locked": false,
+        "stealable": true
+    },
+    "modified": "1995-07-31T17:30:00+00:00",
+    "next_item": {},
+    "parent": {
+        "@id": "http://localhost:55001/plone",
+        "@type": "Plone Site",
+        "description": "",
+        "title": "Plone site",
+        "type_title": "Plone Site"
+    },
+    "previous_item": {},
+    "relatedItems": [],
+    "review_state": "private",
+    "rights": "",
+    "subjects": [],
+    "table_of_contents": null,
+    "text": null,
+    "title": "Test document",
+    "type_title": "Page",
+    "version": "current",
+    "versioning_enabled": true,
+    "working_copy": null,
+    "working_copy_of": null
+}

--- a/src/plone/restapi/tests/http-examples/inherit_get.req
+++ b/src/plone/restapi/tests/http-examples/inherit_get.req
@@ -1,0 +1,3 @@
+GET /plone/document/@inherit?expand.inherit.behaviors=plone.navigationroot HTTP/1.1
+Accept: application/json
+Authorization: Basic YWRtaW46c2VjcmV0

--- a/src/plone/restapi/tests/http-examples/inherit_get.resp
+++ b/src/plone/restapi/tests/http-examples/inherit_get.resp
@@ -2,12 +2,14 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "plone.navigationroot": {
+    "inherit": {
         "@id": "http://localhost:55001/plone/document/@inherit?expand.inherit.behaviors=plone.navigationroot",
-        "data": {},
-        "from": {
-            "@id": "http://localhost:55001/plone",
-            "title": "Plone site"
+        "plone.navigationroot": {
+            "data": {},
+            "from": {
+                "@id": "http://localhost:55001/plone",
+                "title": "Plone site"
+            }
         }
     }
 }

--- a/src/plone/restapi/tests/http-examples/inherit_get.resp
+++ b/src/plone/restapi/tests/http-examples/inherit_get.resp
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "plone.navigationroot": {
+        "@id": "http://localhost:55001/plone/document/@inherit?expand.inherit.behaviors=plone.navigationroot",
+        "data": {},
+        "from": {
+            "@id": "http://localhost:55001/plone",
+            "title": "Plone site"
+        }
+    }
+}

--- a/src/plone/restapi/tests/test_documentation.py
+++ b/src/plone/restapi/tests/test_documentation.py
@@ -1838,6 +1838,26 @@ class TestDocumentation(TestDocumentationBase):
         response = self.api_session.get("/@site")
         save_request_and_response_for_docs("site_get", response)
 
+    def test_inherit_get(self):
+        self.doc = self.portal.invokeFactory(
+            "Document", id="document", title="Test document"
+        )
+        transaction.commit()
+        response = self.api_session.get(
+            "/document/@inherit?expand.inherit.behaviors=plone.navigationroot"
+        )
+        save_request_and_response_for_docs("inherit_get", response)
+
+    def test_inherit_expansion(self):
+        self.doc = self.portal.invokeFactory(
+            "Document", id="document", title="Test document"
+        )
+        transaction.commit()
+        response = self.api_session.get(
+            "/document/?expand=inherit&expand.inherit.behaviors=plone.navigationroot"
+        )
+        save_request_and_response_for_docs("inherit_expansion", response)
+
 
 class TestDocumentationMessageTranslations(TestDocumentationBase):
     layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING


### PR DESCRIPTION
This adds a new service, `@inherit`, to explicitly get values from behaviors assigned to ancestors in the object hierarchy.

(It's Acquisition, but without the bad magic.)

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1887.org.readthedocs.build/en/1887/endpoints/inherit.html

<!-- readthedocs-preview plonerestapi end -->