### PR TITLE
Return 401 when user lacks permission for control panel access

### DIFF
--- a/src/plone/restapi/services/controlpanels/get.py
+++ b/src/plone/restapi/services/controlpanels/get.py
@@ -9,6 +9,9 @@ from zope.component import getAdapters
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
+from zope.security import checkPermission
+from zExceptions import Unauthorized
+
 
 
 @implementer(IPublishTraverse)
@@ -65,6 +68,9 @@ class ControlpanelsGet(Service):
             self.request.response.setStatus(404)
             return
 
+        # 🔐 Permission check (FIX for #1949)
+        if not checkPermission("cmf.ManagePortal", panel):
+            raise Unauthorized()
         # Panel child request
         if len(self.params) > 1:
             return IJsonCompatible(panel.get(self.params[1:]))


### PR DESCRIPTION
Fixes #1949

Return a 401 Unauthorized response when the current user does not have
permission to access a control panel, instead of raising an AttributeError
during serialization.


<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1974.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->