### PR TITLE
fix(types/utils): pass root context when no DX content in layout

### DIFF
--- a/news/1917.bugfix
+++ b/news/1917.bugfix
@@ -1,1 +1,1 @@
-fix(types/utils): attribute error on fake_context when updating Content-type field through DX layout @nileshgulia
+Fix `AttributeError` when updating the default blocks layout for a content type. @nileshgulia, @davisagli

--- a/news/1917.bugfix
+++ b/news/1917.bugfix
@@ -1,0 +1,1 @@
+fix(types/utils): attribute error on fake_context when updating Content-type field through DX layout @nileshgulia

--- a/src/plone/restapi/deserializer/utils.py
+++ b/src/plone/restapi/deserializer/utils.py
@@ -2,8 +2,9 @@ from Acquisition import aq_parent
 from plone.app.redirector.interfaces import IRedirectionStorage
 from plone.uuid.interfaces import IUUID
 from plone.uuid.interfaces import IUUIDAware
-from zope.component import getMultiAdapter
+from Products.CMFCore.interfaces import ISiteRoot
 from zope.component import getUtility
+from zope.component.hooks import getSite
 
 import re
 
@@ -11,18 +12,26 @@ import re
 PATH_RE = re.compile(r"^(.*?)((?=/@@|#).*)?$")
 
 
+def get_portal():
+    closest_site = getSite()
+    if closest_site is not None:
+        for potential_portal in closest_site.aq_chain:
+            if ISiteRoot.providedBy(potential_portal):
+                return potential_portal
+    raise Exception("Plone site root not found")
+
+
 def path2uid(context, link):
-    # unrestrictedTraverse requires a string on py3. see:
-    # https://github.com/zopefoundation/Zope/issues/674
     if not link:
         return ""
-    portal = getMultiAdapter(
-        (context, context.REQUEST), name="plone_portal_state"
-    ).portal()
+    portal = get_portal()
     portal_url = portal.portal_url()
     portal_path = "/".join(portal.getPhysicalPath())
     path = link
-    context_url = context.absolute_url()
+    try:
+        context_url = context.absolute_url()
+    except AttributeError:
+        context_url = portal_url
     relative_up = len(context_url.split("/")) - len(portal_url.split("/"))
     if path.startswith(portal_url):
         path = path[len(portal_url) + 1 :]

--- a/src/plone/restapi/tests/test_services_types.py
+++ b/src/plone/restapi/tests/test_services_types.py
@@ -425,6 +425,46 @@ class TestServicesTypes(unittest.TestCase):
             "contact_info", [f["id"] for f in response.json().get("fieldsets")]
         )  # noqa
 
+    def test_types_document_blocks_patch(self):
+        json = {
+            "properties": {
+                "blocks": {
+                    "default": {
+                        "0ff5c86f-dfea-4199-a855-d0e507b9a44c": {"@type": "title"},
+                        "d6a0a308-0757-4713-bfe0-359817b364cd": {
+                            "@type": "slate",
+                            "value": [
+                                {
+                                    "type": "p",
+                                    "children": [
+                                        {"text": ""},
+                                        {
+                                            "type": "link",
+                                            "data": {"url": "/doc1"},
+                                            "children": [{"text": "Plone"}],
+                                        },
+                                        {"text": ""},
+                                    ],
+                                }
+                            ],
+                            "plaintext": " Plone ",
+                        },
+                    }
+                },
+                "blocks_layout": {
+                    "default": {
+                        "items": [
+                            "0ff5c86f-dfea-4199-a855-d0e507b9a44c",
+                            "d6a0a308-0757-4713-bfe0-359817b364cd",
+                        ]
+                    }
+                },
+            }
+        }
+
+        response = self.api_session.patch("/@types/Document", json=json)
+        self.assertEqual(response.status_code, 204)
+
     def test_types_document_remove_field(self):
         response = self.api_session.delete(
             "/@types/Document/author_email",

--- a/src/plone/restapi/tests/test_services_types.py
+++ b/src/plone/restapi/tests/test_services_types.py
@@ -298,6 +298,24 @@ class TestServicesTypes(unittest.TestCase):
                             },
                             "5060e030-727b-47bc-8023-b80b7cccd96f": {"@type": "image"},
                             "e3d8f8e4-8fee-47e7-9451-28724bf74a90": {"@type": "text"},
+                            "d6a0a308-0757-4713-bfe0-359817b364cd": {
+                                "@type": "slate",
+                                "value": [
+                                    {
+                                        "type": "p",
+                                        "children": [
+                                            {"text": ""},
+                                            {
+                                                "type": "link",
+                                                "data": {"url": "/doc1"},
+                                                "children": [{"text": "Plone"}],
+                                            },
+                                            {"text": ""},
+                                        ],
+                                    }
+                                ],
+                                "plaintext": " Plone ",
+                            },
                         },
                     },
                     "blocks_layout": {
@@ -311,6 +329,7 @@ class TestServicesTypes(unittest.TestCase):
                                 "338013ce-acca-454f-a6f4-14113c187dca",
                                 "5060e030-727b-47bc-8023-b80b7cccd96f",
                                 "e3d8f8e4-8fee-47e7-9451-28724bf74a90",
+                                "d6a0a308-0757-4713-bfe0-359817b364cd",
                             ]
                         },
                     },
@@ -424,46 +443,6 @@ class TestServicesTypes(unittest.TestCase):
         self.assertIn(
             "contact_info", [f["id"] for f in response.json().get("fieldsets")]
         )  # noqa
-
-    def test_types_document_blocks_patch(self):
-        json = {
-            "properties": {
-                "blocks": {
-                    "default": {
-                        "0ff5c86f-dfea-4199-a855-d0e507b9a44c": {"@type": "title"},
-                        "d6a0a308-0757-4713-bfe0-359817b364cd": {
-                            "@type": "slate",
-                            "value": [
-                                {
-                                    "type": "p",
-                                    "children": [
-                                        {"text": ""},
-                                        {
-                                            "type": "link",
-                                            "data": {"url": "/doc1"},
-                                            "children": [{"text": "Plone"}],
-                                        },
-                                        {"text": ""},
-                                    ],
-                                }
-                            ],
-                            "plaintext": " Plone ",
-                        },
-                    }
-                },
-                "blocks_layout": {
-                    "default": {
-                        "items": [
-                            "0ff5c86f-dfea-4199-a855-d0e507b9a44c",
-                            "d6a0a308-0757-4713-bfe0-359817b364cd",
-                        ]
-                    }
-                },
-            }
-        }
-
-        response = self.api_session.patch("/@types/Document", json=json)
-        self.assertEqual(response.status_code, 204)
 
     def test_types_document_remove_field(self):
         response = self.api_session.delete(

--- a/src/plone/restapi/types/utils.py
+++ b/src/plone/restapi/types/utils.py
@@ -60,11 +60,6 @@ FIELD_PROPERTIES_MAPPING = {
 }
 
 
-@implementer(IDexterityContent)
-class FakeDXContext:
-    """Fake DX content class, so we can reuse the DX field deserializers"""
-
-
 def create_form(context, request, base_schema, additional_schemata=None):
     """Create a minimal, standalone z3c form and run the field processing
     logic of plone.autoform on it.
@@ -528,8 +523,11 @@ def update_field(context, request, data):
     edit.form_instance.applyChanges(properties)
 
     if default is not _marker:
-        fake_context = FakeDXContext()
+        base_context = context
+        if not IDexterityContent.providedBy(context):
+            # fallback to site root
+            base_context = getSite()
         deserializer = queryMultiAdapter(
-            (field.field, fake_context, request), IFieldDeserializer
+            (field.field, base_context, request), IFieldDeserializer
         )
         setattr(field.field, "default", deserializer(default))

--- a/src/plone/restapi/types/utils.py
+++ b/src/plone/restapi/types/utils.py
@@ -41,7 +41,6 @@ from zope.component import queryUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
-from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 
 


### PR DESCRIPTION
fixes #1914 
Pass root context when no DX content available on updating field through DX controlpanel.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1917.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->