### PR TITLE
Remove default limit of 1000 from QuerystringSearch

### DIFF
--- a/docs/source/endpoints/querystringsearch.md
+++ b/docs/source/endpoints/querystringsearch.md
@@ -138,7 +138,7 @@ The sort_order can be either `ascending` or `descending`.
 
 ### Limit
 
-Querystring `query` with a `limit` parameter:
+Use the `limit` parameter to set a maximum number of results that will be returned:
 
 ```
 {
@@ -154,7 +154,7 @@ Querystring `query` with a `limit` parameter:
 ```
 
 The `limit` parameter is optional.
-The default value is `1000`.
+The default value is no limit (but a single page of results will still have a size determined by the Batch Size).
 
 ### Query
 

--- a/news/1955.bugfix
+++ b/news/1955.bugfix
@@ -1,0 +1,1 @@
+Remove default limit of 1000 from service @querystring-search. @wesleybl

--- a/src/plone/restapi/services/querystringsearch/get.py
+++ b/src/plone/restapi/services/querystringsearch/get.py
@@ -38,7 +38,9 @@ class QuerystringSearch:
         b_size = parse_int(data, "b_size", 25)
         sort_on = data.get("sort_on", None)
         sort_order = data.get("sort_order", None)
-        limit = parse_int(data, "limit", 1000)
+        limit = data.get("limit")
+        if limit is not None:
+            limit = parse_int(data, "limit", None)
         fullobjects = bool(data.get("fullobjects", False))
 
         if not query:


### PR DESCRIPTION
Backport of #1963 to plone.restapi 9.

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1978.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->