### PR TITLE
Make the @site endpoint public

### DIFF
--- a/docs/source/endpoints/site.md
+++ b/docs/source/endpoints/site.md
@@ -10,7 +10,7 @@ myst:
 # Site
 
 The `@site` endpoint provides general site-wide information, such as the site title, logo, and other information.
-It uses the `zope2.View` permission, which requires appropriate authorization.
+It is accessible to anonymous users, so that a frontend can fetch the data it needs to bootstrap itself, even on sites that require authentication to view content.
 
 Send a `GET` request to the `@site` endpoint:
 
@@ -57,4 +57,9 @@ class MyAddonExpander:
 ```{tip}
 Use this for data that is needed to render any page, but that does not change depending on the context.
 If the data is context-dependent, use a custom API expander instead.
+```
+
+```{warning}
+The `@site` endpoint is public.
+Expanders must only add information that may be disclosed to anonymous users.
 ```

--- a/news/2022.bugfix
+++ b/news/2022.bugfix
@@ -1,0 +1,1 @@
+Make the `@site` endpoint public, so that anonymous requests get the site bootstrap data even on sites that require authentication to view content. @reebalazs

--- a/src/plone/restapi/services/site/configure.zcml
+++ b/src/plone/restapi/services/site/configure.zcml
@@ -9,7 +9,7 @@
       method="GET"
       factory=".get.SiteGet"
       for="plone.restapi.bbb.IPloneSiteRoot"
-      permission="zope2.View"
+      permission="zope.Public"
       name="@site"
       />
 

--- a/src/plone/restapi/tests/test_services_site.py
+++ b/src/plone/restapi/tests/test_services_site.py
@@ -12,6 +12,7 @@ from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
 
+import transaction
 import unittest
 
 
@@ -46,6 +47,20 @@ class TestServicesSite(unittest.TestCase):
         self.assertIn("plone.default_language", response.json())
         self.assertEqual(response.json()["plone.portal_timezone"], "UTC")
         self.assertEqual(response.json()["features"]["multilingual"], False)
+
+    def test_get_site_anonymous_with_restricted_site_root(self):
+        # @site provides the public bootstrap data a frontend needs before
+        # rendering anything, so it must remain accessible to anonymous
+        # users even on sites that require authentication to view content.
+        self.portal.manage_permission("View", roles=["Manager"], acquire=False)
+        transaction.commit()
+
+        response = self.api_session.get(
+            "/@site",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("plone.site_title", response.json())
 
     def test_get_site_expander(self):
         @adapter(Interface, Interface)


### PR DESCRIPTION
## Problem

The `@site` endpoint provides the public bootstrap data a frontend needs before it can render anything: site title, logo, available/default languages, portal timezone, the `features` dict, and whatever `ISiteEndpointExpander` adapters contribute.

It is currently registered with `permission="zope2.View"`, checked against the site root. On sites that restrict the View permission on the site root to authenticated users — e.g. intranets such as the ones built with [kitconcept.intranet](https://github.com/kitconcept/kitconcept.intranet), where a restricted workflow grants View on published content only to `Authenticated` — anonymous requests to `/@site` return **401**.

This breaks frontend bootstrapping: Volto fetches `/@site` once at SSR time, typically while the user is still anonymous, and add-ons relying on expander data (e.g. `@kitconcept/volto-solr` reading `collective.solr.active` to decide which search UI to render) silently misbehave for the entire session, since the post-login redirect is a client-side route transition that never re-runs SSR.

Real-world manifestation: https://gitlab.kitconcept.io/kitconcept/kitconcept-intranet/-/work_items/127 (after Google login, the old search page shows instead of the Solr one).

## Fix

Register the `@site` service with `permission="zope.Public"`, matching its design contract: it serves only data that is needed before authentication and safe to disclose publicly.

- New test: anonymous `GET /@site` returns 200 even when View is revoked from Anonymous on the site root (fails with 401 before the change).
- Docs updated: removed the `zope2.View` mention, added a warning to the expander section that expander data is publicly visible.

Pinging @davisagli as the author of the `ISiteEndpointExpander` mechanism (#1921).

<!-- readthedocs-preview plonerestapi start -->
----
📚 Documentation preview 📚: https://plonerestapi--2022.org.readthedocs.build/

<!-- readthedocs-preview plonerestapi end -->