### PR TITLE
Fix JSON schema provider crash for Dict/List fields (#2037)

### DIFF
--- a/news/2037.bugfix
+++ b/news/2037.bugfix
@@ -1,0 +1,1 @@
+Fix schema serialization with Dict and List fields that don't specify a value_type/key_type. @erral 

--- a/src/plone/restapi/__init__.py
+++ b/src/plone/restapi/__init__.py
@@ -20,7 +20,6 @@ PROJECT_NAME = "plone.restapi"
 
 allow_module("json")
 
-# BBB: Plone 5.2
 HAS_PLONE_6 = getattr(
     import_module("Products.CMFPlone.factory"), "PLONE60MARKER", False
 )

--- a/src/plone/restapi/tests/test_types.py
+++ b/src/plone/restapi/tests/test_types.py
@@ -797,3 +797,48 @@ class TestJsonSchemaProviders(TestCase):
             },
             adapter.get_schema(),
         )
+
+    def test_dict_without_types(self):
+        field = schema.Dict(title="My field", description="My great field")
+        adapter = getMultiAdapter(
+            (field, self.portal, self.request), IJsonSchemaProvider
+        )
+        self.assertEqual(
+            {
+                "type": "dict",
+                "title": "My field",
+                "description": "My great field",
+            },
+            adapter.get_schema(),
+        )
+
+    def test_list_without_value_type(self):
+        field = schema.List(title="My field", description="My great field")
+        adapter = getMultiAdapter(
+            (field, self.portal, self.request), IJsonSchemaProvider
+        )
+        self.assertEqual(
+            {
+                "type": "array",
+                "title": "My field",
+                "description": "My great field",
+                "factory": "List",
+                "uniqueItems": False,
+                "additionalItems": True,
+                "items": {},
+            },
+            adapter.get_schema(),
+        )
+
+    def test_dict_with_generic_field_value_type(self):
+        field = schema.Dict(
+            title="Generic Dict", value_type=schema.Field(title="Generic Value")
+        )
+        adapter = getMultiAdapter(
+            (field, self.portal, self.request), IJsonSchemaProvider
+        )
+        schema_data = adapter.get_schema()
+        # Should not crash, and value_type schema should omit 'type'
+        self.assertIn("value_type", schema_data)
+        self.assertNotIn("type", schema_data["value_type"]["schema"])
+        self.assertEqual("Generic Value", schema_data["value_type"]["schema"]["title"])

--- a/src/plone/restapi/types/adapters.py
+++ b/src/plone/restapi/types/adapters.py
@@ -68,12 +68,16 @@ class DefaultJsonSchemaProvider:
         You should override `additional` method to provide more properties
         about the field."""
         schema = {
-            "type": self.get_type(),
             "title": self.get_title(),
             "description": self.get_description(),
         }
 
+        field_type = self.get_type()
+        if field_type:
+            schema["type"] = field_type
+
         widget = self.get_widget()
+
         if widget:
             schema["widget"] = widget
 
@@ -96,7 +100,7 @@ class DefaultJsonSchemaProvider:
         return schema
 
     def get_type(self):
-        raise NotImplementedError
+        return None
 
     def get_factory(self):
         pass
@@ -270,11 +274,14 @@ class CollectionJsonSchemaProvider(DefaultJsonSchemaProvider):
 
     def get_items(self):
         """Get items properties."""
-        value_type_adapter = getMultiAdapter(
-            (self.field.value_type, self.context, self.request), IJsonSchemaProvider
-        )
+        if self.field.value_type:
+            value_type_adapter = getMultiAdapter(
+                (self.field.value_type, self.context, self.request), IJsonSchemaProvider
+            )
 
-        return value_type_adapter.get_schema()
+            return value_type_adapter.get_schema()
+
+        return {}
 
     def additional(self):
         info = {}
@@ -434,20 +441,25 @@ class DictJsonSchemaProvider(DefaultJsonSchemaProvider):
 
     def additional(self):
         info = {}
-        key_type = getMultiAdapter(
-            (self.field.key_type, self.context, self.request), IJsonSchemaProvider
-        )
-        info["key_type"] = {
-            "schema": key_type.get_schema(),
-            "additional": key_type.additional(),
-        }
-        value_type = getMultiAdapter(
-            (self.field.value_type, self.context, self.request), IJsonSchemaProvider
-        )
-        info["value_type"] = {
-            "schema": value_type.get_schema(),
-            "additional": value_type.additional(),
-        }
+        if self.field.key_type:
+            key_type = getMultiAdapter(
+                (self.field.key_type, self.context, self.request), IJsonSchemaProvider
+            )
+            info["key_type"] = {
+                "schema": key_type.get_schema(),
+                "additional": key_type.additional(),
+            }
+
+        if self.field.value_type:
+            value_type = getMultiAdapter(
+                (self.field.value_type, self.context, self.request), IJsonSchemaProvider
+            )
+
+            info["value_type"] = {
+                "schema": value_type.get_schema(),
+                "additional": value_type.additional(),
+            }
+
         return info
 
 


### PR DESCRIPTION
This PR fixes a crash in the JSON schema providers for Dict and List fields when they are defined without specifying sub-types (`key_type` or `value_type`).

In `zope.schema`, these sub-types default to `None`. The previous implementation was unconditionally attempting to adapt these `None` values to `IJsonSchemaProvider`, leading to a `ComponentLookupError`.

Changes:
- Replaced `getMultiAdapter` with `queryMultiAdapter` and added safety checks for `key_type` and `value_type` in `DictJsonSchemaProvider` and `CollectionJsonSchemaProvider`.
- Added regression tests in `src/plone/restapi/tests/test_types.py`.

Fixes #2037