### PR TITLE
Drop metadata_fields from the catalog query

### DIFF
--- a/news/2031.bugfix.md
+++ b/news/2031.bugfix.md
@@ -1,0 +1,7 @@
+Stop passing `metadata_fields` into the catalog query. It is a control parameter
+read from the request by the summary serializer, not a catalog index, and every
+request from Volto's `ObjectBrowserWidget` carries it. `ignore_query_params` in
+`ZCatalogCompatibleQueryAdapter` only suppressed the "No such index" warning; the
+key still reached `catalog.searchResults()`, where ZCatalog silently ignores it
+but a catalog that validates its query does not.
+@kunalKumar-13

--- a/src/plone/restapi/search/query.py
+++ b/src/plone/restapi/search/query.py
@@ -78,6 +78,10 @@ class ZCatalogCompatibleQueryAdapter:
         "sort_order": {list: list, tuple: list, str: str},
     }
 
+    # Control parameters that are not catalog indexes. They are read from
+    # the request where they are needed -- ``metadata_fields`` is read from
+    # ``request.form`` (or the JSON body) by the summary serializer -- and
+    # are dropped here so they never reach ``catalog.searchResults()``.
     ignore_query_params = ["metadata_fields"]
 
     def __init__(self, context, request):
@@ -100,6 +104,9 @@ class ZCatalogCompatibleQueryAdapter:
                 return future_value(idx_query)
 
     def __call__(self, query):
+        for param in self.ignore_query_params:
+            query.pop(param, None)
+
         for idx_name, idx_query in query.items():
             if idx_name in self.global_query_params:
                 # It's a query-wide parameter like 'sort_limit'
@@ -115,8 +122,7 @@ class ZCatalogCompatibleQueryAdapter:
             # that could not be serialized in a query string or JSON
             index = self.get_index(idx_name)
             if index is None:
-                if idx_name not in self.ignore_query_params:
-                    log.warning("No such index: %r" % idx_name)
+                log.warning("No such index: %r" % idx_name)
                 continue
 
             query_opts_parser = getMultiAdapter(

--- a/src/plone/restapi/tests/test_search.py
+++ b/src/plone/restapi/tests/test_search.py
@@ -10,6 +10,7 @@ from plone.app.textfield.value import RichTextValue
 from plone.dexterity.utils import createContentInContainer
 from plone.registry.interfaces import IRegistry
 from plone.restapi.bbb import INavigationRoot
+from plone.restapi.search.handler import SearchHandler
 from plone.restapi.search.query import ZCatalogCompatibleQueryAdapter
 from plone.restapi.testing import PLONE_RESTAPI_DX_FUNCTIONAL_TESTING
 from plone.restapi.testing import RelativeSession
@@ -941,3 +942,46 @@ class TestSearchFunctional(unittest.TestCase):
                     "sort_order": "ascending",
                 },
             )
+
+    def test_zcatalogcompatiblequeryadapter_drops_metadata_fields(self):
+        """metadata_fields is a control parameter, not a catalog index.
+
+        It is read from the request by the summary serializer, and must not
+        be handed to catalog.searchResults(): a catalog that validates its
+        query -- rather than silently ignoring unknown keys the way ZCatalog
+        does -- rejects it.
+        """
+        query_adapter = ZCatalogCompatibleQueryAdapter(self.portal, self.request)
+        parsed = query_adapter(
+            {
+                "SearchableText": "lorem",
+                "metadata_fields": ["portal_type", "review_state"],
+            }
+        )
+        self.assertNotIn("metadata_fields", parsed)
+        self.assertIn("SearchableText", parsed)
+
+    def test_search_handler_does_not_pass_metadata_fields_to_catalog(self):
+        class RecordingCatalog:
+            def __init__(self, catalog):
+                self._catalog_tool = catalog
+                self.last_query = None
+
+            def searchResults(self, **query):
+                self.last_query = query
+                return self._catalog_tool.searchResults(**query)
+
+            def __getattr__(self, name):
+                return getattr(self._catalog_tool, name)
+
+        handler = SearchHandler(self.portal, self.request)
+        recorder = RecordingCatalog(handler.catalog)
+        handler.catalog = recorder
+        handler.search(
+            {
+                "SearchableText": "lorem",
+                "metadata_fields": ["portal_type", "review_state"],
+            }
+        )
+        self.assertIsNotNone(recorder.last_query)
+        self.assertNotIn("metadata_fields", recorder.last_query)


### PR DESCRIPTION
Fixes #2031.

### Root cause

`@search` hands the whole request dict to `catalog.searchResults()`, so control
parameters that are not catalog indexes go with it. `metadata_fields` is one: it
is read from `request.form` (or the JSON body) by the summary serializer, never
from the query dict, and every request from Volto's `ObjectBrowserWidget`
carries it.

`ZCatalogCompatibleQueryAdapter` already had a name for this class of key,
`ignore_query_params`, but it only used it to suppress the "No such index"
warning — the key was still left in the query it returned. ZCatalog ignores
unknown keys, which is why nothing breaks in stock Plone; a catalog that
validates its query instead of ignoring what it does not recognise rejects it.

### Change

Pop the `ignore_query_params` keys at the top of `__call__`, so the attribute
does what its name says. That makes the guard further down redundant.

### Why this is safe

Checked before changing anything that `metadata_fields` is not read back from
this dict. `services/search/get.py` passes `request.form.copy()`, and
`SummaryJSONSerializer.metadata_fields()` reads `request.form` or re-parses
`request["BODY"]` itself — so dropping it from the query cannot affect the
metadata that comes back. The three existing end-to-end tests for partial, full
and `fullobjects` metadata retrieval confirm it.

### Tests

- `test_zcatalogcompatiblequeryadapter_drops_metadata_fields` — the adapter's
  output no longer contains the key.
- `test_search_handler_does_not_pass_metadata_fields_to_catalog` — asserts on
  the kwargs that actually reach `catalog.searchResults()`.

### Measured

Plone 6.2.1 / Python 3.13, `zope-testrunner --all`, `TZ=UTC`:

- `main`, before the change: **1406 tests, 0 failures, 0 errors, 13 skipped**
- with the fix and the two new tests: **1408 tests, 0 failures, 0 errors**
- reverting only `search/query.py` and keeping the tests: **1408 tests, 2
  failures** — the two new tests and nothing else

(Note for reproduction: `test_date_index_query` and
`test_full_metadata_retrieval` fail on an unpatched checkout when the machine is
not on UTC — they compare rendered timestamps against fixed UTC strings. Run
with `TZ=UTC`.)
