### PR TITLE
Adds @id to @content-rules endpoint and makes it consistent with other endpoints

### DIFF
--- a/news/1901.bugfix
+++ b/news/1901.bugfix
@@ -1,0 +1,1 @@
+Changed the structure of the @content-rules endpoint response to return a flat format with @id at the top level, making it consistent with other REST API endpoints. @irtisamsajin

--- a/src/plone/restapi/services/rules/get.py
+++ b/src/plone/restapi/services/rules/get.py
@@ -23,9 +23,8 @@ class ContentRulesGet(Service):
         assignable_rules = manage_assignments.assignable_rules()
 
         return {
-            "content-rules": {
-                "acquired_rules": acquired_rules,
-                "assigned_rules": assigned_rules,
-                "assignable_rules": assignable_rules,
-            }
+            "@id": f"{self.context.absolute_url()}/@content-rules",
+            "acquired_rules": acquired_rules,
+            "assigned_rules": assigned_rules,
+            "assignable_rules": assignable_rules,
         }

--- a/src/plone/restapi/tests/http-examples/rules_get.resp
+++ b/src/plone/restapi/tests/http-examples/rules_get.resp
@@ -2,30 +2,29 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "content-rules": {
-        "acquired_rules": [],
-        "assignable_rules": [],
-        "assigned_rules": [
-            {
-                "bubbles": true,
-                "description": "First rule added in the testing setup",
-                "enabled": true,
-                "global_enabled": true,
-                "id": "rule-1",
-                "title": "First test rule",
-                "trigger": "Comment added",
-                "url": "http://localhost:55001/plone/++rule++rule-1/@@manage-elements"
-            },
-            {
-                "bubbles": true,
-                "description": "Second rule added in the testing setup",
-                "enabled": true,
-                "global_enabled": true,
-                "id": "rule-2",
-                "title": "Second test rule",
-                "trigger": "Comment added",
-                "url": "http://localhost:55001/plone/++rule++rule-2/@@manage-elements"
-            }
-        ]
-    }
+    "@id": "http://localhost:55001/plone/@content-rules",
+    "acquired_rules": [],
+    "assignable_rules": [],
+    "assigned_rules": [
+        {
+            "bubbles": true,
+            "description": "First rule added in the testing setup",
+            "enabled": true,
+            "global_enabled": true,
+            "id": "rule-1",
+            "title": "First test rule",
+            "trigger": "Comment added",
+            "url": "http://localhost:55001/plone/++rule++rule-1/@@manage-elements"
+        },
+        {
+            "bubbles": true,
+            "description": "Second rule added in the testing setup",
+            "enabled": true,
+            "global_enabled": true,
+            "id": "rule-2",
+            "title": "Second test rule",
+            "trigger": "Comment added",
+            "url": "http://localhost:55001/plone/++rule++rule-2/@@manage-elements"
+        }
+    ]
 }


### PR DESCRIPTION
Fixes #1901 
I have added the @id field to the response. Also made changes to the response so that the response is now consistent with other endpoints 

Old response
```

HTTP/1.1 200 OK
Content-Type: application/json

{
    "content-rules": {
        "acquired_rules": [],
        "assignable_rules": [],
        "assigned_rules": [
            {
                "bubbles": true,
                "description": "First rule added in the testing setup",
                "enabled": true,
                "global_enabled": true,
                "id": "rule-1",
                "title": "First test rule",
                "trigger": "Comment added",
                "url": "http://localhost:55001/plone/++rule++rule-1/@@manage-elements"
            },
            {
                "bubbles": true,
                "description": "Second rule added in the testing setup",
                "enabled": true,
                "global_enabled": true,
                "id": "rule-2",
                "title": "Second test rule",
                "trigger": "Comment added",
                "url": "http://localhost:55001/plone/++rule++rule-2/@@manage-elements"
            }
        ]
    }
}
```

New Response:
```

HTTP/1.1 200 OK
Content-Type: application/json

{
    "@id": "http://localhost:55001/plone/@content-rules",
    "acquired_rules": [],
    "assignable_rules": [],
    "assigned_rules": [
        {
            "bubbles": true,
            "description": "First rule added in the testing setup",
            "enabled": true,
            "global_enabled": true,
            "id": "rule-1",
            "title": "First test rule",
            "trigger": "Comment added",
            "url": "http://localhost:55001/plone/++rule++rule-1/@@manage-elements"
        },
        {
            "bubbles": true,
            "description": "Second rule added in the testing setup",
            "enabled": true,
            "global_enabled": true,
            "id": "rule-2",
            "title": "Second test rule",
            "trigger": "Comment added",
            "url": "http://localhost:55001/plone/++rule++rule-2/@@manage-elements"
        }
    ]
}
```