### PR TITLE
Fix RichTextValue serialization when nested in Dict or List

### DIFF
--- a/news/2039.bugfix
+++ b/news/2039.bugfix
@@ -1,0 +1,1 @@
+Add IJsonCompatible converter for IRichTextValue to handle nested RichText fields safely.

--- a/src/plone/restapi/serializer/configure.zcml
+++ b/src/plone/restapi/serializer/configure.zcml
@@ -89,6 +89,7 @@
   <adapter factory=".converters.persistent_mapping_converter" />
   <adapter factory=".converters.python_datetime_converter" />
   <adapter factory=".converters.RichtextDXContextConverter" />
+  <adapter factory=".converters.richtext_converter" />
   <adapter factory=".converters.set_converter" />
   <adapter factory=".converters.bytes_converter" />
   <adapter factory=".converters.time_converter" />

--- a/src/plone/restapi/serializer/converters.py
+++ b/src/plone/restapi/serializer/converters.py
@@ -175,6 +175,16 @@ def timedelta_converter(value):
     return json_compatible(value.total_seconds())
 
 
+@adapter(IRichTextValue)
+@implementer(IJsonCompatible)
+def richtext_converter(value):
+    return {
+        "data": json_compatible(value.raw),
+        "content-type": json_compatible(value.mimeType),
+        "encoding": json_compatible(value.encoding),
+    }
+
+
 @adapter(IRichTextValue, IDexterityContent)
 @implementer(IContextawareJsonCompatible)
 class RichtextDXContextConverter:

--- a/src/plone/restapi/tests/test_serializer_converters.py
+++ b/src/plone/restapi/tests/test_serializer_converters.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from DateTime import DateTime
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
+from plone.app.textfield.value import RichTextValue
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.testing import PLONE_RESTAPI_DX_INTEGRATION_TESTING
 from unittest import TestCase
@@ -218,3 +219,16 @@ class TestJsonCompatibleConverters(TestCase):
 
     def test_missing_value(self):
         self.assertEqual(None, json_compatible(Missing.Value))
+
+    def test_richtext_value_nested(self):
+        value = RichTextValue(
+            raw="<p>foo</p>", mimeType="text/html", outputMimeType="text/x-html-safe"
+        )
+        self.assertEqual(
+            {
+                "data": "<p>foo</p>",
+                "content-type": "text/html",
+                "encoding": "utf-8",
+            },
+            json_compatible({"foo": value})["foo"],
+        )


### PR DESCRIPTION
This PR adds a global `IJsonCompatible` converter for `IRichTextValue`. 

Previously, `RichTextValue` was only serializable when a context was available (via `IContextawareJsonCompatible`). However, when a `RichTextValue` is nested inside a `Dict` or `List`, the recursive `json_compatible` call is often made without a context, leading to a `TypeError`.

By adding a non-context-aware converter that defaults to using the `.raw` value, we provide a safe fallback that prevents these crashes.