### PR TITLE
Fix tests to expect an extra registry record.

### DIFF
--- a/news/+0b828c61.tests.md
+++ b/news/+0b828c61.tests.md
@@ -1,0 +1,1 @@
+Fix tests to expect an extra registry record.  @mauritsvanrees

--- a/src/plone/restapi/tests/http-examples/registry_get_list.resp
+++ b/src/plone/restapi/tests/http-examples/registry_get_list.resp
@@ -423,5 +423,5 @@ Content-Type: application/json
             "value": "The person that created an item"
         }
     ],
-    "items_total": 2998
+    "items_total": 2999
 }


### PR DESCRIPTION
We have a new one for a tinymce license key.  That landed on dist.plone.org/release/6.2-dev yesterday.

See [failure on main](https://github.com/plone/plone.restapi/actions/runs/20365347802/job/58519057658#step:5:53) that I triggered.


<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1970.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->