### PR TITLE
Fix isDefaultPortrait when the default portrait is not traversable

### DIFF
--- a/news/2035.bugfix
+++ b/news/2035.bugfix
@@ -1,0 +1,1 @@
+Fix an `AttributeError` in the `@users` endpoint when the site's default portrait cannot be traversed. `isDefaultPortrait` now reports a mismatch instead of raising. @ericof

--- a/src/plone/restapi/services/users/get.py
+++ b/src/plone/restapi/services/users/get.py
@@ -75,6 +75,8 @@ def getPortraitUrl(user):
 def isDefaultPortrait(value):
     portal = getSite()
     default_portrait_value = portal.restrictedTraverse(default_portrait, None)
+    if default_portrait_value is None:
+        return False
     return (
         aq_inner(value).getPhysicalPath()
         == aq_inner(default_portrait_value).getPhysicalPath()

--- a/src/plone/restapi/tests/test_services_users.py
+++ b/src/plone/restapi/tests/test_services_users.py
@@ -13,6 +13,8 @@ from plone.restapi.testing import RelativeSession
 from Products.CMFCore.permissions import SetOwnPassword
 from Products.CMFCore.utils import getToolByName
 from Products.MailHost.interfaces import IMailHost
+from unittest.mock import MagicMock
+from unittest.mock import patch
 from zope.component import getUtility
 
 import base64
@@ -31,6 +33,15 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(extract("TEXT/PLAIN"), "text/plain")
         self.assertEqual(extract("text / plain"), "text/plain")
         self.assertEqual(extract(" text/plain ; charset=utf-8"), "text/plain")
+
+    def test_is_default_portrait_without_default_portrait(self):
+        """A missing default portrait must not raise, but report a mismatch."""
+        from plone.restapi.services.users import get as users_get
+
+        portal = MagicMock()
+        portal.restrictedTraverse.return_value = None
+        with patch.object(users_get, "getSite", return_value=portal):
+            self.assertFalse(users_get.isDefaultPortrait(MagicMock()))
 
 
 class TestUsersEndpoint(unittest.TestCase):
@@ -438,6 +449,20 @@ class TestUsersEndpoint(unittest.TestCase):
             transaction.commit()
 
         response = self.api_session.get("/@users/noam")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["portrait"].endswith("/@portrait/noam"))
+
+    def test_get_user_with_portrait_set_and_no_default_portrait(self):
+        from plone.restapi.services.users import get as users_get
+
+        with self.makeRealImage() as image:
+            pm = api.portal.get_tool("portal_membership")
+            pm.changeMemberPortrait(image, "noam")
+            transaction.commit()
+
+        with patch.object(users_get, "default_portrait", "no-such-default-portrait"):
+            response = self.api_session.get("/@users/noam")
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["portrait"].endswith("/@portrait/noam"))


### PR DESCRIPTION
## Problem

`isDefaultPortrait` resolves the site's default portrait with `portal.restrictedTraverse(default_portrait, None)`, which returns `None` when the object is missing or not accessible. That `None` was passed straight into `aq_inner(...).getPhysicalPath()`, raising an `AttributeError`.

The user-visible symptom is a **500** on `GET /@users/<userid>` for any user that has a portrait set, on sites where the default portrait cannot be traversed.

## Fix

Return `False` when the default portrait cannot be resolved — a value cannot be equal to a default that does not exist. `getPortraitUrl` then falls through to returning the `@portrait` URL, which is the correct behaviour when there is no default to compare against.

```python
def isDefaultPortrait(value):
    portal = getSite()
    default_portrait_value = portal.restrictedTraverse(default_portrait, None)
    if default_portrait_value is None:
        return False
    ...
```

## Tests

- `TestUnit.test_is_default_portrait_without_default_portrait` — layer-free unit test for the guard. Fails without the fix with `AttributeError: 'NoneType' object has no attribute 'getPhysicalPath'`.
- `TestUsersEndpoint.test_get_user_with_portrait_set_and_no_default_portrait` — functional test covering the endpoint. Fails without the fix with `AssertionError: 500 != 200`.

Both were verified to fail on the unpatched code, so neither passes vacuously.

Full suite: 1398 tests, 7 failures — all seven are pre-existing date/time failures in `test_workflow`, `test_search`, and `test_statictime`, reproduced identically on a clean checkout and unrelated to this change.

Closes #2035