### PR TITLE
Fix the security check when a wrong permission is specified [9.x.x]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.13"
-            plone-version: "6.2"
+            plone-version: "6.1"
     steps:
       # git checkout
       - uses: actions/checkout@v5

--- a/news/2041.bugfix.md
+++ b/news/2041.bugfix.md
@@ -1,0 +1,2 @@
+Fix the security check when a wrong permission is specified.
+@ale-rt

--- a/src/plone/restapi/serializer/schema.py
+++ b/src/plone/restapi/serializer/schema.py
@@ -1,4 +1,5 @@
 from AccessControl import getSecurityManager
+from logging import getLogger
 from plone.autoform.interfaces import READ_PERMISSIONS_KEY
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISchemaSerializer
@@ -12,6 +13,9 @@ from zope.interface import Interface
 from zope.interface.interfaces import IInterface
 from zope.schema import getFields
 from zope.security.interfaces import IPermission
+
+
+logger = getLogger(__name__)
 
 
 @adapter(IInterface, Interface, Interface)
@@ -53,7 +57,15 @@ def _check_permission(permission_name, instance, obj=None) -> bool:
     if permission_name not in permission_cache:
         permission = queryUtility(IPermission, name=permission_name)
         if permission is None:
-            permission_cache[permission_name] = True
+            logger.warning(
+                (
+                    "The permission %r was not found, forbidding access. "
+                    "Be sure to specify a properly registered permission id, "
+                    "e.g. zope2.View"
+                ),
+                permission_name,
+            )
+            permission_cache[permission_name] = False
         else:
             sm = getSecurityManager()
             permission_cache[permission_name] = bool(

--- a/src/plone/restapi/services/inherit/get.py
+++ b/src/plone/restapi/services/inherit/get.py
@@ -37,7 +37,7 @@ class InheritedBehaviorExpander:
                         obj
                         for obj in self.context.aq_chain
                         if registration.marker.providedBy(obj)
-                        and _check_permission("View", self, obj)
+                        and _check_permission("zope2.View", self, obj)
                     ),
                     None,
                 )

--- a/src/plone/restapi/tests/http-examples/querystring_get.resp
+++ b/src/plone/restapi/tests/http-examples/querystring_get.resp
@@ -181,13 +181,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -199,7 +199,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -265,13 +265,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -283,7 +283,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -361,13 +361,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -379,7 +379,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -445,13 +445,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -463,7 +463,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -669,13 +669,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -687,7 +687,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -996,13 +996,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1014,7 +1014,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1117,13 +1117,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1135,7 +1135,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1201,13 +1201,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1219,7 +1219,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1285,13 +1285,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1303,7 +1303,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1369,13 +1369,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1387,7 +1387,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1516,13 +1516,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1534,7 +1534,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1691,13 +1691,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1709,7 +1709,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },

--- a/src/plone/restapi/tests/http-examples/querystring_get_contextual.resp
+++ b/src/plone/restapi/tests/http-examples/querystring_get_contextual.resp
@@ -181,13 +181,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -199,7 +199,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -265,13 +265,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -283,7 +283,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -361,13 +361,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -379,7 +379,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -445,13 +445,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -463,7 +463,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -669,13 +669,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -687,7 +687,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -996,13 +996,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1014,7 +1014,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1117,13 +1117,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1135,7 +1135,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1201,13 +1201,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1219,7 +1219,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1285,13 +1285,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1303,7 +1303,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1369,13 +1369,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1387,7 +1387,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1516,13 +1516,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1534,7 +1534,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },
@@ -1691,13 +1691,13 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.between": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._between",
+                    "operation": "plone.app.querystring.queryparser._dateBetween",
                     "title": "Between dates",
                     "widget": "DateRangeWidget"
                 },
                 "plone.app.querystring.operation.date.largerThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._largerThan",
+                    "operation": "plone.app.querystring.queryparser._dateLargerThan",
                     "title": "After date",
                     "widget": "DateWidget"
                 },
@@ -1709,7 +1709,7 @@ Content-Type: application/json
                 },
                 "plone.app.querystring.operation.date.lessThan": {
                     "description": "Please use YYYY/MM/DD.",
-                    "operation": "plone.app.querystring.queryparser._lessThan",
+                    "operation": "plone.app.querystring.queryparser._dateLessThan",
                     "title": "Before date",
                     "widget": "DateWidget"
                 },

--- a/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_addons.resp
@@ -76,18 +76,6 @@ Content-Type: application/json
             "version": "1.2.3"
         },
         {
-            "@id": "http://localhost:55001/plone/@addons/plone.app.layout",
-            "description": "Installs the plone.app.layout add-on.",
-            "id": "plone.app.layout",
-            "install_profile_id": "plone.app.layout:default",
-            "is_installed": false,
-            "profile_type": "default",
-            "title": "plone.app.layout",
-            "uninstall_profile_id": "plone.app.layout:uninstall",
-            "upgrade_info": {},
-            "version": "1.2.3"
-        },
-        {
             "@id": "http://localhost:55001/plone/@addons/plone.app.multilingual",
             "description": "Instalar para activar el soporte de contenido multiling\u00fce con plone.app.multilingual",
             "id": "plone.app.multilingual",

--- a/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
+++ b/src/plone/restapi/tests/http-examples/translated_messages_types_folder.resp
@@ -138,6 +138,7 @@ Content-Type: application/json+schema
             "behavior": "plone.dublincore",
             "description": "Usado en listados de elementos y resultados de b\u00fasquedas.",
             "factory": "Text",
+            "maxLength": 10000,
             "title": "Descripci\u00f3n",
             "type": "string",
             "widget": "textarea"
@@ -251,6 +252,7 @@ Content-Type: application/json+schema
             "behavior": "plone.dublincore",
             "description": "",
             "factory": "Text line (String)",
+            "maxLength": 1024,
             "title": "T\u00edtulo",
             "type": "string"
         }

--- a/src/plone/restapi/tests/http-examples/types_document.resp
+++ b/src/plone/restapi/tests/http-examples/types_document.resp
@@ -159,6 +159,7 @@ Content-Type: application/json+schema
             "behavior": "plone.dublincore",
             "description": "Used in item listings and search results.",
             "factory": "Text",
+            "maxLength": 10000,
             "title": "Summary",
             "type": "string",
             "widget": "textarea"
@@ -279,6 +280,7 @@ Content-Type: application/json+schema
             "behavior": "plone.dublincore",
             "description": "",
             "factory": "Text line (String)",
+            "maxLength": 1024,
             "title": "Title",
             "type": "string"
         },

--- a/src/plone/restapi/tests/http-examples/types_document_put.req
+++ b/src/plone/restapi/tests/http-examples/types_document_put.req
@@ -124,6 +124,7 @@ Content-Type: application/json
             "behavior": "plone.dublincore",
             "description": "Used in item listings and search results.",
             "factory": "Text",
+            "maxLength": 10000,
             "title": "Summary",
             "type": "string",
             "widget": "textarea"
@@ -244,6 +245,7 @@ Content-Type: application/json
             "behavior": "plone.dublincore",
             "description": "",
             "factory": "Text line (String)",
+            "maxLength": 1024,
             "title": "Title",
             "type": "string"
         },

--- a/src/plone/restapi/tests/test_services_inherit.py
+++ b/src/plone/restapi/tests/test_services_inherit.py
@@ -180,15 +180,27 @@ class TestServiceInherit(unittest.TestCase):
             title="Restricted Child",
         )
         alsoProvides(restricted_parent, ITestBehaviorMarker)
+        api.content.transition(restricted_child, to_state="published")
         transaction.commit()
 
         logout()
         anon_session = RelativeSession(self.portal.absolute_url())
         anon_session.headers.update({"Accept": "application/json"})
 
+        # Anonymous is allowed to view the child, as it is published.
+        url = f"{restricted_child.absolute_url()}"
+        response = anon_session.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Anonymous is also allowed to request an inherited behavior on the
+        # published child.
         url = f"{restricted_child.absolute_url()}/@inherit?expand.inherit.behaviors=plone.testbehavior.ITestBehavior"
         response = anon_session.get(url)
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 200)
+
+        # But no data of the parent is exposed, as the parent is private.
+        data = response.json()
+        self.assertEqual(sorted(data.keys()), ["@id"])
 
     def test_inherit_expansion(self):
         response = self.api_session.get(

--- a/test-no-uncommitted-doc-changes
+++ b/test-no-uncommitted-doc-changes
@@ -13,12 +13,12 @@ function red {
     echo "$RED $1 $RESET"
 }
 
-if [ "$PLONE_VERSION" == "6.2" ] && [ "$PYTHON_VERSION" == '3.13' ]; then
-    echo "Running check for undocumented changes for Plone 6.2.x on Python 3.13"
+if [ "$PLONE_VERSION" == "6.1" ] && [ "$PYTHON_VERSION" == '3.13' ]; then
+    echo "Running check for undocumented changes for Plone 6.1.x on Python 3.13"
 else
     # request/response dumps have known differences for different Python/Plone combinations
     # => skip, we can't have the Plone 5 build fail because of those
-    echo "Skipping checks for undocumented changes for everything except Plone 6.2.x on Python 3.13"
+    echo "Skipping checks for undocumented changes for everything except Plone 6.1.x on Python 3.13"
     echo "PLONE_VERSION=$PLONE_VERSION"
     echo "PYTHON_VERSION=$PYTHON_VERSION"
     exit 0


### PR DESCRIPTION
Backport of PR #2042 for Plone 6.1 and earlier.

And update the `http-examples` in the documentation to be correct for Plone 6.1.

Note that the lint check may fail because `pyupgrade` wants to remove these lines from `setup.py`:

```
-if sys.version_info.major == 2:
-    raise ValueError(
-        "plone.restapi 10 requires Python 3. "
-        "Please downgrade to plone.restapi 7 for Python 2 and Plone 4.3/5.1."
-    )
-
-
```

And afterwards `flake8` then complains:

```
setup.py:5:1: F401 'sys' imported but unused
```

I think we want to keep those lines on this 9.x.x branch.