### PR TITLE
Fix the security check when a wrong permission is specified

### DIFF
--- a/news/2041.bugfix.md
+++ b/news/2041.bugfix.md
@@ -1,0 +1,2 @@
+Fix the security check when a wrong permission is specified.
+@ale-rt

--- a/src/plone/restapi/serializer/schema.py
+++ b/src/plone/restapi/serializer/schema.py
@@ -1,4 +1,5 @@
 from AccessControl import getSecurityManager
+from logging import getLogger
 from plone.autoform.interfaces import READ_PERMISSIONS_KEY
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISchemaSerializer
@@ -12,6 +13,8 @@ from zope.interface import Interface
 from zope.interface.interfaces import IInterface
 from zope.schema import getFields
 from zope.security.interfaces import IPermission
+
+logger = getLogger(__name__)
 
 
 @adapter(IInterface, Interface, Interface)
@@ -53,7 +56,15 @@ def _check_permission(permission_name, instance, obj=None) -> bool:
     if permission_name not in permission_cache:
         permission = queryUtility(IPermission, name=permission_name)
         if permission is None:
-            permission_cache[permission_name] = True
+            logger.warning(
+                (
+                    "The permission %r was not found, forbidding access. "
+                    "Be sure to specify a properly registered permission id, "
+                    "e.g. zope2.View"
+                ),
+                permission_name,
+            )
+            permission_cache[permission_name] = False
         else:
             sm = getSecurityManager()
             permission_cache[permission_name] = bool(

--- a/src/plone/restapi/services/inherit/get.py
+++ b/src/plone/restapi/services/inherit/get.py
@@ -37,7 +37,7 @@ class InheritedBehaviorExpander:
                         obj
                         for obj in self.context.aq_chain
                         if registration.marker.providedBy(obj)
-                        and _check_permission("View", self, obj)
+                        and _check_permission("zope2.View", self, obj)
                     ),
                     None,
                 )

--- a/src/plone/restapi/tests/test_services_inherit.py
+++ b/src/plone/restapi/tests/test_services_inherit.py
@@ -180,7 +180,7 @@ class TestServiceInherit(unittest.TestCase):
             title="Restricted Child",
         )
         alsoProvides(restricted_parent, ITestBehaviorMarker)
-        api.content.transition(restricted_child, to_state='published')
+        api.content.transition(restricted_child, to_state="published")
         transaction.commit()
 
         logout()

--- a/src/plone/restapi/tests/test_services_inherit.py
+++ b/src/plone/restapi/tests/test_services_inherit.py
@@ -180,15 +180,27 @@ class TestServiceInherit(unittest.TestCase):
             title="Restricted Child",
         )
         alsoProvides(restricted_parent, ITestBehaviorMarker)
+        api.content.transition(restricted_child, to_state='published')
         transaction.commit()
 
         logout()
         anon_session = RelativeSession(self.portal.absolute_url())
         anon_session.headers.update({"Accept": "application/json"})
 
+        # Anonymous is allowed to view the child, as it is published.
+        url = f"{restricted_child.absolute_url()}"
+        response = anon_session.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Anonymous is also allowed to request an inherited behavior on the
+        # published child.
         url = f"{restricted_child.absolute_url()}/@inherit?expand.inherit.behaviors=plone.testbehavior.ITestBehavior"
         response = anon_session.get(url)
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 200)
+
+        # But no data of the parent is exposed, as the parent is private.
+        data = response.json()
+        self.assertEqual(sorted(data.keys()), ["@id"])
 
     def test_inherit_expansion(self):
         response = self.api_session.get(


### PR DESCRIPTION
Also add a warning to support developers in fixing the permission checks.

Fixes #2041
