### PR TITLE
Fix permission check in schema serializer

### DIFF
--- a/news/1916.bugfix
+++ b/news/1916.bugfix
@@ -1,0 +1,2 @@
+Fix exposing protected fields in schema serializer.
+[maethu]

--- a/src/plone/restapi/deserializer/dxcontent.py
+++ b/src/plone/restapi/deserializer/dxcontent.py
@@ -7,13 +7,13 @@ from plone.restapi import _
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import IFieldDeserializer
+from plone.restapi.serializer.schema import _check_permission
 from plone.supermodel.utils import mergedTaggedValueDict
 from z3c.form.interfaces import IDataManager
 from z3c.form.interfaces import IManagerValidator
 from zExceptions import BadRequest
 from zope.component import adapter
 from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 from zope.event import notify
 from zope.i18n import translate
 from zope.interface import implementer
@@ -22,7 +22,6 @@ from zope.lifecycleevent import Attributes
 from zope.lifecycleevent import ObjectModifiedEvent
 from zope.schema import getFields
 from zope.schema.interfaces import ValidationError
-from zope.security.interfaces import IPermission
 
 
 @implementer(IDeserializeFromJson)
@@ -179,15 +178,5 @@ class DeserializeFromJson(OrderingMixin):
         self.modified.setdefault(schema, []).append(prefixed_name)
 
     def check_permission(self, permission_name):
-        if permission_name is None:
-            return True
-
-        if permission_name not in self.permission_cache:
-            permission = queryUtility(IPermission, name=permission_name)
-            if permission is None:
-                self.permission_cache[permission_name] = True
-            else:
-                self.permission_cache[permission_name] = bool(
-                    self.sm.checkPermission(permission.title, self.context)
-                )
-        return self.permission_cache[permission_name]
+        # Here for backwards-compatibility
+        return _check_permission(permission_name, self)

--- a/src/plone/restapi/serializer/dxcontent.py
+++ b/src/plone/restapi/serializer/dxcontent.py
@@ -17,7 +17,7 @@ from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.expansion import expandable_elements
 from plone.restapi.serializer.nextprev import NextPrevious
-from plone.restapi.serializer.schema import check_permission as _check_permission
+from plone.restapi.serializer.schema import _check_permission
 from plone.restapi.serializer.utils import get_portal_type_title
 from plone.restapi.services.locking import lock_info
 from plone.rfc822.interfaces import IPrimaryFieldInfo
@@ -150,7 +150,7 @@ class SerializeToJson:
 
     def check_permission(self, permission_name, obj):
         # Here for backwards-compatibility
-        return _check_permission(permission_name, obj)
+        return _check_permission(permission_name, self, obj)
 
 
 @implementer(ISerializeToJson)
@@ -243,7 +243,7 @@ class DexterityObjectPrimaryFieldTarget:
 
     def check_permission(self, permission_name, obj):
         # for backwards-compatibility
-        return _check_permission(permission_name, obj)
+        return _check_permission(permission_name, self, obj)
 
 
 @adapter(ILink, Interface)

--- a/src/plone/restapi/serializer/site.py
+++ b/src/plone/restapi/serializer/site.py
@@ -11,7 +11,7 @@ from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.dxcontent import get_allow_discussion_value
 from plone.restapi.serializer.dxcontent import update_with_working_copy_info
 from plone.restapi.serializer.expansion import expandable_elements
-from plone.restapi.serializer.schema import check_permission as _check_permission
+from plone.restapi.serializer.schema import _check_permission
 from plone.restapi.serializer.utils import get_portal_type_title
 from plone.restapi.services.locking import lock_info
 from Products.CMFCore.utils import getToolByName
@@ -115,7 +115,7 @@ class SerializeSiteRootToJson:
         return result
 
     def check_permission(self, permission_name, obj):
-        return _check_permission(permission_name, obj)
+        return _check_permission(permission_name, self, obj)
 
     def serialize_blocks(self):
         # This is only for below 6

--- a/src/plone/restapi/services/inherit/get.py
+++ b/src/plone/restapi/services/inherit/get.py
@@ -2,7 +2,7 @@ from plone.behavior.registration import BehaviorRegistrationNotFound
 from plone.behavior.registration import lookup_behavior_registration
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISchemaSerializer
-from plone.restapi.serializer.schema import check_permission
+from plone.restapi.serializer.schema import _check_permission
 from plone.restapi.services import Service
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -37,7 +37,7 @@ class InheritedBehaviorExpander:
                         obj
                         for obj in self.context.aq_chain
                         if registration.marker.providedBy(obj)
-                        and check_permission("View", obj)
+                        and _check_permission("View", self, obj)
                     ),
                     None,
                 )

--- a/src/plone/restapi/tests/test_dxcontent_serializer.py
+++ b/src/plone/restapi/tests/test_dxcontent_serializer.py
@@ -174,6 +174,10 @@ class TestDXContentSerializer(unittest.TestCase):
         self.assertIn("test_read_permission_field", obj)
         self.assertEqual("Secret Stuff", obj["test_read_permission_field"])
 
+        # Re-test field with read permission - make sure its not cached
+        setRoles(self.portal, TEST_USER_ID, ["Member"])
+        self.assertNotIn("test_read_permission_field", self.serialize())
+
     def test_get_layout(self):
         current_layout = self.portal.doc1.getLayout()
         obj = self.serialize()


### PR DESCRIPTION
Env:
Plone == 6.1.1
Python == 3.12.8
plone.restapi == 9.13.3

Issue: Exposing of protected information

Reproduce:

Protect any field with a permission not given to an anonymous user
Make request with Manager account, which has the permission --> Field is in response
Make a request as an anonymous user to same object, WITHOUT the permission --> Field is still there!!
Reboot the instance and make a new request as an anonymous user. --> Field is gone.
I'm not sure if this is intentional, or not.
But in my case, it exposes information I don't want to.

It got implemented here: [Add `@inherit` service to get inherited behavior values (#1887) · plone/plone.restapi@763ce18 · GitHub](https://github.com/plone/plone.restapi/commit/763ce189400c4640f7b05ebbc1c3ffcefd5c7eae#diff-74ad4dd30dcaee75ebfef37954d68ac69de8d5abf4a83e02b52d525fd3756407R41-R49)

Which clearly is meant to be stored on the object, but no committed (volatile).

Before it was "cached" only in the serializer instance: [Add `@inherit` service to get inherited behavior values (#1887) · plone/plone.restapi@763ce18 · GitHub](https://github.com/plone/plone.restapi/commit/763ce189400c4640f7b05ebbc1c3ffcefd5c7eae#diff-faaee0c689417efa563809ccb96137e21ce38e7f38c3700dcb57fdf59116f0b5L78) Which is IMHO the correct way to do this.



Fix:
Store it again on the serializer instance


<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1916.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->