### PR TITLE
fix: the search handler removes sort_order if present

### DIFF
--- a/news/1954.bugfix
+++ b/news/1954.bugfix
@@ -1,0 +1,1 @@
+In the `@search` service, fix a case where the `sort_order` parameter was ignored. @mamico, @davisagli

--- a/src/plone/restapi/search/handler.py
+++ b/src/plone/restapi/search/handler.py
@@ -131,23 +131,19 @@ class SearchHandler:
                 bits = query["path"]["query"].split("/")[len(vhm_physical_path) :]
                 query["path"]["query"] = "/".join(bits) or "/"
 
-        default_sort_on = search_settings.sort_on
-
+        # Get default sort_on from registry if not specified in query
         if "sort_on" not in query:
-            if default_sort_on != "relevance":
-                query["sort_on"] = self.default_sort_on
-        elif query["sort_on"] == "relevance":
-            del query["sort_on"]
+            query["sort_on"] = search_settings.sort_on
+            # To rank by relevance, sort_on must be omitted
+            if query["sort_on"] == "relevance":
+                del query["sort_on"]
 
-        if not query.get("sort_order") and (
-            query.get("sort_on", "") == "Date"
-            or query.get("sort_on", "") == "effective"  # compatibility with Volto
-        ):
+        sort_on = query.get("sort_on")
+        # Remove sort_order if sort_on is not set
+        if not sort_on and "sort_order" in query:
+            del query["sort_order"]
+        # Default to reverse sort_order if sort_on is a date
+        elif sort_on in ("Date", "effective") and not query.get("sort_order"):
             query["sort_order"] = "reverse"
-        elif "sort_order" in query:
-            del query["sort_order"]
-
-        if "sort_order" in query and not query["sort_order"]:
-            del query["sort_order"]
 
         return query

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -765,6 +765,19 @@ class TestSearchFunctional(unittest.TestCase):
             "Other Document",
         )
 
+        response = self.api_session.get(
+            "/@search",
+            params={
+                "use_site_search_settings": 1,
+                "sort_on": "effective",
+                "sort_order": "reverse",
+            },
+        ).json()
+        self.assertEqual(
+            [item["title"] for item in response["items"]][0],
+            "Other Document",
+        )
+
     def test_search_use_site_search_settings_with_navigation_root(self):
 
         alsoProvides(self.folder, INavigationRoot)


### PR DESCRIPTION
Backport of #1954 to plone.restapi 9

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1980.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->