### PR TITLE
Clean up docs from #1963

### DIFF
--- a/docs/source/endpoints/querystringsearch.md
+++ b/docs/source/endpoints/querystringsearch.md
@@ -154,7 +154,7 @@ Use the `limit` parameter to set a maximum number of results that will be return
 ```
 
 The `limit` parameter is optional.
-The default value is no limit (but a single page of results will still have a size determined by the Batch Size).
+The default value is `None`, but a single page of results will still have a size determined by the batch size parameter `b_size`.
 
 ### Query
 


### PR DESCRIPTION
I didn't have the chance to review the docs change before it was merged. No change log needed as it's polish for #1963 which already has an entry.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1972.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->