### PR TITLE
Consolidate test layers to share PLONE_RESTAPI_DX_FIXTURE base

### DIFF
--- a/news/1983.internal
+++ b/news/1983.internal
@@ -1,0 +1,1 @@
+Consolidate test layers so PAM, Iterate, Blocks, and Workflows all share `PLONE_RESTAPI_DX_FIXTURE` as base, reducing redundant layer setup time. @jensens

--- a/src/plone/restapi/tests/test_boolean_value.py
+++ b/src/plone/restapi/tests/test_boolean_value.py
@@ -1,12 +1,12 @@
 from plone.restapi.deserializer import boolean_value
-from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 
 import unittest
 
 
 class TestBooleanValue(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
+    layer = PLONE_RESTAPI_DX_INTEGRATION_TESTING
 
     def test_true_bool(self):
         self.assertTrue(boolean_value(True))

--- a/src/plone/restapi/tests/test_dxfield_publication.py
+++ b/src/plone/restapi/tests/test_dxfield_publication.py
@@ -3,7 +3,6 @@ from plone.registry.interfaces import IRegistry
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
-from transaction import commit
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 
@@ -44,8 +43,6 @@ class TestPublicationFields(unittest.TestCase):
 
         self.app = self.layer["app"]
         self.portal = self.layer["portal"]
-
-        commit()
 
     def tearDown(self):
         os.environ["TZ"] = "UTC"

--- a/src/plone/restapi/tests/test_indexers.py
+++ b/src/plone/restapi/tests/test_indexers.py
@@ -1,5 +1,5 @@
 from plone.dexterity.interfaces import IDexterityFTI
-from plone.restapi.testing import PLONE_RESTAPI_BLOCKS_FUNCTIONAL_TESTING
+from plone.restapi.testing import PLONE_RESTAPI_BLOCKS_INTEGRATION_TESTING
 from Products.CMFCore.utils import getToolByName
 from uuid import uuid4
 from zope.component import queryUtility
@@ -89,7 +89,7 @@ TABLE_BLOCK = {
 
 class TestSearchableTextIndexer(unittest.TestCase):
 
-    layer = PLONE_RESTAPI_BLOCKS_FUNCTIONAL_TESTING
+    layer = PLONE_RESTAPI_BLOCKS_INTEGRATION_TESTING
 
     def setUp(self):
         self.portal = self.layer["portal"]


### PR DESCRIPTION
## Summary

- Make `PloneRestApiDXPAMLayer` and `PloneRestApiDXIterateLayer` extend `PLONE_RESTAPI_DX_FIXTURE` instead of duplicating its setup, eliminating redundant ZCML + profile loading cycles (~5-15s wall time saved per full test run)
- Switch `test_boolean_value` and `test_indexers` from FUNCTIONAL to INTEGRATION testing (no HTTP calls or commits needed)
- Fix pre-existing test isolation bug in `test_dxfield_publication` where `transaction.commit()` in IntegrationTesting leaked `portal_timezone` into the shared DemoStorage

Fixes #1983

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--1984.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->