### PR TITLE
Include all summary fields when serializing `next_item` and `previous_item`.

### DIFF
--- a/news/+nextprev.feature
+++ b/news/+nextprev.feature
@@ -1,0 +1,1 @@
+Include all summary fields when serializing `next_item` and `previous_item`. @davisagli

--- a/src/plone/restapi/serializer/nextprev.py
+++ b/src/plone/restapi/serializer/nextprev.py
@@ -1,7 +1,10 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from plone.app.dexterity.behaviors.nextprevious import INextPreviousProvider
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.utils import get_portal_type_title
+from zope.component import getMultiAdapter
 
 
 class NextPrevious:
@@ -12,6 +15,22 @@ class NextPrevious:
         self.parent = aq_parent(aq_inner(context))
         self.nextprev = INextPreviousProvider(self.parent, None)
         self.enabled = self.nextprev is not None and self.nextprev.enabled
+
+    def _get_summary_serialization(self, data):
+        if "obj" in data:
+            summary = getMultiAdapter(
+                (data["obj"], self.context.REQUEST), ISerializeToJsonSummary
+            )()
+            return json_compatible(summary)
+        else:
+            # Backwards compatibility for before `obj` was available
+            return {
+                "@id": data["url"].lstrip("/view"),
+                "@type": data["portal_type"],
+                "type_title": get_portal_type_title(data.get("portal_type")),
+                "title": data["title"],
+                "description": data["description"],
+            }
 
     @property
     def next(self):
@@ -24,13 +43,7 @@ class NextPrevious:
         data = self.nextprev.getNextItem(self.context)
         if data is None:
             return {}
-        return {
-            "@id": data["url"].lstrip("/view"),
-            "@type": data["portal_type"],
-            "type_title": get_portal_type_title(data.get("portal_type")),
-            "title": data["title"],
-            "description": data["description"],
-        }
+        return self._get_summary_serialization(data)
 
     @property
     def previous(self):
@@ -43,10 +56,4 @@ class NextPrevious:
         data = self.nextprev.getPreviousItem(self.context)
         if data is None:
             return {}
-        return {
-            "@id": data["url"].lstrip("/view"),
-            "@type": data["portal_type"],
-            "type_title": get_portal_type_title(data.get("portal_type")),
-            "title": data["title"],
-            "description": data["description"],
-        }
+        return self._get_summary_serialization(data)


### PR DESCRIPTION
(Depends on https://github.com/plone/plone.app.dexterity/pull/409, but falls back to the old serialization without it.)