### PR TITLE
Fix error serializing empty reference from Archetypes content. [7.x.x]

### DIFF
--- a/news/1913.bugfix
+++ b/news/1913.bugfix
@@ -1,0 +1,2 @@
+Fix error serializing empty reference from Archetypes content.
+[maurits]

--- a/src/plone/restapi/serializer/atfields.py
+++ b/src/plone/restapi/serializer/atfields.py
@@ -126,7 +126,7 @@ class ReferenceFieldSerializer(DefaultFieldSerializer):
         accessor = self.field.getAccessor(self.context)
         refs = accessor()
         if self.field.multiValued:
-            return [json_compatible(r.absolute_url()) for r in refs]
+            return [json_compatible(r.absolute_url()) for r in refs if r is not None]
         else:
             if refs is None:
                 return None


### PR DESCRIPTION
Fixes https://github.com/plone/plone.restapi/issues/1913