### PR TITLE
pin setuptools for build

### DIFF
--- a/news/1890.bugfix
+++ b/news/1890.bugfix
@@ -1,0 +1,1 @@
+Fix wheel compatibility with older versions of setuptools and buildout. @davisagli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2"]
+requires = ["setuptools>=68.2,<=75.8.0"]
 
 [tool.towncrier]
 directory = "news/"


### PR DESCRIPTION
This is needed in order to build a wheel with dist-info named plone.restapi-9.13.1.dev0.dist-info instead of plone_restapi-9.13.1.dev0.dist-info, so that it can be found by older versions of buildout and setuptools.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1890.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->